### PR TITLE
fix: fix a failing restore when backup is stuck in RESTORING status

### DIFF
--- a/dbaas/dbaas-aggregator/src/main/java/org/qubership/cloud/dbaas/service/DBBackupsService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/org/qubership/cloud/dbaas/service/DBBackupsService.java
@@ -749,10 +749,17 @@ public class DBBackupsService {
                         .toList()
             );
         }
-        NamespaceRestoration result = new NamespaceRestoration();
-        result.setId(restorationId);
+
+        NamespaceRestoration result;
+        Optional<NamespaceRestoration> existingRestoration = backup.getRestorations().stream().filter(r -> r.getId().equals(restorationId)).findAny();
+        if (existingRestoration.isPresent()) {
+            result = existingRestoration.get();
+        } else {
+            result = new NamespaceRestoration();
+            result.setId(restorationId);
+            addToBackup(backup, result);
+        }
         result.setStatus(Status.PROCEEDING);
-        addToBackup(backup, result);
 
         backup.setStatus(NamespaceBackup.Status.RESTORING);
         runInNewTransaction(() -> backupsDbaasRepository.save(backup)); // save backup restore proceeds

--- a/dbaas/dbaas-aggregator/src/test/java/org/qubership/cloud/dbaas/service/DBBackupsServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/org/qubership/cloud/dbaas/service/DBBackupsServiceTest.java
@@ -523,6 +523,7 @@ public class DBBackupsServiceTest {
     private NamespaceBackup getNamespaceBackupSample() {
         final NamespaceBackup namespaceBackup = new NamespaceBackup(UUID.randomUUID(), TEST_NAMESPACE, new ArrayList<>(), new ArrayList<>());
         namespaceBackup.setBackups(new ArrayList<>());
+        namespaceBackup.setRestorations(new ArrayList<>());
         return namespaceBackup;
     }
 


### PR DESCRIPTION
Previously the stuck restoration wasn't deleted in DBBackupsService.deleteRestore, but was created and added again in DBBackupsService.runRestoration, which leads to an error. Now we will reuse the existing restoration instead of creation of the new one.