### PR TITLE
chore: use separate group for Quarkus update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,19 @@
   "assignAutomerge": true,
   "assigneesFromCodeOwners": true,
   "reviewersFromCodeOwners": true,
-  "extends": [ "github>Netcracker/qubership-core-infra:renovate-core-config" ]
+  "extends": [
+    "github>Netcracker/qubership-core-infra:renovate-core-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "io.quarkus.platform:quarkus-bom",
+        "io.quarkus.platform:quarkus-maven-plugin",
+        "io.quarkus.platform:quarkus-operator-sdk-bom"
+      ],
+      "groupName": "quarkus",
+      "separateMajorMinor": true,
+      "separateMinorPatch": true
+    }
+  ]
 }


### PR DESCRIPTION
We can't upgrade Quarkus version without related cloud-core-quarkus lib upgrade, and we can't merge PRs with some deps + Quarkus update without manual editing. So we will move Quarkus version upgrade to separate PR.