### PR TITLE
feat(api): immutability rules for DatabaseDeclaration and DbPolicy identity fields

### DIFF
--- a/dbaas-operator/api/v1/databasedeclaration_types.go
+++ b/dbaas-operator/api/v1/databasedeclaration_types.go
@@ -56,13 +56,23 @@ type DatabaseDeclarationSpec struct {
 	// classifier uniquely identifies this database in dbaas.
 	// The aggregator uses it to look up or create the physical database.
 	// Required keys: microserviceName, scope.
+	// Immutable after creation — changing the classifier of an existing
+	// DatabaseDeclaration would switch the CR onto a different database while
+	// the controller's status (trackingID, observedGeneration) still references
+	// the original one. To rebind to a different database, delete and recreate
+	// the CR.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.classifier is immutable after creation"
 	Classifier Classifier `json:"classifier"`
 
 	// type is the database engine type. Must match a type known to dbaas-aggregator,
 	// e.g. "postgresql", "mongodb", "opensearch".
+	// Immutable after creation — changing engine type mid-flight would request
+	// provisioning of a fresh database on a different adapter while the original
+	// remains registered under the same CR identity.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.type is immutable after creation"
 	Type string `json:"type"`
 
 	// lazy indicates whether the database should be provisioned on first access rather

--- a/dbaas-operator/api/v1/dbpolicy_types.go
+++ b/dbaas-operator/api/v1/dbpolicy_types.go
@@ -69,8 +69,13 @@ type PolicyRole struct {
 type DbPolicySpec struct {
 	// microserviceName is the microservice that owns this policy.
 	// Mapped to metadata.microserviceName in the DBaaS declarative payload.
+	// Immutable after creation — repointing a DbPolicy CR at a different
+	// microservice would rewrite role grants under the same K8s object,
+	// destroying the audit trail of who owned the policy originally. Create
+	// a new CR for a different service instead.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.microserviceName is immutable after creation"
 	MicroserviceName string `json:"microserviceName"`
 
 	// services defines per-microservice database role assignments. Each entry grants

--- a/dbaas-operator/config-dev/crd/bases/dbaas.netcracker.com_databasedeclarations.yaml
+++ b/dbaas-operator/config-dev/crd/bases/dbaas.netcracker.com_databasedeclarations.yaml
@@ -62,6 +62,11 @@ spec:
                   classifier uniquely identifies this database in dbaas.
                   The aggregator uses it to look up or create the physical database.
                   Required keys: microserviceName, scope.
+                  Immutable after creation — changing the classifier of an existing
+                  DatabaseDeclaration would switch the CR onto a different database while
+                  the controller's status (trackingID, observedGeneration) still references
+                  the original one. To rebind to a different database, delete and recreate
+                  the CR.
                 properties:
                   customKeys:
                     additionalProperties:
@@ -99,6 +104,9 @@ spec:
                 - microserviceName
                 - scope
                 type: object
+                x-kubernetes-validations:
+                - message: spec.classifier is immutable after creation
+                  rule: self == oldSelf
               initialInstantiation:
                 description: |-
                   initialInstantiation defines how the database is created on the first deployment.
@@ -174,8 +182,14 @@ spec:
                 description: |-
                   type is the database engine type. Must match a type known to dbaas-aggregator,
                   e.g. "postgresql", "mongodb", "opensearch".
+                  Immutable after creation — changing engine type mid-flight would request
+                  provisioning of a fresh database on a different adapter while the original
+                  remains registered under the same CR identity.
                 minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.type is immutable after creation
+                  rule: self == oldSelf
               versioningConfig:
                 description: |-
                   versioningConfig defines the strategy for handling database versions during

--- a/dbaas-operator/config-dev/crd/bases/dbaas.netcracker.com_dbpolicies.yaml
+++ b/dbaas-operator/config-dev/crd/bases/dbaas.netcracker.com_dbpolicies.yaml
@@ -64,8 +64,15 @@ spec:
                 description: |-
                   microserviceName is the microservice that owns this policy.
                   Mapped to metadata.microserviceName in the DBaaS declarative payload.
+                  Immutable after creation — repointing a DbPolicy CR at a different
+                  microservice would rewrite role grants under the same K8s object,
+                  destroying the audit trail of who owned the policy originally. Create
+                  a new CR for a different service instead.
                 minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.microserviceName is immutable after creation
+                  rule: self == oldSelf
               policy:
                 description: |-
                   policy defines default and additional role rules per database type. Entries here

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_databasedeclarations.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_databasedeclarations.yaml
@@ -62,6 +62,11 @@ spec:
                   classifier uniquely identifies this database in dbaas.
                   The aggregator uses it to look up or create the physical database.
                   Required keys: microserviceName, scope.
+                  Immutable after creation — changing the classifier of an existing
+                  DatabaseDeclaration would switch the CR onto a different database while
+                  the controller's status (trackingID, observedGeneration) still references
+                  the original one. To rebind to a different database, delete and recreate
+                  the CR.
                 properties:
                   customKeys:
                     additionalProperties:
@@ -99,6 +104,9 @@ spec:
                 - microserviceName
                 - scope
                 type: object
+                x-kubernetes-validations:
+                - message: spec.classifier is immutable after creation
+                  rule: self == oldSelf
               initialInstantiation:
                 description: |-
                   initialInstantiation defines how the database is created on the first deployment.
@@ -174,8 +182,14 @@ spec:
                 description: |-
                   type is the database engine type. Must match a type known to dbaas-aggregator,
                   e.g. "postgresql", "mongodb", "opensearch".
+                  Immutable after creation — changing engine type mid-flight would request
+                  provisioning of a fresh database on a different adapter while the original
+                  remains registered under the same CR identity.
                 minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.type is immutable after creation
+                  rule: self == oldSelf
               versioningConfig:
                 description: |-
                   versioningConfig defines the strategy for handling database versions during

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_dbpolicies.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_dbpolicies.yaml
@@ -64,8 +64,15 @@ spec:
                 description: |-
                   microserviceName is the microservice that owns this policy.
                   Mapped to metadata.microserviceName in the DBaaS declarative payload.
+                  Immutable after creation — repointing a DbPolicy CR at a different
+                  microservice would rewrite role grants under the same K8s object,
+                  destroying the audit trail of who owned the policy originally. Create
+                  a new CR for a different service instead.
                 minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.microserviceName is immutable after creation
+                  rule: self == oldSelf
               policy:
                 description: |-
                   policy defines default and additional role rules per database type. Entries here

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-databasedeclarations.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-databasedeclarations.yaml
@@ -63,6 +63,11 @@ spec:
                   classifier uniquely identifies this database in dbaas.
                   The aggregator uses it to look up or create the physical database.
                   Required keys: microserviceName, scope.
+                  Immutable after creation — changing the classifier of an existing
+                  DatabaseDeclaration would switch the CR onto a different database while
+                  the controller's status (trackingID, observedGeneration) still references
+                  the original one. To rebind to a different database, delete and recreate
+                  the CR.
                 properties:
                   customKeys:
                     additionalProperties:
@@ -100,6 +105,9 @@ spec:
                 - microserviceName
                 - scope
                 type: object
+                x-kubernetes-validations:
+                - message: spec.classifier is immutable after creation
+                  rule: self == oldSelf
               initialInstantiation:
                 description: |-
                   initialInstantiation defines how the database is created on the first deployment.
@@ -175,8 +183,14 @@ spec:
                 description: |-
                   type is the database engine type. Must match a type known to dbaas-aggregator,
                   e.g. "postgresql", "mongodb", "opensearch".
+                  Immutable after creation — changing engine type mid-flight would request
+                  provisioning of a fresh database on a different adapter while the original
+                  remains registered under the same CR identity.
                 minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.type is immutable after creation
+                  rule: self == oldSelf
               versioningConfig:
                 description: |-
                   versioningConfig defines the strategy for handling database versions during

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-dbpolicies.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-dbpolicies.yaml
@@ -65,8 +65,15 @@ spec:
                 description: |-
                   microserviceName is the microservice that owns this policy.
                   Mapped to metadata.microserviceName in the DBaaS declarative payload.
+                  Immutable after creation — repointing a DbPolicy CR at a different
+                  microservice would rewrite role grants under the same K8s object,
+                  destroying the audit trail of who owned the policy originally. Create
+                  a new CR for a different service instead.
                 minLength: 1
                 type: string
+                x-kubernetes-validations:
+                - message: spec.microserviceName is immutable after creation
+                  rule: self == oldSelf
               policy:
                 description: |-
                   policy defines default and additional role rules per database type. Entries here
@@ -149,8 +156,8 @@ spec:
                     - "Stalled" — True when the error is permanent and the controller will
                                   not retry until the spec is changed (e.g. InvalidSpec,
                                   AggregatorRejected). False for transient errors that are
-                                  retried automatically (e.g. AggregatorError, Unauthorized,
-                                  ProvisioningStarted).
+                                  retried automatically (e.g. SecretError, AggregatorError,
+                                  Unauthorized, ProvisioningStarted).
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/OperatorIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/OperatorIT.java
@@ -879,6 +879,87 @@ public class OperatorIT extends AbstractIT {
                 helperV3.getDatabaseByClassifierAsPOJO(
                         helperV3.getClusterDbaAuthorization(), cloneClassifierMap, NAMESPACE, "postgresql", 200);
             }
+
+            @Test
+            void testDatabaseDeclarationTryToUpdateClassifier() {
+                String crName = generateName();
+                String microserviceName = generateName();
+
+                var cr = buildDatabaseDeclarationCR(crName, microserviceName, NAMESPACE, "postgresql");
+                createCR(CRD_DATABASE_DECLARATION, cr);
+
+                KubernetesClientException ex = assertThrows(KubernetesClientException.class, () ->
+                        kubernetesClient.genericKubernetesResources(CRD_DATABASE_DECLARATION)
+                                .inNamespace(NAMESPACE)
+                                .resource(cr)
+                                .edit(r -> {
+                                    Map<String, Object> spec = (Map<String, Object>) r.getAdditionalProperties().get("spec");
+                                    // Provide all CRD-required fields so the schema validation passes
+                                    // and the XValidation immutability rule is the one that fires.
+                                    spec.put("classifier", Map.of(
+                                            "microserviceName", "updatedMicroservice",
+                                            "scope", "service"
+                                    ));
+                                    return r;
+                                }));
+                assertEquals(422, ex.getCode());
+                assertTrue(ex.toString().contains("spec.classifier is immutable after creation"));
+            }
+
+            @Test
+            void testDatabaseDeclarationTryToUpdateType() {
+                String crName = generateName();
+                String microserviceName = generateName();
+                String updatedType = "mongodb";
+
+                var cr = buildDatabaseDeclarationCR(crName, microserviceName, NAMESPACE, "postgresql");
+                var spec = (Map<String, Object>) cr.getAdditionalProperties().get("spec");
+                assertNotEquals(updatedType, spec.get("type"));
+
+                createCR(CRD_DATABASE_DECLARATION, cr);
+
+                KubernetesClientException ex = assertThrows(KubernetesClientException.class, () ->
+                        kubernetesClient.genericKubernetesResources(CRD_DATABASE_DECLARATION)
+                                .inNamespace(NAMESPACE)
+                                .resource(cr)
+                                .edit(r -> {
+                                    Map<String, Object> currSpec = (Map<String, Object>) r.getAdditionalProperties().get("spec");
+                                    currSpec.put("type", updatedType);
+                                    return r;
+                                }));
+                assertEquals(422, ex.getCode());
+                assertTrue(ex.toString().contains("spec.type is immutable after creation"));
+            }
+
+            @Test
+            void testDatabaseDeclarationCanUpdateSettings() throws IOException {
+                String crName = generateName();
+                String microserviceName = generateName();
+
+                var cr = buildDatabaseDeclarationCR(crName, microserviceName, NAMESPACE, "postgresql");
+                createCR(CRD_DATABASE_DECLARATION, cr);
+                waitForDesiredState(CRD_DATABASE_DECLARATION, cr,
+                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE);
+
+                var updatedSettings = Map.of(TEST_ID, "updated");
+                var updatedResource = kubernetesClient.genericKubernetesResources(CRD_DATABASE_DECLARATION)
+                        .inNamespace(NAMESPACE)
+                        .resource(cr)
+                        .edit(r -> {
+                            Map<String, Object> currSpec = (Map<String, Object>) r.getAdditionalProperties().get("spec");
+                            currSpec.put("settings", updatedSettings);
+                            return r;
+                        });
+                waitForDesiredState(CRD_DATABASE_DECLARATION, updatedResource,
+                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE);
+
+                var refreshed = kubernetesClient.genericKubernetesResources(CRD_DATABASE_DECLARATION)
+                        .inNamespace(NAMESPACE)
+                        .resource(cr)
+                        .get();
+                var refreshedSpec = (Map<String, Object>) refreshed.getAdditionalProperties().get("spec");
+                assertEquals(updatedSettings, refreshedSpec.get("settings"));
+            }
         }
 
         @Nested
@@ -998,6 +1079,62 @@ public class OperatorIT extends AbstractIT {
                 var actualService = actualServices.getFirst();
                 assertEquals(service.get("name"), actualService.getName());
                 assertEquals(service.get("roles"), actualService.getRoles());
+            }
+
+            @Test
+            void testDbPolicyTryToUpdateMicroserviceName() {
+                String crName = generateName();
+                String microserviceName = generateName();
+                String updatedMicroserviceName = generateName();
+                assertNotEquals(microserviceName, updatedMicroserviceName);
+
+                var service = Map.of("name", "svc-a", "roles", List.of("admin"));
+                var cr = buildDbPolicyCR(crName, microserviceName, List.of(service), null);
+                createCR(CRD_DB_POLICY, cr);
+
+                KubernetesClientException ex = assertThrows(KubernetesClientException.class, () ->
+                        kubernetesClient.genericKubernetesResources(CRD_DB_POLICY)
+                                .inNamespace(NAMESPACE)
+                                .resource(cr)
+                                .edit(r -> {
+                                    Map<String, Object> currSpec = (Map<String, Object>) r.getAdditionalProperties().get("spec");
+                                    currSpec.put("microserviceName", updatedMicroserviceName);
+                                    return r;
+                                }));
+                assertEquals(422, ex.getCode());
+                assertTrue(ex.toString().contains("spec.microserviceName is immutable after creation"));
+            }
+
+            @Test
+            void testDbPolicyCanUpdateServices() {
+                String crName = generateName();
+                String microserviceName = generateName();
+
+                var initialService = Map.of("name", "svc-a", "roles", List.of("admin"));
+                var cr = buildDbPolicyCR(crName, microserviceName, List.of(initialService), null);
+                createCR(CRD_DB_POLICY, cr);
+                waitForDesiredState(CRD_DB_POLICY, cr,
+                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_POLICY_APPLIED, STATUS_FALSE);
+
+                var updatedService = Map.of("name", "svc-b", "roles", List.of("readonly"));
+                var updatedResource = kubernetesClient.genericKubernetesResources(CRD_DB_POLICY)
+                        .inNamespace(NAMESPACE)
+                        .resource(cr)
+                        .edit(r -> {
+                            Map<String, Object> currSpec = (Map<String, Object>) r.getAdditionalProperties().get("spec");
+                            currSpec.put("services", List.of(updatedService));
+                            return r;
+                        });
+                waitForDesiredState(CRD_DB_POLICY, updatedResource,
+                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_POLICY_APPLIED, STATUS_FALSE);
+
+                var roles = helperV3.getAccessRoles(NAMESPACE, microserviceName, 200);
+                var actualServices = roles.getServices();
+                assertTrue(actualServices != null && !actualServices.isEmpty());
+                assertEquals(1, actualServices.size());
+                var actualService = actualServices.getFirst();
+                assertEquals(updatedService.get("name"), actualService.getName());
+                assertEquals(updatedService.get("roles"), actualService.getRoles());
             }
         }
     }

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/OperatorIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/OperatorIT.java
@@ -951,7 +951,7 @@ public class OperatorIT extends AbstractIT {
                             return r;
                         });
                 waitForDesiredState(CRD_DATABASE_DECLARATION, updatedResource,
-                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE);
+                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE, true);
 
                 var refreshed = kubernetesClient.genericKubernetesResources(CRD_DATABASE_DECLARATION)
                         .inNamespace(NAMESPACE)
