### PR TITLE
build: always build Aggregator and Operator

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -9,12 +9,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'dbaas-operator/**'
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'dbaas-operator/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -3,12 +3,8 @@ name: Maven build
 
 on:
   push:
-    paths-ignore:
-      - 'dbaas-operator/**'
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - 'dbaas-operator/**'
 
 jobs:
   mvn:


### PR DESCRIPTION
Remove path restrictions. We need both builds always to be able to run integration tests on any branch.