### PR TITLE
fix: logical backup restore doesn't work for migrated databases

### DIFF
--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
@@ -212,7 +212,7 @@ public class MigrationService {
             }
 
             if (isUserCreation) {
-                recreateUserResources(dbName, db);
+                recreateUserResources(dbName, db, requestsWithAdapterId.getClassifier());
             }
 
             boolean hasDatabaseKind = db.getResources().stream().anyMatch(res -> DbResource.DATABASE_KIND.equals(res.getKind()));
@@ -232,7 +232,7 @@ public class MigrationService {
 
             if (isProcessExternalAsInternal) {
                 if (!isUserCreation) {
-                    updateAdapterMetadata(dbName, db);
+                    updateAdapterMetadata(dbName, db, requestsWithAdapterId.getClassifier());
                 }
 
                 markDatabaseAsCreated(db);
@@ -249,9 +249,11 @@ public class MigrationService {
         }
     }
 
-    private void updateAdapterMetadata(String dbName, DatabaseRegistry dbRegistry) {
-        physicalDatabasesService.getAdapterById(dbRegistry.getAdapterId()).changeMetaData(dbName,
-                AbstractDbaasAdapterRESTClient.buildMetadata(dbRegistry.getClassifier()));
+    private void updateAdapterMetadata(String dbName,
+                                       DatabaseRegistry dbRegistry,
+                                       Map<String, Object> classifier) {
+        physicalDatabasesService.getAdapterById(dbRegistry.getAdapterId())
+                .changeMetaData(dbName, AbstractDbaasAdapterRESTClient.buildMetadata(classifier));
     }
 
     private void markDatabaseAsCreated(DatabaseRegistry dbRegistry) {
@@ -262,10 +264,11 @@ public class MigrationService {
         dbRegistry.getDatabase().getDbState().setDatabaseState(CREATED);
     }
 
-    private void recreateUserResources(String dbName, DatabaseRegistry dbRegistry) {
+    private void recreateUserResources(String dbName, DatabaseRegistry dbRegistry,
+                                       Map<String, Object> classifier) {
         PhysicalDatabase physicalDb = physicalDatabasesService.getByAdapterId(dbRegistry.getAdapterId());
 
-        updateAdapterMetadata(dbName, dbRegistry);
+        updateAdapterMetadata(dbName, dbRegistry, classifier);
 
         List<String> userRoles = physicalDb.getRoles();
         List<EnsuredUser> ensuredUsers = userRoles.stream().map(role -> dBaaService.recreateUsers(physicalDatabasesService.getAdapterById(dbRegistry.getAdapterId()), null, dbName, null, role))

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
@@ -200,6 +200,7 @@ public class MigrationService {
                 existingDatabase.setBackupDisabled(requestsWithAdapterId.getBackupDisabled());
                 existingDatabase.setPhysicalDatabaseId(requestsWithAdapterId.getPhysicalDatabaseId());
                 existingDatabase.setAdapterId(requestsWithAdapterId.getAdapterId());
+                existingDatabase.setConnectionProperties(new ArrayList<>(requestsWithAdapterId.getConnectionProperties()));
             }
             DatabaseRegistry db = isProcessExternalAsInternal ?
                     existingDatabase :

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
@@ -210,13 +210,10 @@ public class MigrationService {
             } else {
                 db.setResources(new ArrayList<>());
             }
+
             if (isUserCreation) {
                 recreateUserResources(dbName, db);
-            } else {
-                updateAdapterMetadata(dbName, db);
             }
-
-            markDatabaseAsCreated(db);
 
             boolean hasDatabaseKind = db.getResources().stream().anyMatch(res -> DbResource.DATABASE_KIND.equals(res.getKind()));
             if (!hasDatabaseKind) {
@@ -231,6 +228,14 @@ public class MigrationService {
                         "database not existing in dbaas");
                 log.error("Got db {} without password and this db doesn't exist in the database of DBAAS", requestsWithAdapterId);
                 return;
+            }
+
+            if (isProcessExternalAsInternal) {
+                if (!isUserCreation) {
+                    updateAdapterMetadata(dbName, db);
+                }
+
+                markDatabaseAsCreated(db);
             }
 
             dBaaService.encryptAndSaveDatabaseEntity(db);

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
@@ -7,10 +7,7 @@ import com.netcracker.cloud.dbaas.dto.EnsuredUser;
 import com.netcracker.cloud.dbaas.dto.Source;
 import com.netcracker.cloud.dbaas.dto.migration.RegisterDatabaseResponseBuilder;
 import com.netcracker.cloud.dbaas.dto.v3.RegisterDatabaseRequestV3;
-import com.netcracker.cloud.dbaas.entity.pg.Database;
-import com.netcracker.cloud.dbaas.entity.pg.DatabaseRegistry;
-import com.netcracker.cloud.dbaas.entity.pg.DbResource;
-import com.netcracker.cloud.dbaas.entity.pg.PhysicalDatabase;
+import com.netcracker.cloud.dbaas.entity.pg.*;
 import com.netcracker.cloud.dbaas.exceptions.DbNotFoundException;
 import com.netcracker.cloud.dbaas.exceptions.UnregisteredPhysicalDatabaseException;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -23,6 +20,7 @@ import org.hibernate.exception.ConstraintViolationException;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.netcracker.cloud.dbaas.entity.shared.AbstractDbState.DatabaseStateStatus.CREATED;
 import static com.netcracker.cloud.dbaas.service.PasswordEncryption.PASSWORD_FIELD;
 
 @ApplicationScoped
@@ -206,7 +204,7 @@ public class MigrationService {
             DatabaseRegistry db = isProcessExternalAsInternal ?
                     existingDatabase :
                     newDatabaseByRequest(requestsWithAdapterId);
-            
+
             if (requestsWithAdapterId.getResources() != null && !requestsWithAdapterId.getResources().isEmpty()) {
                 db.setResources(new ArrayList<>(requestsWithAdapterId.getResources()));
             } else {
@@ -214,7 +212,12 @@ public class MigrationService {
             }
             if (isUserCreation) {
                 recreateUserResources(dbName, db);
+            } else {
+                updateAdapterMetadata(dbName, db);
             }
+
+            markDatabaseAsCreated(db);
+
             boolean hasDatabaseKind = db.getResources().stream().anyMatch(res -> DbResource.DATABASE_KIND.equals(res.getKind()));
             if (!hasDatabaseKind) {
                 db.getResources().add(new DbResource(DbResource.DATABASE_KIND, db.getName()));
@@ -241,10 +244,24 @@ public class MigrationService {
         }
     }
 
+    private void updateAdapterMetadata(String dbName, DatabaseRegistry dbRegistry) {
+        physicalDatabasesService.getAdapterById(dbRegistry.getAdapterId()).changeMetaData(dbName,
+                AbstractDbaasAdapterRESTClient.buildMetadata(dbRegistry.getClassifier()));
+    }
+
+    private void markDatabaseAsCreated(DatabaseRegistry dbRegistry) {
+        if (dbRegistry.getDatabase().getDbState() == null) {
+            dbRegistry.getDatabase().setDbState(new DbState());
+        }
+
+        dbRegistry.getDatabase().getDbState().setDatabaseState(CREATED);
+    }
+
     private void recreateUserResources(String dbName, DatabaseRegistry dbRegistry) {
         PhysicalDatabase physicalDb = physicalDatabasesService.getByAdapterId(dbRegistry.getAdapterId());
-        physicalDatabasesService.getAdapterById(physicalDb.getAdapter().getAdapterId())
-                .changeMetaData(dbRegistry.getName(), AbstractDbaasAdapterRESTClient.buildMetadata(dbRegistry.getClassifier()));
+
+        updateAdapterMetadata(dbName, dbRegistry);
+
         List<String> userRoles = physicalDb.getRoles();
         List<EnsuredUser> ensuredUsers = userRoles.stream().map(role -> dBaaService.recreateUsers(physicalDatabasesService.getAdapterById(dbRegistry.getAdapterId()), null, dbName, null, role))
                 .collect(Collectors.toList());

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/MigrationService.java
@@ -200,7 +200,9 @@ public class MigrationService {
                 existingDatabase.setBackupDisabled(requestsWithAdapterId.getBackupDisabled());
                 existingDatabase.setPhysicalDatabaseId(requestsWithAdapterId.getPhysicalDatabaseId());
                 existingDatabase.setAdapterId(requestsWithAdapterId.getAdapterId());
-                existingDatabase.setConnectionProperties(new ArrayList<>(requestsWithAdapterId.getConnectionProperties()));
+                if (requestsWithAdapterId.getConnectionProperties() != null && !requestsWithAdapterId.getConnectionProperties().isEmpty()) {
+                    existingDatabase.setConnectionProperties(new ArrayList<>(requestsWithAdapterId.getConnectionProperties()));
+                }
             }
             DatabaseRegistry db = isProcessExternalAsInternal ?
                     existingDatabase :

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
@@ -173,6 +173,7 @@ public class MigrationServiceTest {
         verify(dbaasAdapter).getDatabases();
         verify(dbaasAdapter).identifier();
         verify(dBaaService, times(2)).recreateUsers(any(), any(), any(), any(), any());
+        verify(dbaasAdapter).changeMetaData(eq(TEST_DB_NAME), anyMap());
         verifyNoMoreInteractions(databaseRegistryDbaasRepository, physicalDatabasesService, dbaasAdapter);
     }
 
@@ -424,15 +425,17 @@ public class MigrationServiceTest {
         when(dbaasAdapter.getDatabases()).thenReturn(Collections.singleton(TEST_DB_NAME));
         when(dbaasAdapter.identifier()).thenReturn(TEST_ADAPTER_ID);
 
+        SortedMap<String, Object> classifier = getClassifier();
         RegisterDatabaseRequestV3 testRequest = getRegisterDatabaseRequestSample();
         testRequest.setAdapterId(null);
         testRequest.setDbHost(TEST_TYPE + "." + TEST_NAMESPACE);
+        testRequest.setClassifier(classifier);
 
         Database testDb = new Database();
         testDb.setName(TEST_DB_NAME);
         testDb.setPhysicalDatabaseId(TEST_PHYDBID);
         testDb.setExternallyManageable(true);
-        testDb.setClassifier(testRequest.getClassifier());
+        testDb.setClassifier(classifier);
         testDb.setConnectionProperties(List.of(Map.of("username", "username", "password", "password")));
         DatabaseRegistry databaseRegistry = new DatabaseRegistry();
         databaseRegistry.setDatabase(testDb);
@@ -451,7 +454,7 @@ public class MigrationServiceTest {
         verify(dbaasAdapter, times(1)).getDatabases();
         verify(dbaasAdapter, times(1)).identifier();
         verify(dbaasAdapter).changeMetaData(eq(TEST_DB_NAME), anyMap());
-        
+
         verifyNoMoreInteractions(databaseRegistryDbaasRepository, physicalDatabasesService, dbaasAdapter);
     }
 

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
@@ -59,8 +59,10 @@ public class MigrationServiceTest {
     private final String TEST_DB_NAME = "test-db";
     private final String TEST_USER = "test-user";
     private final String TEST_TYPE = "test-type";
+    private final String ROLE_RW = "rw";
 
     @Test
+
     void testRegisterRequestValidation() {
         final RegisterDatabaseRequestV3 wrongAdapterId = getRegisterDatabaseRequestSample();
         wrongAdapterId.setAdapterId("wrong-adapter-id");
@@ -136,7 +138,7 @@ public class MigrationServiceTest {
     @Test
     void testRegisterDatabasesWithUserCreation() {
         PhysicalDatabase physicalDatabaseSample = getPhysicalDatabaseSample(TEST_ADAPTER_ID, TEST_PHYDBID);
-        physicalDatabaseSample.setRoles(Arrays.asList("admin", "rw"));
+        physicalDatabaseSample.setRoles(Arrays.asList("admin", ROLE_RW));
         when(physicalDatabasesService.getByPhysicalDatabaseIdentifier(TEST_PHYDBID)).thenReturn(physicalDatabaseSample);
         when(physicalDatabasesService.getByAdapterId(TEST_ADAPTER_ID)).thenReturn(physicalDatabaseSample);
         when(physicalDatabasesService.getAdapterById(TEST_ADAPTER_ID)).thenReturn(dbaasAdapter);
@@ -146,8 +148,8 @@ public class MigrationServiceTest {
 
         when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, "admin"))
                 .thenReturn(createEnsureUser(getConnectionProp("admin")));
-        when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, "rw"))
-                .thenReturn(createEnsureUser(getConnectionProp("rw")));
+        when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, ROLE_RW))
+                .thenReturn(createEnsureUser(getConnectionProp(ROLE_RW)));
 
         RegisterDatabaseRequestV3 registerDatabaseRequest = new RegisterDatabaseRequestV3();
         registerDatabaseRequest.setName(TEST_DB_NAME);
@@ -482,7 +484,7 @@ public class MigrationServiceTest {
     @Test
     void testRegisterExternalAsInternalWithUserCreationShouldSetCreatedStatusAndUpdateMetadata() {
         PhysicalDatabase physicalDatabase = getPhysicalDatabaseSample(TEST_ADAPTER_ID, TEST_PHYDBID);
-        physicalDatabase.setRoles(Arrays.asList(Role.ADMIN.toString(), "rw"));
+        physicalDatabase.setRoles(Arrays.asList(Role.ADMIN.toString(), ROLE_RW));
 
         RegisterDatabaseRequestV3 request = prepareExternalAsInternalMigration(physicalDatabase);
 
@@ -490,8 +492,8 @@ public class MigrationServiceTest {
 
         when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, Role.ADMIN.toString()))
                 .thenReturn(createEnsureUser(getConnectionProp(Role.ADMIN.toString())));
-        when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, "rw"))
-                .thenReturn(createEnsureUser(getConnectionProp("rw")));
+        when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, ROLE_RW))
+                .thenReturn(createEnsureUser(getConnectionProp(ROLE_RW)));
 
         RegisterDatabaseResponseBuilder result = migrationService.registerDatabases(
                 Collections.singletonList(request), API_VERSION.V3, true);

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
@@ -441,14 +441,17 @@ public class MigrationServiceTest {
         final List<RegisterDatabaseRequestV3> registerDatabaseRequestList = Collections.singletonList(testRequest);
 
         mockConnectionPropertiesResponse(dBaaService);
+
         final RegisterDatabaseResponseBuilder registerDatabaseResponseBuilder = migrationService.registerDatabases(registerDatabaseRequestList, API_VERSION.V1, false);
         assertEquals(Response.Status.OK.getStatusCode(), registerDatabaseResponseBuilder.buildAndResponse().getStatus());
 
         verify(physicalDatabasesService, times(1)).getPhysicalDatabaseByAdapterHost(TEST_NAMESPACE);
-        verify(physicalDatabasesService, times(1)).getAdapterById(TEST_ADAPTER_ID);
+        verify(physicalDatabasesService, times(2)).getAdapterById(TEST_ADAPTER_ID);
         verify(physicalDatabasesService, times(1)).getByPhysicalDatabaseIdentifier(TEST_PHYDBID);
         verify(dbaasAdapter, times(1)).getDatabases();
         verify(dbaasAdapter, times(1)).identifier();
+        verify(dbaasAdapter).changeMetaData(eq(TEST_DB_NAME), anyMap());
+        
         verifyNoMoreInteractions(databaseRegistryDbaasRepository, physicalDatabasesService, dbaasAdapter);
     }
 

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
@@ -437,8 +437,11 @@ public class MigrationServiceTest {
         testDb.setExternallyManageable(true);
         testDb.setClassifier(classifier);
         testDb.setConnectionProperties(List.of(Map.of("username", "username", "password", "password")));
+
         DatabaseRegistry databaseRegistry = new DatabaseRegistry();
         databaseRegistry.setDatabase(testDb);
+        databaseRegistry.setClassifier(classifier);
+
         testDb.setDatabaseRegistry(Arrays.asList(databaseRegistry));
         when(dBaaService.findDatabaseByOldClassifierAndType(testRequest.getClassifier(), TEST_TYPE, true)).thenReturn(databaseRegistry);
         final List<RegisterDatabaseRequestV3> registerDatabaseRequestList = Collections.singletonList(testRequest);

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/MigrationServiceTest.java
@@ -12,7 +12,6 @@ import com.netcracker.cloud.dbaas.exceptions.UnregisteredPhysicalDatabaseExcepti
 import com.netcracker.cloud.dbaas.repositories.dbaas.DatabaseRegistryDbaasRepository;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -24,6 +23,7 @@ import java.util.*;
 
 import static com.netcracker.cloud.dbaas.Constants.ROLE;
 import static com.netcracker.cloud.dbaas.DbaasApiPath.VERSION_2;
+import static com.netcracker.cloud.dbaas.entity.shared.AbstractDbState.DatabaseStateStatus.CREATED;
 import static com.netcracker.cloud.dbaas.service.PasswordEncryption.PASSWORD_FIELD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -479,6 +479,45 @@ public class MigrationServiceTest {
         assertEquals(true, hasDatabase, "Database resource should be present in saved entity");
     }
 
+    @Test
+    void testRegisterExternalAsInternalWithUserCreationShouldSetCreatedStatusAndUpdateMetadata() {
+        PhysicalDatabase physicalDatabase = getPhysicalDatabaseSample(TEST_ADAPTER_ID, TEST_PHYDBID);
+        physicalDatabase.setRoles(Arrays.asList(Role.ADMIN.toString(), "rw"));
+
+        RegisterDatabaseRequestV3 request = prepareExternalAsInternalMigration(physicalDatabase);
+
+        when(physicalDatabasesService.getByAdapterId(TEST_ADAPTER_ID)).thenReturn(physicalDatabase);
+
+        when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, Role.ADMIN.toString()))
+                .thenReturn(createEnsureUser(getConnectionProp(Role.ADMIN.toString())));
+        when(dBaaService.recreateUsers(dbaasAdapter, null, TEST_DB_NAME, null, "rw"))
+                .thenReturn(createEnsureUser(getConnectionProp("rw")));
+
+        RegisterDatabaseResponseBuilder result = migrationService.registerDatabases(
+                Collections.singletonList(request), API_VERSION.V3, true);
+
+        assertEquals(Response.Status.OK.getStatusCode(), result.buildAndResponse().getStatus());
+
+        verify(dbaasAdapter).changeMetaData(eq(TEST_DB_NAME), anyMap());
+        verify(dBaaService, times(2)).recreateUsers(any(), any(), any(), any(), any());
+        assertSavedDatabaseHasCreatedStatus();
+    }
+
+    @Test
+    void testRegisterExternalAsInternalWithoutUserCreationShouldSetCreatedStatusAndUpdateMetadata() {
+        PhysicalDatabase physicalDatabase = getPhysicalDatabaseSample(TEST_ADAPTER_ID, TEST_PHYDBID);
+        RegisterDatabaseRequestV3 request = prepareExternalAsInternalMigration(physicalDatabase);
+
+        RegisterDatabaseResponseBuilder result = migrationService.registerDatabases(
+                Collections.singletonList(request), API_VERSION.V3, false);
+
+        assertEquals(Response.Status.OK.getStatusCode(), result.buildAndResponse().getStatus());
+
+        verify(dbaasAdapter).changeMetaData(eq(TEST_DB_NAME), anyMap());
+        verify(dBaaService, never()).recreateUsers(any(), any(), any(), any(), any());
+        assertSavedDatabaseHasCreatedStatus();
+    }
+
     private RegisterDatabaseRequestV3 getRegisterDatabaseRequestSample() {
         final RegisterDatabaseRequestV3 registerDatabaseRequest = new RegisterDatabaseRequestV3();
         registerDatabaseRequest.setName(TEST_DB_NAME);
@@ -498,5 +537,52 @@ public class MigrationServiceTest {
         physicalDatabase.setAdapter(new ExternalAdapterRegistrationEntry(adapterId, "test-address", new HttpBasicCredentials("", ""), VERSION_2, null));
         physicalDatabase.setType(TEST_TYPE);
         return physicalDatabase;
+    }
+
+    private RegisterDatabaseRequestV3 prepareExternalAsInternalMigration(PhysicalDatabase physicalDatabase) {
+        physicalDatabase.setPhysicalDatabaseIdentifier(TEST_PHYDBID);
+
+        when(physicalDatabasesService.getPhysicalDatabaseByAdapterHost(TEST_NAMESPACE))
+                .thenReturn(Collections.singletonList(physicalDatabase));
+        when(physicalDatabasesService.getAdapterById(TEST_ADAPTER_ID)).thenReturn(dbaasAdapter);
+        when(physicalDatabasesService.getByPhysicalDatabaseIdentifier(TEST_PHYDBID)).thenReturn(physicalDatabase);
+
+        when(dbaasAdapter.getDatabases()).thenReturn(Collections.singleton(TEST_DB_NAME));
+        when(dbaasAdapter.identifier()).thenReturn(TEST_ADAPTER_ID);
+        doNothing().when(dbaasAdapter).changeMetaData(eq(TEST_DB_NAME), anyMap());
+
+        RegisterDatabaseRequestV3 request = getRegisterDatabaseRequestSample();
+        request.setAdapterId(null);
+        request.setDbHost(TEST_TYPE + "." + TEST_NAMESPACE);
+        request.setClassifier(getClassifier());
+
+        Database externalDb = new Database();
+        externalDb.setName(TEST_DB_NAME);
+        externalDb.setPhysicalDatabaseId(TEST_PHYDBID);
+        externalDb.setExternallyManageable(true);
+        externalDb.setClassifier(request.getClassifier());
+        externalDb.setConnectionProperties(List.of(Map.of(
+                "username", TEST_USER,
+                PASSWORD_FIELD, "password"
+        )));
+
+        DatabaseRegistry databaseRegistry = new DatabaseRegistry();
+        databaseRegistry.setDatabase(externalDb);
+        externalDb.setDatabaseRegistry(Collections.singletonList(databaseRegistry));
+
+        when(dBaaService.findDatabaseByClassifierAndType(request.getClassifier(), TEST_TYPE, true))
+                .thenReturn(databaseRegistry);
+
+        mockConnectionPropertiesResponse(dBaaService);
+
+        return request;
+    }
+
+    private void assertSavedDatabaseHasCreatedStatus() {
+        ArgumentCaptor<DatabaseRegistry> databaseCaptor = ArgumentCaptor.forClass(DatabaseRegistry.class);
+        verify(dBaaService).encryptAndSaveDatabaseEntity(databaseCaptor.capture());
+        DatabaseRegistry savedRegistry = databaseCaptor.getValue();
+        assertEquals(CREATED, savedRegistry.getDatabase().getDbState().getDatabaseState(),
+                "Migrated database should be saved with CREATED state");
     }
 }

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/entity/RegisterDatabaseRequest.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/entity/RegisterDatabaseRequest.java
@@ -1,0 +1,66 @@
+package com.netcracker.it.dbaas.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterDatabaseRequest {
+
+    @NotNull
+    private Map<String, Object> classifier;
+
+    @NotNull
+    private List<ConnectionProperties> connectionProperties;
+
+    @NotNull
+    private List<DbResource> resources;
+
+    @NotNull
+    private String namespace;
+
+    @NotNull
+    private String type;
+
+    @NotNull
+    private String adapterId;
+
+    @NotNull
+    private String name;
+
+    private Boolean backupDisabled = false;
+
+    @Nullable
+    private String physicalDatabaseId;
+
+    @Nullable
+    private String dbHost;
+
+    public RegisterDatabaseRequest(Map<String, Object> classifier,
+                                   List<ConnectionProperties> connectionProperties,
+                                   List<DbResource> resources,
+                                   String namespace,
+                                   String adapterId,
+                                   String type,
+                                   String name,
+                                   @Nullable String physicalDatabaseId,
+                                   @Nullable String dbHost) {
+        this.classifier = classifier;
+        this.connectionProperties = connectionProperties;
+        this.resources = resources;
+        this.namespace = namespace;
+        this.adapterId = adapterId;
+        this.type = type;
+        this.name = name;
+        this.physicalDatabaseId = physicalDatabaseId;
+        this.dbHost = dbHost;
+    }
+}

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/DbaasHelperV3.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/DbaasHelperV3.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.gson.GsonBuilder;
 import com.mongodb.*;
+import com.mongodb.client.MongoDatabase;
 import com.netcracker.cloud.junit.cloudcore.extension.provider.LocalHostAddressGenerator;
 import com.netcracker.cloud.junit.cloudcore.extension.service.Endpoint;
 import com.netcracker.cloud.junit.cloudcore.extension.service.NetSocketAddress;
@@ -38,6 +39,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
@@ -81,6 +83,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Slf4j
 public class DbaasHelperV3 {
@@ -139,6 +142,8 @@ public class DbaasHelperV3 {
             .build();
 
     public static final Pattern TEST_NAMESPACE_PATTERN = Pattern.compile("^dbaas-autotests-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+    public static final String CONNECTION_PROPERTIES = "connectionProperties";
+    private static final String DBAAS_METADATA = "_dbaas_metadata";
 
     @NonNull
     private volatile URL dbaasServiceUrl;
@@ -953,8 +958,7 @@ public class DbaasHelperV3 {
         try {
             log.info("Check connection to created database {}", db);
             switch (db.getType()) {
-                case MONGODB_TYPE ->
-                        checkConnectionMongo(db, expectCannotConnect, setData, checkData);
+                case MONGODB_TYPE -> checkConnectionMongo(db, expectCannotConnect, setData, checkData);
                 case POSTGRES_TYPE -> checkConnectionPostgres(db, setData, checkData);
                 case OPENSEARCH_TYPE -> checkConnectionOpensearch(db, setData, checkData);
                 case CASSANDRA_TYPE -> checkConnectionCassandra(db, setData, checkData);
@@ -1311,6 +1315,42 @@ public class DbaasHelperV3 {
         return changePassword(passwordChangeRequest, expectHttpCode, namespace);
     }
 
+    public Map createDbViaAdapter(String dbType, String microserviceName, String namespace) throws IOException {
+        PhysicalDatabaseRegistrationResponseDTOV3 physDb = getGlobalPhysicalDbEntry(dbType).getValue();
+        String adapterAddress = physDb.getAdapterAddress();
+        URL portForward = createPortForward(adapterAddress);
+        String apiVersion = physDb.getSupportedVersion();
+        String payload = String.format(
+                "{\"metadata\":{\"classifier\":{\"microserviceName\":\"%s\",\"scope\":\"service\",\"namespace\":\"%s\"}}}",
+                microserviceName, namespace);
+        String adapterCredentials = readAdapterCredentials(adapterAddress);
+        Request request = new Request.Builder()
+                .url(portForward.toString() + "api/" + apiVersion + "/dbaas/adapter/" + dbType + "/databases")
+                .post(RequestBody.create(payload, JSON))
+                .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(adapterCredentials.getBytes()))
+                .addHeader("X-Request-Id", getRequestId())
+                .build();
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            String resBody = response.body().string();
+            log.info("Adapter {} created database: {}", adapterAddress, resBody);
+            assumeTrue(response.code() == 201, "dbaas-adapter could not create database, skip test");
+            return objectMapper.readValue(resBody, Map.class);
+        } catch (IOException e) {
+            log.error("Error while creating database via adapter {}", adapterAddress, e);
+            throw e;
+        }
+    }
+
+    public Map.Entry<String, PhysicalDatabaseRegistrationResponseDTOV3> getGlobalPhysicalDbEntry(String dbType) throws IOException {
+        return getRegisteredPhysicalDatabases(dbType, getClusterDbaAuthorization(), 200)
+                .getIdentified()
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().isGlobal())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No global physical database found for type: " + dbType));
+    }
+
     private PasswordChangeResponse changePassword(PasswordChangeRequest passwordChangeRequest, int expectHttpCode, String namespace) throws IOException {
         String passwordChangeRequestJson = new GsonBuilder().create().toJson(passwordChangeRequest);
         Request request = new Request.Builder()
@@ -1325,6 +1365,40 @@ public class DbaasHelperV3 {
             log.debug("Response body: {}", body);
             assertThat(response.code(), is(expectHttpCode));
             return objectMapper.readValue(body, PasswordChangeResponse.class);
+        }
+    }
+
+    @SneakyThrows
+    public void removePgMetadata(Map map) {
+        log.info("remove pg metadata");
+        List<Map<String, Object>> connectionProperties = (List<Map<String, Object>>) map.get(CONNECTION_PROPERTIES);
+        Map<String, Object> adminConnectionProperty = connectionProperties.stream().filter(cp -> cp.get("role").equals(Role.ADMIN.getRoleValue())).findFirst().get();
+        log.info("connection property {}", adminConnectionProperty);
+        DatabaseResponse databaseResponse = DatabaseResponse.builder().connectionProperties(adminConnectionProperty).build();
+        try (Connection connection = connectPg(databaseResponse);
+             Statement statement = connection.createStatement()) {
+            try {
+                String sql = "DROP TABLE _dbaas_metadata";
+                statement.executeUpdate(sql);
+            } catch (Throwable ex) {
+                throw new CannotConnect(ex);
+            }
+        }
+    }
+
+    @SneakyThrows
+    public void removeMongoMetadata(Map map) {
+        log.info("remove mongodb metadata");
+        List<Map<String, Object>> connectionProperties = (List<Map<String, Object>>) map.get(CONNECTION_PROPERTIES);
+        Map<String, Object> adminConnectionProperty = connectionProperties.stream().filter(cp -> cp.get("role").equals(Role.ADMIN.getRoleValue())).findFirst().get();
+        log.info("connection property {}", adminConnectionProperty);
+        DatabaseResponse databaseResponse = DatabaseResponse.builder().connectionProperties(adminConnectionProperty).build();
+        try (MongoClient mongoClient = connectMongo(databaseResponse, false)) {
+            MongoDatabase mongoDatabase = mongoClient.getDatabase((String) adminConnectionProperty.get("authDbName"));
+            mongoDatabase.getCollection("autotestsData").insertOne(new Document("testkey", "testvalue")); // if database does not have any collections mongo drops such db, so we create fake collection
+            mongoDatabase.getCollection(DBAAS_METADATA).drop();
+            assertFalse(mongoDatabase.listCollectionNames()
+                    .into(new ArrayList<>()).contains(DBAAS_METADATA));
         }
     }
 
@@ -1600,6 +1674,42 @@ public class DbaasHelperV3 {
             }
         }
         return Optional.empty();
+    }
+
+    public String readAdapterCredentials(String adapterAddress) {
+        String adapterNamespace = DbaasHelperV3.getServiceNamespaceFromUrl(adapterAddress);
+        String adapterServiceName = DbaasHelperV3.getServiceNameFromUrl(adapterAddress);
+
+        Pod adapterPod = getAdapterPodByServiceName(adapterNamespace, adapterServiceName)
+                .orElseThrow(() -> new RuntimeException(
+                        "Could not find adapter pod for service " + adapterServiceName
+                                + " in namespace: " + adapterNamespace));
+
+        String username = readFirstAvailableSecretFromEnv(
+                adapterPod,
+                adapterNamespace,
+                List.of("DBAAS_ADAPTER_API_USER", "DBAAS_AGGREGATOR_USERNAME")
+        );
+
+        String password = readFirstAvailableSecretFromEnv(
+                adapterPod,
+                adapterNamespace,
+                List.of("DBAAS_ADAPTER_API_PASSWORD", "DBAAS_AGGREGATOR_PASSWORD")
+        );
+
+        return username + ":" + password;
+    }
+
+    private String readFirstAvailableSecretFromEnv(Pod pod, String namespace, List<String> envNames) {
+        for (String envName : envNames) {
+            Optional<String> value = readSecretFromEnvVariable(pod, namespace, envName);
+            if (value.isPresent()) {
+                return value.get();
+            }
+        }
+        throw new RuntimeException("None of env variables " + envNames
+                + " found in pod " + pod.getMetadata().getName()
+                + " in namespace " + namespace);
     }
 
     private String getAdapterAddress(String dbType, String physicalDatabaseId) {

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/AbstractIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/AbstractIT.java
@@ -13,7 +13,6 @@ import com.netcracker.it.dbaas.entity.DbaasUsersData;
 import com.netcracker.it.dbaas.helpers.DbaasHelperV3;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.failsafe.RetryPolicy;
@@ -32,7 +31,8 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Base class for all the DBaaS Aggregator ITs.
@@ -183,7 +183,6 @@ public abstract class AbstractIT {
 
     protected static DbaasUsersData readDbaasUsersFromSecret() {
         Secret secret = kubernetesClient.secrets().withName("dbaas-security-configuration-secret").get();
-
 
         String usersJson;
         if (secret.getData().size() > 1) {

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/DatabaseMigrationIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/DatabaseMigrationIT.java
@@ -1,36 +1,26 @@
 package com.netcracker.it.dbaas.test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.mongodb.MongoClient;
-import com.mongodb.client.MongoDatabase;
 import com.netcracker.cloud.core.error.rest.tmf.TmfErrorResponse;
 import com.netcracker.it.dbaas.entity.*;
 import com.netcracker.it.dbaas.entity.response.MigrationResult;
 import com.netcracker.it.dbaas.exceptions.CannotConnect;
 import com.netcracker.it.dbaas.helpers.ClassifierBuilder;
 import com.netcracker.it.dbaas.helpers.DbaasHelperV3;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import org.bson.Document;
 import org.junit.jupiter.api.*;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
-import java.net.URL;
-import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.*;
 import java.util.function.Consumer;
 
 import static com.netcracker.it.dbaas.helpers.DbaasHelperV3.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Slf4j
 public class DatabaseMigrationIT extends AbstractIT {

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/DatabaseMigrationIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/DatabaseMigrationIT.java
@@ -1,0 +1,390 @@
+package com.netcracker.it.dbaas.test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import com.netcracker.cloud.core.error.rest.tmf.TmfErrorResponse;
+import com.netcracker.it.dbaas.entity.*;
+import com.netcracker.it.dbaas.entity.response.MigrationResult;
+import com.netcracker.it.dbaas.exceptions.CannotConnect;
+import com.netcracker.it.dbaas.helpers.ClassifierBuilder;
+import com.netcracker.it.dbaas.helpers.DbaasHelperV3;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.function.Consumer;
+
+import static com.netcracker.it.dbaas.helpers.DbaasHelperV3.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Slf4j
+public class DatabaseMigrationIT extends AbstractIT {
+
+    private static final String BASE_MIGRATE_API = "api/v3/dbaas/migration/databases";
+    private static final String MIGRATE_WITH_USER_CREATION_API = BASE_MIGRATE_API + "/with-user-creation";
+
+    private static final String DATABASE_ERROR_MSG = "registered database must contain ";
+    private static final String INVALID_CLASSIFIER_ERROR_MSG = "Invalid classifier. It does not match v3 format. Classifier: ";
+    private static final String MIGRATE_EXTERNAL_TEST_VAL = "migrate_external_";
+    private static final String USERNAME = "username";
+    private static final String NAME = "name";
+    private static final String PASSWORD = "password";
+    private static final String URL = "url";
+    private static final String INCORRECT_POSTGRES_TYPE = "postgrsql";
+    private static final String TEST_MIGRATED_DB_NAME = "migrated_db";
+    private static final String TEST_PHYSICAL_DB_ID = "physical_db_id";
+
+    @BeforeEach
+    public void initAndCleanDbs() throws IOException {
+        cleanDbs();
+    }
+
+    @AfterEach
+    public void cleanDbs() throws IOException {
+        log.info("Clean databases");
+
+        helperV3.deleteDatabases(helperV3.getClusterDbaAuthorization(), DbaasHelperV3.TEST_NAMESPACE);
+    }
+
+    @Test
+    public void migrateWithUserCreation_NotValidRequest() throws IOException {
+        RegisterDatabaseWithUserCreationRequest requestBody = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBody.setType(null);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBody, DATABASE_ERROR_MSG + "dbType");
+
+        requestBody = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBody.setClassifier(null);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBody, DATABASE_ERROR_MSG + "classifier");
+
+        requestBody = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBody.setName(null);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBody, DATABASE_ERROR_MSG + "database name");
+
+        requestBody = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBody.setPhysicalDatabaseId(null);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBody, DATABASE_ERROR_MSG + "physical database id or dbHost");
+
+        requestBody = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBody.getClassifier().remove(NAMESPACE);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBody, DATABASE_ERROR_MSG + "namespace in classifier");
+    }
+
+    @Test
+    public void migrateWithUserCreation_NotValidClassifier() throws IOException {
+        RegisterDatabaseWithUserCreationRequest requestBodySec = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBodySec.setClassifier(new TreeMap<>(Map.of(NAMESPACE, DbaasHelperV3.TEST_NAMESPACE)));
+
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBodySec, INVALID_CLASSIFIER_ERROR_MSG + requestBodySec.getClassifier());
+
+        requestBodySec = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBodySec.getClassifier().remove(MICROSERVICE_NAME);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBodySec, INVALID_CLASSIFIER_ERROR_MSG + requestBodySec.getClassifier());
+
+        requestBodySec = getNotValidRegisterDatabaseWithUserCreationRequest();
+        requestBodySec.getClassifier().remove("scope");
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBodySec, INVALID_CLASSIFIER_ERROR_MSG + requestBodySec.getClassifier());
+    }
+
+    @Test
+    public void migrateWithUserCreation_NotValidPhysicalId() {
+        RegisterDatabaseWithUserCreationRequest requestBodySec = new RegisterDatabaseWithUserCreationRequest(
+                new ClassifierBuilder().test("migrateWithUserCreation_NotValidPhysicalId").build(),
+                POSTGRES_TYPE,
+                "fake-name",
+                "fake-phys-id",
+                null
+        );
+        Request request = helperV3.createRequest(MIGRATE_WITH_USER_CREATION_API, helperV3.getClusterDbaAuthorization(), Collections.singletonList(requestBodySec), HttpMethod.PUT.name());
+
+        Map<String, MigrationResult> resultMap = sendRequest(request, HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+        Assertions.assertEquals("fake-name failed due to: Physical database fake-phys-id is not registered", resultMap.get(POSTGRES_TYPE).getFailureReasons().getFirst());
+    }
+
+    @Test
+    public void migrateWithUserCreation_DatabaseNotExist() throws IOException {
+        String physId = helperV3.getRegisteredPhysicalDatabases(POSTGRES_TYPE, helperV3.getClusterDbaAuthorization(), HttpStatus.OK.value()).
+                getIdentified()
+                .entrySet()
+                .stream().filter(phys -> phys.getValue().isGlobal()).map(Map.Entry::getKey).findFirst().get();
+        RegisterDatabaseWithUserCreationRequest requestBodySec = new RegisterDatabaseWithUserCreationRequest(
+                new ClassifierBuilder().test("migrateWithUserCreation_NotValidPhysicalId").build(),
+                INCORRECT_POSTGRES_TYPE,
+                "fake-name",
+                physId,
+                null
+        );
+        Request request = helperV3.createRequest(MIGRATE_WITH_USER_CREATION_API, helperV3.getClusterDbaAuthorization(), Collections.singletonList(requestBodySec), HttpMethod.PUT.name());
+
+        Map<String, MigrationResult> resultMap = sendRequest(request, HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+        Assertions.assertTrue(resultMap.get(INCORRECT_POSTGRES_TYPE).getFailureReasons().getFirst().contains("fake-name failed due to: Could not find registered database by adapter"));
+    }
+
+    @Test
+    @Tag("Smoke")
+    public void migrateWithUserCreation_SuccessfullyMigratedPostgresql() throws IOException, SQLException {
+        testDatabaseMigration(POSTGRES_TYPE, helperV3::removePgMetadata, false, true);
+    }
+
+    @Test
+    public void migrateWithUserCreation_SuccessfullyMigratedMongodb() throws IOException, SQLException {
+        Assumptions.assumeTrue(helperV3.hasAdapterOfType(MONGODB_TYPE), "No mongodb adapter. Skip test.");
+        testDatabaseMigration(MONGODB_TYPE, helperV3::removeMongoMetadata, false, true);
+    }
+
+    @Test
+    public void migrateWithUserCreation_SuccessfullyMigratedPostgresql_SetOnlyHostDb() throws IOException, SQLException {
+        testDatabaseMigration(POSTGRES_TYPE, helperV3::removePgMetadata, true, true);
+    }
+
+    @Test
+    void migrateWithUserCreation_MigrateExternalAsInternal() throws IOException, SQLException {
+        Consumer<Map> removeMetadata = helperV3::removePgMetadata;
+        String physicalId = null;
+        for (Map.Entry<String, PhysicalDatabaseRegistrationResponseDTOV3> physicalDbEntrySet : helperV3.getRegisteredPhysicalDatabases(POSTGRES_TYPE, helperV3.getClusterDbaAuthorization(), 200).
+                getIdentified().entrySet()) {
+            if (physicalDbEntrySet.getValue().isGlobal()) {
+                physicalId = physicalDbEntrySet.getKey();
+            }
+        }
+
+        // create database via adapter so it can be registered as external
+        Map map = helperV3.createDbViaAdapter(POSTGRES_TYPE, TEST_MICROSERVICE_NAME, DbaasHelperV3.TEST_NAMESPACE);
+        removeMetadata.accept(map);
+
+        // register created database as external
+        String dbName = map.get(NAME).toString();
+        List<Map<String, Object>> listOfConnProps = (List<Map<String, Object>>) map.get(CONNECTION_PROPERTIES);
+        Map<String, Object> classifier = Map.of(MICROSERVICE_NAME, TEST_MICROSERVICE_NAME, "scope", "service", TEST_CLASSIFIER_KEY, "ext-as-int", NAMESPACE, DbaasHelperV3.TEST_NAMESPACE);
+        ExternalDatabaseRequestV3 externalRegistrationRequest = ExternalDatabaseRequestV3.builder()
+                .classifier(classifier)
+                .connectionProperties(listOfConnProps)
+                .dbName(dbName)
+                .originService(TEST_MICROSERVICE_NAME)
+                .userRole(Role.ADMIN.getRoleValue())
+                .type(POSTGRES_TYPE).build();
+        Request request = helperV3.createRequest(String.format(EXTERNALLY_MANAGEABLE_V3, TEST_NAMESPACE), helperV3.getClusterDbaAuthorization(), externalRegistrationRequest, HttpMethod.PUT.name());
+        ExternalDatabaseResponseV3 externalDatabaseResponse = helperV3.executeRequest(request, ExternalDatabaseResponseV3.class, 201);
+
+        // re-register external database as internal via 'with-user-creation'
+        RegisterDatabaseWithUserCreationRequest requestBodySec = new RegisterDatabaseWithUserCreationRequest(
+                classifier,
+                POSTGRES_TYPE,
+                dbName,
+                physicalId,
+                null
+        );
+        Request migraterequest = helperV3.createRequest(MIGRATE_WITH_USER_CREATION_API, helperV3.getClusterDbaAuthorization(), Collections.singletonList(requestBodySec), HttpMethod.PUT.name());
+        Map<String, MigrationResult> resultMap = sendRequest(migraterequest, HttpStatus.OK.value());
+        MigrationResult migrationResult = resultMap.get(POSTGRES_TYPE);
+        Assertions.assertNotNull(migrationResult);
+        Assertions.assertEquals(dbName, migrationResult.getMigrated().getFirst());
+        DatabaseV3 migratedDb = migrationResult.getMigratedDbInfo().getFirst();
+        Assertions.assertNotNull(migratedDb);
+        Assertions.assertEquals(dbName, migratedDb.getName());
+
+        // get database by classifier and check that it is not external anymore
+        DatabaseResponse databaseByClassifierAsPOJO = helperV3.getDatabaseByClassifierAsPOJO(helperV3.getClusterDbaAuthorization(), externalDatabaseResponse.getClassifier(), TEST_NAMESPACE, POSTGRES_TYPE, HttpStatus.OK.value());
+        assertFalse(databaseByClassifierAsPOJO.isExternallyManageable());
+
+        // call get or create database
+        List<DatabaseResponse> databases = helperV3.createDatabases(helperV3.getClusterDbaAuthorization(), "ext-as-int", HttpStatus.OK.value(), TEST_NAMESPACE, POSTGRES_TYPE);
+        assertEquals(1, databases.size());
+        DatabaseResponse databaseByGetOrCreate = databases.getFirst();
+        assertFalse(databaseByGetOrCreate.isExternallyManageable());
+
+        helperV3.checkConnectionPostgres(databaseByGetOrCreate);
+
+        helperV3.deleteDatabasesByClassifierRequest(TEST_NAMESPACE, POSTGRES_TYPE, createClassifierWithRolesRequest(classifier), HttpStatus.OK.value());
+
+        Assertions.assertThrows(CannotConnect.class, () -> {
+            helperV3.checkConnectionPostgres(databaseByGetOrCreate);
+        }, "Connection should fail after database deletion");
+    }
+
+    @Test
+    public void migrateDatabase_NotValidClassifier() {
+        RegisterDatabaseRequest requestBodySec = getNotValidRegisterDatabaseRequest();
+        requestBodySec.setClassifier(new TreeMap<>(Map.of(NAMESPACE, DbaasHelperV3.TEST_NAMESPACE)));
+
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBodySec, INVALID_CLASSIFIER_ERROR_MSG + requestBodySec.getClassifier());
+
+        requestBodySec = getNotValidRegisterDatabaseRequest();
+        requestBodySec.getClassifier().remove(MICROSERVICE_NAME);
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBodySec, INVALID_CLASSIFIER_ERROR_MSG + requestBodySec.getClassifier());
+
+        requestBodySec = getNotValidRegisterDatabaseRequest();
+        requestBodySec.getClassifier().remove("scope");
+        sendAndCheckBadRequestError(MIGRATE_WITH_USER_CREATION_API, requestBodySec, INVALID_CLASSIFIER_ERROR_MSG + requestBodySec.getClassifier());
+    }
+
+    @Test
+    public void migrateDatabaseSuccessfullyMigratedPostgreSql() throws IOException, SQLException {
+        testDatabaseMigration(POSTGRES_TYPE, helperV3::removePgMetadata, false, false);
+    }
+
+    @Test
+    public void migrateDatabaseSuccessfullyMigratedMongodb() throws IOException, SQLException {
+        Assumptions.assumeTrue(helperV3.hasAdapterOfType(MONGODB_TYPE), "No mongodb adapter. Skip test.");
+        testDatabaseMigration(MONGODB_TYPE, helperV3::removeMongoMetadata, false, false);
+    }
+
+    @Test
+    public void migrateDatabaseSuccessfullyMigratedPostgresql_SetOnlyHostDb() throws IOException, SQLException {
+        testDatabaseMigration(POSTGRES_TYPE, helperV3::removePgMetadata, true, false);
+    }
+
+    private ClassifierWithRolesRequest createClassifierWithRolesRequest(Map<String, Object> classifier) {
+        ClassifierWithRolesRequest classifierWithRolesRequest = new ClassifierWithRolesRequest();
+        classifierWithRolesRequest.setClassifier(classifier);
+        classifierWithRolesRequest.setUserRole(Role.ADMIN.getRoleValue());
+        classifierWithRolesRequest.setOriginService((String) classifier.get(MICROSERVICE_NAME));
+        return classifierWithRolesRequest;
+    }
+
+    private void testDatabaseMigration(String dbType, Consumer<Map> removeMetadata, boolean withHostDb,
+                                       boolean withUserCreation) throws IOException, SQLException {
+        Map.Entry<String, PhysicalDatabaseRegistrationResponseDTOV3> physDbEntry = helperV3.getGlobalPhysicalDbEntry(dbType);
+        String physicalId = physDbEntry.getKey();
+        PhysicalDatabaseRegistrationResponseDTOV3 physDb = physDbEntry.getValue();
+
+        Map adapterResponse = helperV3.createDbViaAdapter(dbType, TEST_MICROSERVICE_NAME, DbaasHelperV3.TEST_NAMESPACE);
+        removeMetadata.accept(adapterResponse);
+        String dbName = adapterResponse.get(NAME).toString();
+
+        String hostDbRequest = helperV3.getServiceNameFromUrl(physDb.getAdapterAddress()) + "."
+                + helperV3.getServiceNamespaceFromUrl(physDb.getAdapterAddress());
+
+        String physicalDbIdRequest = withHostDb ? null : physicalId;
+
+        Map<String, Object> classifier = new ClassifierBuilder()
+                .test(MIGRATE_EXTERNAL_TEST_VAL + dbType)
+                .build();
+
+        Object requestBody;
+        String apiEndpoint;
+
+        if (withUserCreation) {
+            apiEndpoint = MIGRATE_WITH_USER_CREATION_API;
+            requestBody = new RegisterDatabaseWithUserCreationRequest(
+                    classifier,
+                    dbType,
+                    dbName,
+                    physicalDbIdRequest,
+                    hostDbRequest);
+        } else {
+            apiEndpoint = BASE_MIGRATE_API;
+            List<ConnectionProperties> connProps = helperV3.objectMapper.convertValue(
+                    adapterResponse.get(CONNECTION_PROPERTIES), new TypeReference<>() {
+                    });
+            List<DbResource> resources = helperV3.objectMapper.convertValue(
+                    adapterResponse.get("resources"), new TypeReference<>() {
+                    });
+            requestBody = new RegisterDatabaseRequest(
+                    classifier,
+                    connProps,
+                    resources,
+                    DbaasHelperV3.TEST_NAMESPACE,
+                    physDb.getAdapterId(),
+                    dbType,
+                    dbName,
+                    physicalDbIdRequest,
+                    hostDbRequest);
+        }
+
+        Request request = helperV3.createRequest(apiEndpoint, helperV3.getClusterDbaAuthorization(),
+                Collections.singletonList(requestBody), HttpMethod.PUT.name());
+
+        Map<String, MigrationResult> resultMap = sendRequest(request, HttpStatus.OK.value());
+        verifyMigrationResults(resultMap, adapterResponse, dbType, classifier, physicalId, physDb);
+
+        DatabaseResponse databaseResponse = helperV3.getDatabaseByClassifierAsPOJO(helperV3.getClusterDbaAuthorization(),
+                classifier, DbaasHelperV3.TEST_NAMESPACE, dbType, HttpStatus.OK.value());
+
+        helperV3.checkConnection(false, databaseResponse, null, null, false);
+
+        helperV3.deleteDatabasesByClassifierRequest(TEST_NAMESPACE, dbType, createClassifierWithRolesRequest(classifier),
+                HttpStatus.OK.value());
+
+        helperV3.checkConnection(true, databaseResponse, null, null, false);
+    }
+
+    private Map<String, MigrationResult> sendRequest(Request request, int expectedCode) {
+        Map response = helperV3.executeRequest(request, Map.class, expectedCode);
+        return helperV3.objectMapper.convertValue(response, new TypeReference<>() {
+        });
+    }
+
+    private <T> void sendAndCheckBadRequestError(String endpoint, T requestBody, String expectErrorMsg) {
+        Request request = helperV3.createRequest(endpoint, helperV3.getClusterDbaAuthorization(),
+                Collections.singletonList(requestBody), HttpMethod.PUT.name());
+        TmfErrorResponse response = helperV3.executeRequest(request, TmfErrorResponse.class, HttpStatus.BAD_REQUEST.value());
+        Assertions.assertEquals(expectErrorMsg, response.getDetail());
+    }
+
+    private RegisterDatabaseWithUserCreationRequest getNotValidRegisterDatabaseWithUserCreationRequest() {
+        Map<String, Object> classifier = new ClassifierBuilder().test("migrateWithUserCreation_NotValidRequest").build();
+        return new RegisterDatabaseWithUserCreationRequest(
+                new TreeMap<>(classifier),
+                POSTGRES_TYPE,
+                TEST_MIGRATED_DB_NAME,
+                TEST_PHYSICAL_DB_ID,
+                null
+        );
+    }
+
+    private void verifyMigrationResults(Map<String, MigrationResult> resultMap, Map adapterResponse, String dbType, Map<String, Object> classifier,
+                                        String physicalId, PhysicalDatabaseRegistrationResponseDTOV3 physDb) {
+        MigrationResult migrationResult = resultMap.get(dbType);
+        Assertions.assertNotNull(migrationResult);
+        Assertions.assertEquals(adapterResponse.get(NAME).toString(), migrationResult.getMigrated().getFirst());
+        DatabaseV3 migratedDb = migrationResult.getMigratedDbInfo().getFirst();
+        Assertions.assertNotNull(migratedDb);
+        Assertions.assertEquals(adapterResponse.get(NAME).toString(), migratedDb.getName());
+        Assertions.assertEquals(classifier, migratedDb.getClassifier());
+        Assertions.assertEquals(physicalId, migratedDb.getPhysicalDatabaseId());
+        Assertions.assertEquals(dbType, migratedDb.getType());
+        Assertions.assertEquals(classifier.get(NAMESPACE), migratedDb.getNamespace());
+        Map<String, Object> connectionProperty = migratedDb.getConnectionPropertyByRole(Role.ADMIN);
+        Assertions.assertTrue(connectionProperty != null && !connectionProperty.isEmpty());
+        Assertions.assertEquals(physDb.getSupportedRoles().size(), migratedDb.getConnectionProperties().size());
+        Assertions.assertTrue(connectionProperty.get(USERNAME) != null && !connectionProperty.get(USERNAME).toString().isEmpty());
+        Assertions.assertTrue(connectionProperty.get(PASSWORD) != null && !connectionProperty.get(PASSWORD).toString().isEmpty());
+        Assertions.assertTrue(connectionProperty.get(URL) != null && !connectionProperty.get(URL).toString().isEmpty());
+    }
+
+    private RegisterDatabaseRequest getNotValidRegisterDatabaseRequest() {
+        Map<String, Object> classifier = new ClassifierBuilder()
+                .test("migrateDatabase_NotValidRequest")
+                .build();
+        List<ConnectionProperties> connProps = new ArrayList<>();
+        List<DbResource> resources = new ArrayList<>();
+        return new RegisterDatabaseRequest(
+                new TreeMap<>(classifier),
+                connProps,
+                resources,
+                DbaasHelperV3.TEST_NAMESPACE,
+                null,
+                POSTGRES_TYPE,
+                TEST_MIGRATED_DB_NAME,
+                TEST_PHYSICAL_DB_ID,
+                null
+        );
+    }
+}

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/backup/BackupV3IT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/backup/BackupV3IT.java
@@ -1,11 +1,12 @@
 package com.netcracker.it.dbaas.test.backup;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.netcracker.cloud.junit.cloudcore.extension.annotations.EnableExtension;
-import com.netcracker.it.dbaas.entity.DatabaseV3;
-import com.netcracker.it.dbaas.entity.LinkDatabasesRequest;
+import com.netcracker.it.dbaas.entity.*;
 import com.netcracker.it.dbaas.entity.backup.v1.*;
 import com.netcracker.it.dbaas.entity.backup.v3.Status;
 import com.netcracker.it.dbaas.entity.config.DatabaseDeclaration;
+import com.netcracker.it.dbaas.entity.response.MigrationResult;
 import com.netcracker.it.dbaas.helpers.*;
 import com.netcracker.it.dbaas.test.AbstractIT;
 import lombok.extern.slf4j.Slf4j;
@@ -15,9 +16,12 @@ import org.bson.Document;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +42,9 @@ class BackupV3IT extends AbstractIT {
     private static BackupHelperV1 backupHelperV1;
     private static DeclarativeConfigHelper declarativeHelper;
     private static BGHelper bgHelper;
+
+    private static final String BASE_MIGRATE_API = "api/v3/dbaas/migration/databases";
+    private static final String MIGRATE_WITH_USER_CREATION_API = BASE_MIGRATE_API + "/with-user-creation";
 
     @Override
     protected void closePortForwardAfterTest() {
@@ -196,6 +203,16 @@ class BackupV3IT extends AbstractIT {
             @Test
             void testBackupRestoreV1_backupRestore() throws IOException {
                 BackupV3IT.this.testBackupRestoreToSameNamespace(POSTGRES_TYPE);
+            }
+
+            @Test
+            void testMigratedExternalToInternalDatabaseBackupRestoreWithUserCreation() throws IOException {
+                testMigratedExternalToInternalDatabaseBackupRestore(true);
+            }
+
+            @Test
+            void testMigratedExternalToInternalDatabaseBackupRestoreWithoutUserCreation() throws IOException {
+                testMigratedExternalToInternalDatabaseBackupRestore(false);
             }
         }
 
@@ -393,6 +410,232 @@ class BackupV3IT extends AbstractIT {
                 BackupV3IT.this.testRestoreDeletedBackup(databaseType);
             }
         }
+    }
+
+    private DatabaseResponse prepareMigratedExternalToInternalPostgresDatabase(String sourceNamespace,
+                                                                               String microserviceName,
+                                                                               boolean withUserCreation) throws IOException {
+        Map.Entry<String, PhysicalDatabaseRegistrationResponseDTOV3> physDbEntry = helperV3.getGlobalPhysicalDbEntry(POSTGRES_TYPE);
+        String physicalId = physDbEntry.getKey();
+        PhysicalDatabaseRegistrationResponseDTOV3 physDb = physDbEntry.getValue();
+
+        Map adapterResponse = helperV3.createDbViaAdapter(POSTGRES_TYPE, microserviceName, sourceNamespace);
+
+        helperV3.removePgMetadata(adapterResponse);
+
+        String dbName = adapterResponse.get("name").toString();
+        List<Map<String, Object>> connectionProperties = (List<Map<String, Object>>) adapterResponse.get(CONNECTION_PROPERTIES);
+
+        Map<String, Object> classifier = new ClassifierBuilder().ms(microserviceName).ns(sourceNamespace).build();
+
+        ExternalDatabaseRequestV3 externalRegistrationRequest = ExternalDatabaseRequestV3
+                .builder()
+                .classifier(classifier)
+                .connectionProperties(connectionProperties)
+                .dbName(dbName)
+                .originService(microserviceName)
+                .userRole(Role.ADMIN.getRoleValue())
+                .type(POSTGRES_TYPE)
+                .build();
+
+        Request externalRegistartionRequest = helperV3.createRequest(String.format(EXTERNALLY_MANAGEABLE_V3, sourceNamespace),
+                helperV3.getClusterDbaAuthorization(), externalRegistrationRequest, HttpMethod.PUT.name());
+
+        helperV3.executeRequest(externalRegistartionRequest, ExternalDatabaseResponseV3.class, HttpStatus.CREATED.value());
+
+        migrateExternalPostgresDatabaseAsInternal(
+                classifier,
+                adapterResponse,
+                dbName,
+                physicalId,
+                physDb,
+                withUserCreation,
+                sourceNamespace
+        );
+
+        DatabaseResponse migratedDb = helperV3.getDatabaseByClassifierAsPOJO(
+                helperV3.getClusterDbaAuthorization(),
+                classifier,
+                sourceNamespace,
+                POSTGRES_TYPE,
+                HttpStatus.OK.value()
+        );
+
+        assertFalse(migratedDb.isExternallyManageable(),
+                "Migrated database should not remain externally manageable");
+        assertEquals(dbName, migratedDb.getName(),
+                "Migrated database should have the same name as the database created via adapter");
+        assertEquals(POSTGRES_TYPE, migratedDb.getType(),
+                "Migrated database should have PostgreSQL type");
+        assertEquals(sourceNamespace, migratedDb.getNamespace(),
+                "Migrated database should belong to the source namespace");
+
+        return migratedDb;
+    }
+
+    private void migrateExternalPostgresDatabaseAsInternal(Map<String, Object> classifier,
+                                                           Map adapterResponse,
+                                                           String dbName,
+                                                           String physicalId,
+                                                           PhysicalDatabaseRegistrationResponseDTOV3 physDb,
+                                                           boolean withUserCreation,
+                                                           String sourceNamespace) {
+        Object requestBody;
+        String apiEndpoint;
+
+        if (withUserCreation) {
+            apiEndpoint = MIGRATE_WITH_USER_CREATION_API;
+
+            requestBody = new RegisterDatabaseWithUserCreationRequest(
+                    classifier,
+                    POSTGRES_TYPE,
+                    dbName,
+                    physicalId,
+                    null
+            );
+        } else {
+            apiEndpoint = BASE_MIGRATE_API;
+
+            List<ConnectionProperties> connProps = helperV3.objectMapper
+                    .convertValue(adapterResponse.get(CONNECTION_PROPERTIES), new TypeReference<>() {
+                    });
+
+            List<DbResource> resources = helperV3.objectMapper
+                    .convertValue(adapterResponse.get("resources"), new TypeReference<>() {
+                    });
+
+            requestBody = new RegisterDatabaseRequest(
+                    classifier,
+                    connProps,
+                    resources,
+                    sourceNamespace,
+                    physDb.getAdapterId(),
+                    POSTGRES_TYPE,
+                    dbName,
+                    physicalId,
+                    null
+            );
+        }
+
+        Request migrationRequest = helperV3.createRequest(
+                apiEndpoint,
+                helperV3.getClusterDbaAuthorization(),
+                Collections.singletonList(requestBody),
+                HttpMethod.PUT.name()
+        );
+
+        Map<String, MigrationResult> resultMap = sendMigrationRequest(
+                migrationRequest,
+                HttpStatus.OK.value()
+        );
+
+        MigrationResult migrationResult = resultMap.get(POSTGRES_TYPE);
+
+        assertNotNull(migrationResult,
+                "Migration result for PostgreSQL should be present");
+
+        assertEquals(dbName, migrationResult.getMigrated().getFirst(),
+                "Migration result should contain migrated database name");
+
+        assertEquals(1, migrationResult.getMigratedDbInfo().size(),
+                "Migration result should contain exactly one migrated database info");
+
+        assertEquals(dbName, migrationResult.getMigratedDbInfo().getFirst().getName(),
+                "Migrated database info should have expected database name");
+    }
+
+    private Map<String, MigrationResult> sendMigrationRequest(Request request, int expectedCode) {
+        Map response = helperV3.executeRequest(request, Map.class, expectedCode);
+
+        return helperV3.objectMapper.convertValue(
+                response,
+                new TypeReference<>() {
+                }
+        );
+    }
+
+    private void testMigratedExternalToInternalDatabaseBackupRestore(boolean withUserCreation) throws IOException{
+        assumeTrue(helperV3.hasAdapterOfType(POSTGRES_TYPE),  MessageFormat.format("No {0} adapter. Skip test.", POSTGRES_TYPE));
+
+        String sourceNamespace = helperV3.generateTestNamespace();
+        String targetNamespace = helperV3.generateTestNamespace();
+
+        String microserviceName = withUserCreation ? DBAAS_AUTO_TEST_1 : DBAAS_AUTO_TEST_2;
+
+        DatabaseResponse migratedDb = prepareMigratedExternalToInternalPostgresDatabase(sourceNamespace,
+                microserviceName,
+                withUserCreation
+        );
+
+        backupHelperV3.checkConnections(
+                false,
+                List.of(migratedDb),
+                BACKUPED_DATA,
+                BACKUPED_DATA,
+                false
+        );
+
+        var backupRequest = new BackupRequestBuilder().filterCriteria(
+                fc -> fc.include(f -> f.ns(sourceNamespace).dbType(POSTGRES_TYPE))).build();
+
+        var backupResponse = backupHelperV1.runBackupAndWait(backupRequest, false);
+
+        assertEquals(BackupStatus.COMPLETED, backupResponse.getStatus(),
+                "Backup should be completed for migrated external-to-internal PostgreSQL database");
+
+        int backedUpDatabasesCount = backupResponse.getLogicalBackups().stream().mapToInt(
+                logicalBackup -> logicalBackup.getBackupDatabases().size())
+                .sum();
+
+        assertEquals(1, backedUpDatabasesCount, "Backup should include migrated external-to-internal PostgreSQL database");
+
+        String changedData = "changedData";
+
+        backupHelperV3.checkConnections(false, List.of(migratedDb), changedData, changedData, false);
+
+        var restoreRequest = new RestoreRequestBuilder().mapping(m -> m.ns(sourceNamespace, targetNamespace)).build();
+
+        var restoreResponse = backupHelperV1.runRestoreAndWait(
+                backupRequest.getBackupName(),
+                restoreRequest,
+                false
+        );
+
+        assertEquals(RestoreStatus.COMPLETED, restoreResponse.getStatus(),
+                "Restore should be completed for migrated external-to-internal PostgreSQL database");
+
+        DatabaseResponse restoredDb = helperV3.getDatabaseByClassifierAsPOJO(
+                helperV3.getClusterDbaAuthorization(),
+                new ClassifierBuilder()
+                        .ms(microserviceName)
+                        .ns(targetNamespace)
+                        .build(),
+                targetNamespace,
+                POSTGRES_TYPE,
+                HttpStatus.OK.value()
+        );
+
+        assertNotEquals(migratedDb.getName(), restoredDb.getName(),
+                "Restored database should have a different physical database name");
+
+        assertNotEquals(migratedDb.getConnectionProperties(), restoredDb.getConnectionProperties(),
+                "Restored database should have different connection properties");
+
+        backupHelperV3.checkConnections(
+                false,
+                List.of(migratedDb),
+                null,
+                changedData,
+                false
+        );
+
+        backupHelperV3.checkConnections(
+                false,
+                List.of(restoredDb),
+                null,
+                BACKUPED_DATA,
+                false
+        );
     }
 
     private void testCollectAndRestoreBackupToTargetNamespace(String databaseType) throws IOException, InterruptedException {

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/stability/BlueGreenStabilityIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/stability/BlueGreenStabilityIT.java
@@ -1,0 +1,265 @@
+package com.netcracker.it.dbaas.test.stability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netcracker.cloud.junit.cloudcore.extension.service.PodPortForwardParams;
+import com.netcracker.it.dbaas.test.AbstractIT;
+import com.netcracker.it.dbaas.entity.BgNamespaceRequest;
+import com.netcracker.it.dbaas.entity.DatabaseCreateRequestV3;
+import com.netcracker.it.dbaas.entity.DatabaseResponse;
+import com.netcracker.it.dbaas.entity.config.DeclarativePayload;
+import com.netcracker.it.dbaas.helpers.BGHelper;
+import com.netcracker.it.dbaas.helpers.ClassifierBuilder;
+import com.netcracker.it.dbaas.helpers.DeclarativeConfigHelper;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import okhttp3.Response;
+import org.junit.jupiter.api.*;
+import org.opentest4j.AssertionFailedError;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.netcracker.it.dbaas.entity.config.DatabaseDeclaration.DeclarativeDBConfigBuilder;
+import static com.netcracker.it.dbaas.helpers.DbaasHelperV3.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Slf4j
+@Tag("failover")
+class BlueGreenStabilityIT extends AbstractIT {
+
+    protected final static RetryPolicy<Object> OPERATION_STATUS_RETRY_POLICY = new RetryPolicy<>()
+            .withMaxRetries(-1).withDelay(Duration.ofSeconds(1)).withMaxDuration(Duration.ofMinutes(5));
+    private final static String TEST_NAMESPACE_ACTIVE = "active-test-namespace";
+
+    private final static String TEST_NAMESPACE_CANDIDATE = "candidate-test-namespace";
+    private final static Duration SCALE_WAIT_TIME_MINUTES = Duration.ofMinutes(3);
+
+
+    private static BGHelper bgHelper;
+    private static DeclarativeConfigHelper declarativeHelper;
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeAll
+    void setUp() {
+        bgHelper = new BGHelper(helperV3);
+        declarativeHelper = new DeclarativeConfigHelper(helperV3);
+    }
+
+    @BeforeEach
+    public void initAndCleanDbs() throws IOException {
+        Function<String, String> resolve = name -> Optional.ofNullable(System.getProperty(name)).orElseGet(() -> System.getenv(name));
+        boolean bgFailoverTest = Boolean.parseBoolean(resolve.apply("BG_FAILOVER_TEST"));
+        assumeTrue(bgFailoverTest, "BG_FAILOVER_TEST must be enabled");
+        cleanDbs();
+    }
+
+    public void cleanDbs() throws IOException {
+        log.info("Clean databases");
+        helperV3.deleteDatabases(helperV3.getClusterDbaAuthorization(), TEST_NAMESPACE_ACTIVE);
+        helperV3.deleteDatabases(helperV3.getClusterDbaAuthorization(), TEST_NAMESPACE_CANDIDATE);
+        bgHelper.destroyDomain(new BgNamespaceRequest(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE)).close();
+    }
+
+    @SneakyThrows
+    @Test
+    void testDeletePod() {
+        try (Response initResponse = bgHelper.initDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(200, initResponse.code());
+        }
+
+        DeclarativePayload payload = new DeclarativeDBConfigBuilder()
+                .classifier(new ClassifierBuilder().test("toClone"))
+                .versioning("clone")
+                .build().asPayload(TEST_NAMESPACE_ACTIVE, TEST_MICROSERVICE_NAME);
+        declarativeHelper.applyDeclarativeConfig(payload);
+
+        DatabaseResponse activeDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE_ACTIVE),
+                getSimplePostgresCreateRequest("toClone", TEST_NAMESPACE_ACTIVE), 200);
+        helperV3.checkConnectionPostgres(activeDatabase, "toClone", "toClone");
+        String finalTrackingId;
+        try (Response warmupResponse = bgHelper.warmupDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(202, warmupResponse.code());
+            JsonNode node = objectMapper.readTree(warmupResponse.body().string());
+            finalTrackingId = node.get("trackingId").asText();
+        }
+        Deployment deployment = getDeployment(kubernetesClient);
+        int requiredPodsCount = deployment.getStatus().getReplicas();
+
+        deletePod(kubernetesClient.getNamespace(), "dbaas-aggregator");
+
+        Failsafe.with(DEFAULT_RETRY_POLICY.copy().withMaxDuration(SCALE_WAIT_TIME_MINUTES)).run(() -> {
+            DeploymentStatus status = getDeployment(kubernetesClient).getStatus();
+            log.info(status.toString());
+            assertEquals(requiredPodsCount, (int) Optional.ofNullable(status.getReplicas()).orElse(0));
+            assertEquals(requiredPodsCount, (int) Optional.ofNullable(status.getReadyReplicas()).orElse(0));
+            List<Pod> pods = kubernetesClient.pods().withLabel("name", DBAAS_SERVICE_NAME).list().getItems();
+            log.info("Pods count: {}", pods.size());
+            assertEquals(requiredPodsCount, pods.size());
+        });
+        Thread.sleep(5000);
+        List<Pod> pods = kubernetesClient.pods().withLabel("name", DBAAS_SERVICE_NAME).list().getItems();
+        portForwardService.closePortForwards();
+        portForwardService.portForward(PodPortForwardParams.builder(pods.getFirst().getMetadata().getName(), HTTP_PORT).build());
+
+        Failsafe.with(OPERATION_STATUS_RETRY_POLICY.copy().withMaxDuration(Duration.ofMinutes(3))).run(() -> {
+            try (Response operationStatus = bgHelper.getOperationStatus(finalTrackingId)) {
+                JsonNode node = objectMapper.readTree(operationStatus.body().string());
+                assertFalse(node.get("status").asText().equals("in progress") || node.get("status").asText().equals("not started"));
+            }
+        });
+
+        DatabaseResponse candidateDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE_CANDIDATE),
+                getSimplePostgresCreateRequest("toClone", TEST_NAMESPACE_CANDIDATE), 200);
+        helperV3.checkConnectionPostgres(candidateDatabase, null, "toClone");
+        cleanDbs();
+
+    }
+
+    @Test
+    void testDeleteAdapterPod() throws IOException, SQLException {
+        try (Response initResponse = bgHelper.initDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(200, initResponse.code());
+        }
+
+        DeclarativePayload payload = new DeclarativeDBConfigBuilder()
+                .classifier(new ClassifierBuilder().test("toClone"))
+                .versioning("clone")
+                .build().asPayload(TEST_NAMESPACE_ACTIVE, TEST_MICROSERVICE_NAME);
+        declarativeHelper.applyDeclarativeConfig(payload);
+
+        DatabaseResponse activeDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE_ACTIVE),
+                getSimplePostgresCreateRequest("toClone", TEST_NAMESPACE_ACTIVE), 200);
+        helperV3.checkConnectionPostgres(activeDatabase, "toClone", "toClone");
+        String finalTrackingId;
+        try (Response warmupResponse = bgHelper.warmupDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(202, warmupResponse.code());
+            JsonNode node = objectMapper.readTree(warmupResponse.body().string());
+            finalTrackingId = node.get("trackingId").asText();
+        }
+        deleteAdapterPod("core-postgresql", "nc-dbaas-postgres-adapter");
+
+        Failsafe.with(OPERATION_STATUS_RETRY_POLICY.copy().withMaxDuration(Duration.ofMinutes(3))).run(() -> {
+            try (Response operationStatus = bgHelper.getOperationStatus(finalTrackingId)) {
+                JsonNode node = objectMapper.readTree(operationStatus.body().string());
+                assertFalse(node.get("status").asText().equals("in progress") || node.get("status").asText().equals("not started"));
+            }
+        });
+
+        DatabaseResponse candidateDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE_CANDIDATE),
+                getSimplePostgresCreateRequest("toClone", TEST_NAMESPACE_CANDIDATE), 200);
+        helperV3.checkConnectionPostgres(candidateDatabase, null, "toClone");
+        cleanDbs();
+    }
+
+    @Test
+    void testDeleteBackupPod() throws IOException, SQLException {
+        try (Response initResponse = bgHelper.initDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(200, initResponse.code());
+        }
+
+        DeclarativePayload payload = new DeclarativeDBConfigBuilder()
+                .classifier(new ClassifierBuilder().test("toClone"))
+                .versioning("clone")
+                .build().asPayload(TEST_NAMESPACE_ACTIVE, TEST_MICROSERVICE_NAME);
+        declarativeHelper.applyDeclarativeConfig(payload);
+
+        DatabaseResponse activeDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE_ACTIVE),
+                getSimplePostgresCreateRequest("toClone", TEST_NAMESPACE_ACTIVE), 200);
+        helperV3.checkConnectionPostgres(activeDatabase, "toClone", "toClone");
+        String finalTrackingId;
+        try (Response warmupResponse = bgHelper.warmupDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(202, warmupResponse.code());
+            JsonNode node = objectMapper.readTree(warmupResponse.body().string());
+            finalTrackingId = node.get("trackingId").asText();
+        }
+        deleteAdapterPod("core-postgresql", "postgres-backup-daemon");
+
+        Assertions.assertThrows(AssertionFailedError.class, () ->
+                Failsafe.with(OPERATION_STATUS_RETRY_POLICY.copy().withMaxDuration(Duration.ofMinutes(3))).run(() -> {
+                    try (Response operationStatus = bgHelper.getOperationStatus(finalTrackingId)) {
+                        JsonNode node = objectMapper.readTree(operationStatus.body().string());
+                        assertFalse(node.get("status").asText().equals("in progress") || node.get("status").asText().equals("not started"));
+                    }
+                })
+        );
+        cleanDbs();
+    }
+
+    @SneakyThrows
+    @Test
+    void testDeletePatroniPod() {
+        try (Response initResponse = bgHelper.initDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(200, initResponse.code());
+        }
+
+        DeclarativePayload payload = new DeclarativeDBConfigBuilder()
+                .classifier(new ClassifierBuilder().test("toClone"))
+                .versioning("clone")
+                .build().asPayload(TEST_NAMESPACE_ACTIVE, TEST_MICROSERVICE_NAME);
+        declarativeHelper.applyDeclarativeConfig(payload);
+
+        DatabaseResponse activeDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE_ACTIVE),
+                getSimplePostgresCreateRequest("toClone", TEST_NAMESPACE_ACTIVE), 200);
+        helperV3.checkConnectionPostgres(activeDatabase, "toClone", "toClone");
+        String finalTrackingId;
+        try (Response warmupResponse = bgHelper.warmupDomain(TEST_NAMESPACE_ACTIVE, TEST_NAMESPACE_CANDIDATE, TEST_NAMESPACE_ACTIVE)) {
+            Assertions.assertEquals(202, warmupResponse.code());
+            JsonNode node = objectMapper.readTree(warmupResponse.body().string());
+            finalTrackingId = node.get("trackingId").asText();
+        }
+        deletePatroniPod("core-postgresql", "patroni");
+
+        Failsafe.with(OPERATION_STATUS_RETRY_POLICY.copy().withMaxDuration(Duration.ofMinutes(3))).run(() -> {
+            try (Response operationStatus = bgHelper.getOperationStatus(finalTrackingId)) {
+                Assertions.assertEquals(500, operationStatus.code());
+            }
+        });
+        Thread.sleep(30000);
+    }
+
+
+    private DatabaseCreateRequestV3 getSimplePostgresCreateRequest(String testClassifierValue, String namespace) {
+        return getPrimaryCreateDbRequestBuilder(POSTGRES_TYPE, testClassifierValue, namespace)
+                .originService(TEST_MICROSERVICE_NAME)
+                .build();
+    }
+
+    private DatabaseCreateRequestV3.DatabaseCreateRequestV3Builder getPrimaryCreateDbRequestBuilder(String type, String testClassifierValue, String namespace) {
+        return DatabaseCreateRequestV3.builder(new ClassifierBuilder().test(testClassifierValue).ns(namespace).build(), type);
+    }
+
+    public void deletePod(String namespace, String serviceName) {
+        kubernetesClient.pods().inNamespace(namespace).withLabel("name", serviceName).delete();
+    }
+
+
+    public void deleteAdapterPod(String namespace, String serviceName) {
+        kubernetesClient.pods().inNamespace(namespace).withLabel("app", serviceName).delete();
+    }
+
+    public void deletePatroniPod(String namespace, String serviceName) {
+        Map<String, String> labels = new HashMap<>();
+        labels.put("app", serviceName);
+        labels.put("pgtype", "master");
+        kubernetesClient.pods().inNamespace(namespace).withLabels(labels).delete();
+    }
+
+    private Deployment getDeployment(KubernetesClient kubernetesClient) {
+        return kubernetesClient.apps().deployments().withName(AbstractIT.DBAAS_SERVICE_NAME).get();
+    }
+}


### PR DESCRIPTION
fix: add unit tests to check database state and metadata renewal after migration