### PR TITLE
fix: restate operator binary in Pod command after Dockerfile CMD switch

### DIFF
--- a/dbaas-operator/dev/k8s/operator.yaml
+++ b/dbaas-operator/dev/k8s/operator.yaml
@@ -120,6 +120,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          # The base image's ENTRYPOINT is /usr/bin/entrypoint.sh. Dockerfile sets
+          # CMD=["/app/dbaas-operator"], but a Pod's `args` field REPLACES image CMD,
+          # so the binary path must be repeated here in `command`.
+          command:
+            - /app/dbaas-operator
           args:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/Deployment.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/Deployment.yaml
@@ -70,6 +70,12 @@ spec:
             - name: projected-tokens
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          # The base image's ENTRYPOINT is /usr/bin/entrypoint.sh (cert loading, signal
+          # handling, init.d hooks). The Dockerfile sets CMD=["/app/dbaas-operator"], but
+          # a Pod's `args` field REPLACES image CMD entirely, so we must restate the binary
+          # in `command` here. Otherwise entrypoint.sh tries to exec the flags as a command.
+          command:
+            - /app/dbaas-operator
           args:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080


### PR DESCRIPTION
## Problem

The integration test on `feat/operator-dev` started failing with `Operator is not ready` after PR #433 switched the Dockerfile from `ENTRYPOINT ["/app/dbaas-operator"]` to `CMD ["/app/dbaas-operator"]`.

Pod logs reveal:

```
[entrypoint.sh] Run subcommand: --health-probe-bind-address=:8081 --metrics-bind-address=:8080 --leader-elect
/usr/bin/entrypoint.sh: line 203: --health-probe-bind-address=:8081: command not found
Process ended with return code 127
```

## Root cause

A Pod's `args:` field **replaces** the image's CMD (it does not append). Before #433:

- Image `ENTRYPOINT` = `/app/dbaas-operator`
- Pod `args` = `[--health-probe-bind-address=...]`
- Result: `/app/dbaas-operator --health-probe-bind-address=...` ✅

After #433:

- Image `ENTRYPOINT` = base image's `/usr/bin/entrypoint.sh` (cert loading, signal handling, etc.)
- Image `CMD` = `/app/dbaas-operator`
- Pod `args` = `[--health-probe-bind-address=...]` — **overrides CMD entirely**
- Result: `entrypoint.sh --health-probe-bind-address=...` ❌ — no binary to run

## Fix

Add `command: [/app/dbaas-operator]` to the Pod spec so `args:` augment it instead of replacing CMD. Applied in two places:

- `helm-templates/dbaas-operator/templates/Deployment.yaml` (production)
- `dev/k8s/operator.yaml` (local kind)

## Verification

Reproduced locally in kind: pod went into `Error` state with the exact log line above. After applying the fix, pod becomes `Running 1/1` and reconciler logs are healthy.

Closes the regression introduced by #433.