@@ -1126,7 +1126,7 @@ public class OperatorIT extends AbstractIT {
                             return r;
                         });
                 waitForDesiredState(CRD_DB_POLICY, updatedResource,
-                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_POLICY_APPLIED, STATUS_FALSE);
+                        PHASE_SUCCEEDED, STATUS_TRUE, REASON_POLICY_APPLIED, STATUS_FALSE, true);
 
                 var roles = helperV3.getAccessRoles(NAMESPACE, microserviceName, 200);
                 var actualServices = roles.getServices();

--- a/docs/howto/DBaaS Operator.md
+++ b/docs/howto/DBaaS Operator.md
@@ -91,6 +91,7 @@ DBaaS Operator is a Kubernetes operator that integrates with dbaas-aggregator. I
 - Credentials for `ExternalDatabase` are read from Kubernetes Secrets at reconcile time.
 - The operator watches referenced Secrets and automatically reconciles affected `ExternalDatabase` CRs when their credentials rotate — no manual spec change required.
 - Authentication to dbaas-aggregator uses a projected service account token (rotated automatically by Kubernetes).
+- Resource-identity fields on all workload CRs are immutable after creation (enforced by CRD CEL rules) — to retarget a CR at a different database, microservice, or operator instance, delete and recreate it. See the per-resource sections for the exact set of immutable fields.
 
 ---
 
