### PR TITLE
build: disable Sonar checks during commits

### DIFF
--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -12,7 +12,4 @@ jobs:
     with:
       event-name: ${{ github.event_name }}
       actor: ${{ github.actor }}
-      sonar-project-key: ${{ vars.SONAR_PROJECT_KEY }}
       pom-file-path: pom.xml
-    secrets:
-      sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Disabled until the test coverage percentage can be configured. Right now it's failing all builds because we have <80% coverage.