### PR TITLE
feat: add new "force" flag for logical database deletion API

### DIFF
--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/controller/v3/AggregatedDatabaseAdministrationControllerV3.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/controller/v3/AggregatedDatabaseAdministrationControllerV3.java
@@ -370,7 +370,10 @@ public class AggregatedDatabaseAdministrationControllerV3 extends AbstractContro
 
 
     @Operation(summary = " V3.Delete database by classifier",
-            description = "Deletes database by id in the specific namespace.")
+            description = "Deletes database by id in the specific namespace. " +
+                    "If the optional 'force' parameter is set to true, errors from the physical adapter during drop are ignored " +
+                    "and the database is removed from DBaaS regardless. " +
+                    "Warning: using force=true may result in the logical database leaking in the physical database.")
     @APIResponses({
             @APIResponse(responseCode = "200", description = "Successfully deleted database.", content = @Content(schema = @Schema(implementation = String.class))),
             @APIResponse(responseCode = "401", description = ROLE_IS_NOT_ALLOWED, content = @Content(schema = @Schema(implementation = String.class))),
@@ -386,7 +389,9 @@ public class AggregatedDatabaseAdministrationControllerV3 extends AbstractContro
                                                @Parameter(description = "Project namespace in which the base is used")
                                                @PathParam(NAMESPACE_PARAMETER) String namespace,
                                                @Parameter(description = "The physical type of logical database. For example mongodb or postgresql", required = true)
-                                               @PathParam("type") String type) {
+                                               @PathParam("type") String type,
+                                               @Parameter(description = "If true, errors from the physical adapter during drop are ignored")
+                                               @QueryParam("force") @DefaultValue("false") Boolean force) {
         assertNotProdMode();
         checkOriginService(classifierRequest);
         String supportedRole = databaseRolesService.getSupportedRoleFromRequest(classifierRequest, type, namespace);
@@ -403,7 +408,7 @@ public class AggregatedDatabaseAdministrationControllerV3 extends AbstractContro
                 throw new ForbiddenNamespaceException(namespace, databaseRegistry.getNamespace(),
                         Source.builder().pathVariable("namespace").build());
             }
-            deletionService.dropRegistrySafe(databaseRegistry);
+            deletionService.dropRegistrySafe(databaseRegistry, Boolean.TRUE.equals(force));
             log.info("Database in namespace={} with classifier={} is dropped", namespace, databaseRegistry.getClassifier());
         }
         //should return ok if db not found

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/controller/v3/AggregatedDatabaseAdministrationControllerV3Test.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/controller/v3/AggregatedDatabaseAdministrationControllerV3Test.java
@@ -843,7 +843,39 @@ class AggregatedDatabaseAdministrationControllerV3Test {
                 .then()
                 .statusCode(OK.getStatusCode());
 
-        verify(deletionService).dropRegistrySafe(database);
+        verify(deletionService).dropRegistrySafe(database, false);
+        verifyNoMoreInteractions(deletionService);
+    }
+
+    @Test
+    void testDeleteDatabaseByClassifier_ForceTrue() throws JsonProcessingException {
+        final UUID id = UUID.randomUUID();
+        TreeMap<String, Object> classifier = new TreeMap<>(getSampleClassifier());
+        ClassifierWithRolesRequest classifierWithRolesRequest = new ClassifierWithRolesRequest();
+        classifierWithRolesRequest.setClassifier(classifier);
+        classifierWithRolesRequest.setUserRole(ADMIN.toString());
+        classifierWithRolesRequest.setOriginService(TEST_MS_NAME);
+        when(dbaaSHelper.isProductionMode()).thenReturn(false);
+        doReturn(ADMIN.toString()).when(databaseRolesService).getSupportedRoleFromRequest(any(ClassifierWithRolesRequest.class), any(), any());
+        String requestBody = objectMapper.writer().withDefaultPrettyPrinter().writeValueAsString(classifierWithRolesRequest);
+
+        final DatabaseRegistry database = getDatabaseSample();
+        database.setId(id);
+        database.setType(POSTGRESQL.toString());
+        database.setClassifier(classifier);
+        database.setNamespace(TEST_NAMESPACE);
+        when(databaseRegistryDbaasRepository.getDatabaseByClassifierAndType(classifier, POSTGRESQL.toString())).thenReturn(Optional.of(database.getDatabaseRegistry().getFirst()));
+
+        given().auth().preemptive().basic("cluster-dba", "someDefaultPassword")
+                .pathParam(NAMESPACE_PARAMETER, TEST_NAMESPACE)
+                .queryParam("force", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .when().delete("/{type}", POSTGRESQL.toString())
+                .then()
+                .statusCode(OK.getStatusCode());
+
+        verify(deletionService).dropRegistrySafe(database, true);
         verifyNoMoreInteractions(deletionService);
     }
 
@@ -893,7 +925,7 @@ class AggregatedDatabaseAdministrationControllerV3Test {
                 .then()
                 .statusCode(OK.getStatusCode());
 
-        verify(deletionService).dropRegistrySafe(database);
+        verify(deletionService).dropRegistrySafe(database, false);
         verifyNoMoreInteractions(deletionService);
     }
 
@@ -969,7 +1001,7 @@ class AggregatedDatabaseAdministrationControllerV3Test {
                 .then()
                 .statusCode(OK.getStatusCode());
 
-        verify(deletionService).dropRegistrySafe(database);
+        verify(deletionService).dropRegistrySafe(database, false);
         verify(databaseRegistryDbaasRepository, times(3)).getDatabaseByClassifierAndType(classifier, POSTGRESQL.toString());
         verify(databaseRegistryDbaasRepository, times(1)).getDatabaseByClassifierAndType(classifier, anotherType);
         verify(databaseRegistryDbaasRepository, times(1)).getDatabaseByClassifierAndType(anotherClassifier, POSTGRESQL.toString());

--- a/docs/OpenAPI.json
+++ b/docs/OpenAPI.json
@@ -8485,7 +8485,7 @@
     "/api/v3/dbaas/{namespace}/databases/{type}": {
       "delete": {
         "summary": " V3.Delete database by classifier",
-        "description": "Deletes database by id in the specific namespace.",
+        "description": "Deletes database by id in the specific namespace. If the optional \u0027force\u0027 parameter is set to true, errors from the physical adapter during drop are ignored and the database is removed from DBaaS regardless. Warning: using force\u003dtrue may result in the logical database leaking in the physical database.",
         "tags": [
           "Controller Database administration"
         ],
@@ -8506,6 +8506,15 @@
             "in": "path",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "If true, errors from the physical adapter during drop are ignored",
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": "false"
             }
           }
         ],

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -578,11 +578,12 @@ Deletes database by classifier in the specific namespace.
   [deployment parameters](./installation/parameters.md#dbaas_cluster_dba_credentials_username-dbaas_cluster_dba_credentials_password).
 * **Request body:**
 
-| Type     | Name                                  | Description                                                              | Schema                                                    |
-|----------|---------------------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------|
-| **Path** | **namespace**  <br>*required*         | Project namespace in which the base is used                              | string                                                    |
-| **Path** | **type**  <br>*required*              | The physical type of logical database. For example mongodb or postgresql | string                                                    |
-| **Body** | **classifierRequest**  <br>*required* | A unique identifier of the document in the database                      | [ClassifierWithRolesRequest](#classifierwithrolesrequest) |
+| Type      | Name                                  | Description                                                                       | Schema                                                    |
+|-----------|---------------------------------------|-----------------------------------------------------------------------------------|-----------------------------------------------------------|
+| **Path**  | **namespace**  <br>*required*         | Project namespace in which the base is used                                       | string                                                    |
+| **Path**  | **type**  <br>*required*              | The physical type of logical database. For example mongodb or postgresql          | string                                                    |
+| **Query** | **force**  <br>*optional*             | If true, errors from the physical adapter during drop are ignored. Default: false | boolean                                                   |
+| **Body**  | **classifierRequest**  <br>*required* | A unique identifier of the document in the database                               | [ClassifierWithRolesRequest](#classifierwithrolesrequest) |
 
 * **Success Response:**
 


### PR DESCRIPTION
It will allow to remove the logical DB from DBaaS registry in cases when the related physical database is already removed or died for some reason.