@@ -841,7 +842,7 @@ spec:
 
 | Field | Required | Mutable | Description |
 |-------|:--------:|:-------:|-------------|
-| `spec.microserviceName` | Yes | Yes | The microservice that owns this policy. Sent as `metadata.microserviceName` in the aggregator payload. |
+| `spec.microserviceName` | Yes | **No** | The microservice that owns this policy. Sent as `metadata.microserviceName` in the aggregator payload. Immutable after creation (CRD CEL rule `self == oldSelf`): repointing the same CR at a different microservice would silently rewrite role grants under the original K8s object and lose the audit link to who created the policy. Create a new CR for a different service. |
 | `spec.services` | At least one of `services` or `policy` | Yes | Per-microservice role assignments. |
 | `spec.policy` | At least one of `services` or `policy` | Yes | Default role rules per database type, applied to services not listed in `services`. |
 | `spec.disableGlobalPermissions` | No | Yes | When `true`, opts out of dbaas-aggregator's default global permission grants. Defaults to `false`. |
@@ -1059,13 +1060,15 @@ spec:
 
 | Field | Required | Mutable | Description |
 |-------|:--------:|:-------:|-------------|
-| `spec.classifier` | Yes | Yes | Database identity in dbaas-aggregator |
-| `spec.type` | Yes | Yes | Database engine type (e.g., `postgresql`, `mongodb`). Must match a type known to dbaas-aggregator |
+| `spec.classifier` | Yes | **No** | Database identity in dbaas-aggregator. Immutable after creation (CRD CEL rule `self == oldSelf`): switching the classifier on an existing CR would re-target the controller at a different database while `status.trackingID` and `status.observedGeneration` still reference the original one. Delete and recreate the CR to rebind. |
+| `spec.type` | Yes | **No** | Database engine type (e.g., `postgresql`, `mongodb`). Must match a type known to dbaas-aggregator. Immutable after creation: changing the engine mid-flight would request provisioning of a fresh database on a different adapter while the original one stays registered under the same CR identity. |
 | `spec.lazy` | No | Yes | When `true`, provisioning is deferred until first access. Defaults to `false`. **Prohibited** in combination with `initialInstantiation.approach=clone` — controller rejects with `InvalidSpec` |
 | `spec.settings` | No | Yes | Free-form string-to-string map of adapter-specific settings |
 | `spec.namePrefix` | No | Yes | Prefix applied to the physical database name created in the DBMS |
 | `spec.versioningConfig` | No | Yes | Strategy for blue-green database versioning. If absent → `versioningType=static`. If present → `versioningType=version` |
 | `spec.initialInstantiation` | No | Yes | Initial database creation strategy. If absent → `approach=new` |
