### PR TITLE
chore(ci): update of CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   CLAAssistant:
+    if: github.event.pull_request.draft == false
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Pinned `contributor-assistant/github-action` version to v2.6.1 SHA