+
+> **Note on `spec.classifier` immutability** — the CEL rule is a strict structural equality check (`self == oldSelf`). Once the CR is created, the exact shape of the classifier is frozen: you can neither add an optional sub-field that was omitted (e.g. `namespace`, `tenantId`, `customKeys`) nor remove one that was present. The same caveat applies as for `ExternalDatabase.spec.classifier` — see the immutability note in that section for the practical implications (the controller still defaults `classifier.namespace` to `metadata.namespace` when the field is absent, so the aggregator receives the right namespace either way).
 
 **`spec.versioningConfig` fields:**
 


### PR DESCRIPTION
## Summary

- Add CRD-level XValidation immutability rules to:
  - `DatabaseDeclaration.spec.classifier`
  - `DatabaseDeclaration.spec.type`
  - `DbPolicy.spec.microserviceName`
- Closes a consistency gap with `ExternalDatabase` (already locks `classifier`, `type`, `dbName`) and `NamespaceBinding` (already locks `operatorNamespace`). All four workload CRs now treat identity fields as frozen after create; retargeting requires delete + recreate.
- Regenerated CRDs across `config/`, `config-dev/`, and `helm-templates/`.
- Documentation updated: `docs/howto/DBaaS Operator.md` marks the fields as immutable with rationale, plus a one-line note in the high-level "Key design decisions" section.

## Why these fields are dangerous to mutate

- **`DD.classifier`** — switching the classifier on an existing CR re-targets the controller at a different database while `status.trackingID` / `status.observedGeneration` still reference the original one. In-flight async operation becomes irrecoverable.
- **`DD.type`** — changing engine type mid-flight requests provisioning of a fresh database on a different adapter while the original stays registered under the same CR identity.
- **`DbPolicy.microserviceName`** — rewriting role grants under the same K8s object destroys the audit link to who created the policy originally.

## Integration test coverage

Five tests added to `OperatorIT.java` mirroring the existing EDB immutability suite:

| Test | Purpose |
|---|---|
| `testDatabaseDeclarationTryToUpdateClassifier` | Update classifier → expect HTTP 422 + immutability message |
| `testDatabaseDeclarationTryToUpdateType` | Update type → expect HTTP 422 + immutability message |
| `testDatabaseDeclarationCanUpdateSettings` | Negative confirmation: `spec.settings` still mutable, CR converges back to `Succeeded` |
| `testDbPolicyTryToUpdateMicroserviceName` | Update microserviceName → expect HTTP 422 + immutability message |
| `testDbPolicyCanUpdateServices` | Negative confirmation: `spec.services` still mutable, CR converges back to `Succeeded`, new service visible via `getAccessRoles` |

## Test plan

- [x] `go build ./...` — Success
- [x] `go test ./...` — green across `api/v1`, `internal/client`, `internal/controller`, `internal/ownership`
- [x] `mvn clean test-compile` on `dbaas-integration-tests` — green
- [x] Manual scan of existing `.edit()` call sites in `OperatorIT.java`: none mutate the now-immutable DD/DbPolicy fields, so no existing test fails
- [ ] CI run on this branch