### PR TITLE
feat: metrics for rule, polling, and namespacebinding CRs

### DIFF
--- a/dbaas-operator/cmd/main.go
+++ b/dbaas-operator/cmd/main.go
@@ -221,6 +221,7 @@ func main() {
 
 	// ── Ownership resolver ────────────────────────────────────────────────────
 	ownershipResolver := ownership.NewOwnershipResolver(cloudNamespace, mgr.GetClient())
+	controller.RegisterResourceMetrics(mgr.GetClient(), ownershipResolver, cloudNamespace)
 	if err := mgr.Add(&ownershipWarmupRunnable{resolver: ownershipResolver}); err != nil {
 		setupLog.Errorf("Failed to register ownership warmup runnable: %v", err)
 		os.Exit(1)

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -355,7 +355,7 @@
                    {
                        "id":  8,
                        "type":  "row",
-                       "title":  "Dashboard-Only Resource Health Substitutes",
+                       "title":  "Historical Failure Activity",
                        "collapsed":  false,
                        "gridPos":  {
                                        "h":  1,
@@ -368,7 +368,7 @@
                        "id":  9,
                        "type":  "timeseries",
                        "title":  "Recent Failed Operations by Owner",
-                       "description":  "Dashboard-only substitute for resource phase health. Shows recent failed operations by owner bucket instead of exact current CR phase counts.",
+                       "description":  "Historical failed operations by owner bucket. Use the CR Health Overview row for exact current CR state.",
                        "gridPos":  {
                                        "h":  8,
                                        "w":  12,
@@ -415,7 +415,7 @@
                        "id":  10,
                        "type":  "timeseries",
                        "title":  "Sustained Failure Signals",
-                       "description":  "Dashboard-only substitute for stuck resources. Shows failure signals that continue over the recent window; it is event-based, not an exact stuck CR count.",
+                       "description":  "Failure signals that continue over the recent window. This is event-based history; use CR phase and condition panels for exact current stuck CRs.",
                        "gridPos":  {
                                        "h":  8,
                                        "w":  12,
@@ -668,6 +668,345 @@
                                        {
                                            "expr":  "sum by (operation, result) (rate(dbaas_aggregator_requests_total{namespace=\"#namespace#\",controller=\"balancingrule\"}[1m]))",
                                            "legendFormat":  "{{operation}} / {{result}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  19,
+                       "type":  "row",
+                       "title":  "CR Health Overview",
+                       "collapsed":  false,
+                       "gridPos":  {
+                                       "h":  1,
+                                       "w":  24,
+                                       "x":  0,
+                                       "y":  69
+                                   }
+                   },
+                   {
+                       "id":  20,
+                       "type":  "timeseries",
+                       "title":  "CRs by Current Phase",
+                       "description":  "Current phase for dbaas operator CRs. This is a current-state gauge, not a reconcile counter.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  0,
+                                       "y":  70
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, phase) (dbaas_resource_phase{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "{{kind}} / {{phase}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  21,
+                       "type":  "timeseries",
+                       "title":  "Unready CRs by Reason",
+                       "description":  "Current Ready=False/Unknown conditions by kind and reason. Reasons are intended to route ownership quickly.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  12,
+                                       "y":  70
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, reason) (dbaas_resource_condition{namespace=\"#namespace#\",condition=\"Ready\",status!=\"True\"})",
+                                           "legendFormat":  "{{kind}} / {{reason}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  22,
+                       "type":  "timeseries",
+                       "title":  "CRs Waiting for Observed Generation",
+                       "description":  "Shows CRs whose metadata.generation is ahead of status.observedGeneration. This is convergence lag, not elapsed time.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  0,
+                                       "y":  78
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, resource_namespace, name) (dbaas_resource_observed_generation_lag{namespace=\"#namespace#\"} > 0)",
+                                           "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  23,
+                       "type":  "timeseries",
+                       "title":  "CR Metrics Collector Health",
+                       "description":  "A value of 0 means the custom CR-state collector failed to list that kind during scrape.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  12,
+                                       "y":  78
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "min by (kind) (dbaas_resource_collector_success{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "{{kind}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  24,
+                       "type":  "row",
+                       "title":  "DatabaseSecretClaim Health",
+                       "collapsed":  false,
+                       "gridPos":  {
+                                       "h":  1,
+                                       "w":  24,
+                                       "x":  0,
+                                       "y":  86
+                                   }
+                   },
+                   {
+                       "id":  25,
+                       "type":  "timeseries",
+                       "title":  "SecretClaim DatabaseNotFound Age",
+                       "description":  "Age of the current DatabaseNotFound streak per DatabaseSecretClaim. Persistent values point to missing DB provisioning or classifier mismatch.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  0,
+                                       "y":  87
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "s",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "max by (resource_namespace, name) (dbaas_secret_claim_not_found_age_seconds{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "{{resource_namespace}}/{{name}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  26,
+                       "type":  "timeseries",
+                       "title":  "SecretClaim Time Since Last Rotation",
+                       "description":  "Seconds since each DatabaseSecretClaim last applied rotated connection properties.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  12,
+                                       "y":  87
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "s",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_last_rotation_timestamp_seconds{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "{{resource_namespace}}/{{name}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  27,
+                       "type":  "row",
+                       "title":  "Placement and Namespace Ownership",
+                       "collapsed":  false,
+                       "gridPos":  {
+                                       "h":  1,
+                                       "w":  24,
+                                       "x":  0,
+                                       "y":  95
+                                   }
+                   },
+                   {
+                       "id":  28,
+                       "type":  "timeseries",
+                       "title":  "Balancing Rule Desired vs Applied Targets",
+                       "description":  "Compares placement intent from spec with the last applied state recorded in status. These counts do not prove referenced physical databases exist or independently read back aggregator state.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  0,
+                                       "y":  96
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, resource_namespace, name, target_type) (dbaas_balancing_rule_desired_targets{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "desired {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
+                                           "refId":  "A"
+                                       },
+                                       {
+                                           "expr":  "sum by (kind, resource_namespace, name, target_type) (dbaas_balancing_rule_applied_targets{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "applied {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
+                                           "refId":  "B"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  29,
+                       "type":  "timeseries",
+                       "title":  "NamespaceBinding States",
+                       "description":  "Current namespace ownership state from this operator instance's point of view. deleting_with_finalizer means deletion is in progress and the protection finalizer remains; it does not by itself prove blocking resources still exist.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  12,
+                                       "y":  96
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (state) (dbaas_namespace_binding_state{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "{{state}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  30,
+                       "type":  "timeseries",
+                       "title":  "Resources Deleting With Finalizers",
+                       "description":  "Current dbaas resources that have deletionTimestamp set. deleting_with_finalizer means cleanup/finalizer removal is still pending.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  24,
+                                       "x":  0,
+                                       "y":  104
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, resource_namespace, name, state) (dbaas_resource_deletion_state{namespace=\"#namespace#\"})",
+                                           "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}} / {{state}}"
                                        }
                                    ]
                    }

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -246,7 +246,7 @@
                        "id":  7,
                        "type":  "timeseries",
                        "title":  "Aggregator Call Outcomes (calls/s)",
-                       "description":  "Result breakdown: spec_rejection = CR/spec owner, auth_error = operator credentials/RBAC, server_error = aggregator, network_error = connectivity/platform.",
+                       "description":  "Result breakdown: database_not_found = DatabaseSecretClaim waiting for DB registration, spec_rejection = CR/spec owner, auth_error = operator credentials/RBAC, server_error = aggregator, network_error = connectivity/platform.",
                        "gridPos":  {
                                        "h":  8,
                                        "w":  12,
@@ -287,6 +287,21 @@
                                                                                         "id":  "color",
                                                                                         "value":  {
                                                                                                       "fixedColor":  "yellow",
+                                                                                                      "mode":  "fixed"
+                                                                                                  }
+                                                                                    }
+                                                                                ]
+                                                             },
+                                                             {
+                                                                 "matcher":  {
+                                                                                 "id":  "byName",
+                                                                                 "options":  "database_not_found"
+                                                                             },
+                                                                 "properties":  [
+                                                                                    {
+                                                                                        "id":  "color",
+                                                                                        "value":  {
+                                                                                                      "fixedColor":  "blue",
                                                                                                       "mode":  "fixed"
                                                                                                   }
                                                                                     }
@@ -400,7 +415,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (controller, result) (increase(dbaas_aggregator_requests_total{namespace=\"#namespace#\",result!=\"success\"}[$__range]))",
+                                           "expr":  "sum by (controller, result) (increase(dbaas_aggregator_requests_total{namespace=\"#namespace#\",result!~\"success|database_not_found\"}[$__range]))",
                                            "legendFormat":  "aggregator {{controller}} / {{result}}",
                                            "refId":  "A"
                                        },
@@ -447,7 +462,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (controller, result) (rate(dbaas_aggregator_requests_total{namespace=\"#namespace#\",result!=\"success\"}[15m])) \u003e 0",
+                                           "expr":  "sum by (controller, result) (rate(dbaas_aggregator_requests_total{namespace=\"#namespace#\",result!~\"success|database_not_found\"}[15m])) \u003e 0",
                                            "legendFormat":  "aggregator {{controller}} / {{result}}",
                                            "refId":  "A"
                                        },
@@ -711,7 +726,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (kind, phase) (dbaas_resource_phase{namespace=\"#namespace#\"})",
+                                          "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{namespace=\"#namespace#\"}))",
                                            "legendFormat":  "{{kind}} / {{phase}}"
                                        }
                                    ]
@@ -744,7 +759,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (kind, reason) (dbaas_resource_condition{namespace=\"#namespace#\",condition=\"Ready\",status!=\"True\"})",
+                                          "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{namespace=\"#namespace#\",condition=\"Ready\",status!=\"True\"}))",
                                            "legendFormat":  "{{kind}} / {{reason}}"
                                        }
                                    ]
@@ -777,7 +792,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (kind, resource_namespace, name) (dbaas_resource_observed_generation_lag{namespace=\"#namespace#\"} > 0)",
+                                          "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{namespace=\"#namespace#\"}) > 0)",
                                            "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}}"
                                        }
                                    ]
@@ -855,7 +870,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "max by (resource_namespace, name) (dbaas_secret_claim_not_found_age_seconds{namespace=\"#namespace#\"})",
+                                          "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_first_not_found_timestamp_seconds{namespace=\"#namespace#\"})",
                                            "legendFormat":  "{{resource_namespace}}/{{name}}"
                                        }
                                    ]
@@ -933,12 +948,12 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (kind, resource_namespace, name, target_type) (dbaas_balancing_rule_desired_targets{namespace=\"#namespace#\"})",
+                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_desired_targets{namespace=\"#namespace#\"}))",
                                            "legendFormat":  "desired {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
                                            "refId":  "A"
                                        },
                                        {
-                                           "expr":  "sum by (kind, resource_namespace, name, target_type) (dbaas_balancing_rule_applied_targets{namespace=\"#namespace#\"})",
+                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_applied_targets{namespace=\"#namespace#\"}))",
                                            "legendFormat":  "applied {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
                                            "refId":  "B"
                                        }
@@ -972,7 +987,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (state) (dbaas_namespace_binding_state{namespace=\"#namespace#\"})",
+                                          "expr":  "sum by (state) (max without (pod, instance) (dbaas_namespace_binding_state{namespace=\"#namespace#\"}))",
                                            "legendFormat":  "{{state}}"
                                        }
                                    ]
@@ -1005,7 +1020,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (kind, resource_namespace, name, state) (dbaas_resource_deletion_state{namespace=\"#namespace#\"})",
+                                          "expr":  "sum by (kind, resource_namespace, name, state) (max without (pod, instance) (dbaas_resource_deletion_state{namespace=\"#namespace#\"}))",
                                            "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}} / {{state}}"
                                        }
                                    ]

--- a/dbaas-operator/internal/controller/balancingrule_controller.go
+++ b/dbaas-operator/internal/controller/balancingrule_controller.go
@@ -117,7 +117,7 @@ func (r *BalancingRuleReconciler) ReconcileMicroservice(ctx context.Context, req
 		r.clearBindingTrigger(key)
 		return result, nil
 	}
-	recordReconcileTrigger(controllerBR, trigger)
+	recordReconcileTrigger(controllerMBR, trigger)
 
 	if !rule.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, r.reconcileMicroserviceDelete(ctx, rule, requestID)
@@ -189,7 +189,7 @@ func (r *BalancingRuleReconciler) ReconcileNamespace(ctx context.Context, req ct
 		r.clearBindingTrigger(key)
 		return result, nil
 	}
-	recordReconcileTrigger(controllerBR, trigger)
+	recordReconcileTrigger(controllerNBR, trigger)
 
 	if !rule.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, r.reconcileNamespaceDelete(ctx, rule, requestID)
@@ -292,7 +292,7 @@ func (r *BalancingRuleReconciler) ReconcilePermanent(ctx context.Context, req ct
 	// scoped to CLOUD_NAMESPACE, so only CRs in the operator namespace reach this
 	// reconcile; validatePermanentRule re-checks metadata.namespace defensively.
 	// Neither the CR's own namespace nor its target namespaces require a binding.
-	recordReconcileTrigger(controllerBR, "")
+	recordReconcileTrigger(controllerPBR, triggerSpecChange)
 
 	if !rule.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, r.reconcilePermanentDelete(ctx, rule, requestID)

--- a/dbaas-operator/internal/controller/databaseaccesspolicy_controller.go
+++ b/dbaas-operator/internal/controller/databaseaccesspolicy_controller.go
@@ -81,7 +81,7 @@ func (r *DatabaseAccessPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 	if bindingTriggered {
 		trigger = triggerNamespaceBindingChange
 	}
-	recordReconcileTrigger(controllerDP, trigger)
+	recordReconcileTrigger(controllerDAP, trigger)
 
 	// Snapshot for the status patch at the end of reconcile.
 	original := dp.DeepCopy()
@@ -110,7 +110,7 @@ func (r *DatabaseAccessPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 	dp.Status.LastRequestID = requestID
 	aggStart := time.Now()
 	_, aggErr := r.Aggregator.ApplyConfig(ctx, payload)
-	recordAggregatorCall(controllerDP, operationApplyConfig, aggStart, aggErr)
+	recordAggregatorCall(controllerDAP, operationApplyConfig, aggStart, aggErr)
 	if aggErr != nil {
 		log.ErrorC(ctx, "failed to apply DatabaseAccessPolicy to dbaas-aggregator: %v", aggErr)
 		return handleAggregatorError(&dp.Status.Phase, &dp.Status.Conditions, dp.Generation, r.Recorder, dp, aggErr, requestID)

--- a/dbaas-operator/internal/controller/databasesecretclaim_controller.go
+++ b/dbaas-operator/internal/controller/databasesecretclaim_controller.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -67,6 +68,11 @@ type DatabaseSecretClaimReconciler struct {
 	Aggregator *aggregatorclient.AggregatorClient
 	Recorder   record.EventRecorder
 	Ownership  *ownership.OwnershipResolver
+
+	bindingTriggerTracker
+	triggerMu             sync.Mutex
+	siblingTriggerStamps  map[string]struct{}
+	rotationTriggerValues map[string]string
 }
 
 func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
@@ -74,16 +80,28 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	s := &dbaasv1.DatabaseSecretClaim{}
 	if err := r.Get(ctx, req.NamespacedName, s); err != nil {
+		if apierrors.IsNotFound(err) {
+			key := req.Namespace + "/" + req.Name
+			r.clearBindingTrigger(key)
+			r.clearSiblingTrigger(key)
+			r.clearRotationTrigger(key)
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	key := s.Namespace + "/" + s.Name
+	trigger := r.triggerForSecretClaim(key, s)
 
 	owned, result, err := checkOwnership(ctx, r.Ownership, s.Namespace, s.Name, "DatabaseSecretClaim")
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if !owned {
+		r.clearBindingTrigger(key)
+		r.clearSiblingTrigger(key)
 		return result, nil
 	}
+	recordReconcileTrigger(controllerDS, trigger)
 
 	original := s.DeepCopy()
 	defer func() {
@@ -115,7 +133,9 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 		OriginService: s.Labels["app.kubernetes.io/name"],
 		UserRole:      s.Spec.UserRole,
 	}
+	aggStart := time.Now()
 	dbResp, err := r.Aggregator.GetDatabaseByClassifier(ctx, s.Namespace, s.Spec.Type, aggReq)
+	recordAggregatorCall(controllerDS, operationGetDatabase, aggStart, err)
 	if err != nil {
 		return r.handleAggregatorErr(ctx, s, err, requestID)
 	}
@@ -644,7 +664,8 @@ func (r *DatabaseSecretClaimReconciler) SetupWithManager(mgr ctrl.Manager, opts 
 }
 
 func (r *DatabaseSecretClaimReconciler) enqueueForBinding(ctx context.Context, obj client.Object) []reconcile.Request {
-	return enqueueForBindingList(ctx, r.Client, &dbaasv1.DatabaseSecretClaimList{}, obj.GetNamespace(), nil)
+	return enqueueForBindingList(ctx, r.Client, &dbaasv1.DatabaseSecretClaimList{}, obj.GetNamespace(),
+		func(o client.Object) { r.stampBindingTrigger(o.GetNamespace() + "/" + o.GetName()) })
 }
 
 // enqueueSiblingsBySecretName re-enqueues every DatabaseSecretClaim in the same
@@ -670,9 +691,67 @@ func (r *DatabaseSecretClaimReconciler) enqueueSiblingsBySecretName(ctx context.
 		if list.Items[i].UID == ds.UID {
 			continue
 		}
+		r.stampSiblingTrigger(list.Items[i].Namespace + "/" + list.Items[i].Name)
 		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&list.Items[i])})
 	}
 	return reqs
+}
+
+func (r *DatabaseSecretClaimReconciler) triggerForSecretClaim(key string, s *dbaasv1.DatabaseSecretClaim) string {
+	switch {
+	case r.consumeRotationTrigger(key, s.Annotations[dbaasv1.AnnotationRotationTrigger]):
+		return triggerRotation
+	case r.consumeBindingTrigger(key):
+		return triggerNamespaceBindingChange
+	case r.consumeSiblingTrigger(key):
+		return triggerSiblingSecretClaim
+	case s.Status.ObservedGeneration >= s.Generation && s.Status.Phase == dbaasv1.PhaseSucceeded:
+		return triggerSafetyNet
+	default:
+		return triggerSpecChange
+	}
+}
+
+func (r *DatabaseSecretClaimReconciler) stampSiblingTrigger(key string) {
+	r.triggerMu.Lock()
+	defer r.triggerMu.Unlock()
+	if r.siblingTriggerStamps == nil {
+		r.siblingTriggerStamps = make(map[string]struct{})
+	}
+	r.siblingTriggerStamps[key] = struct{}{}
+}
+
+func (r *DatabaseSecretClaimReconciler) consumeSiblingTrigger(key string) bool {
+	r.triggerMu.Lock()
+	defer r.triggerMu.Unlock()
+	if _, ok := r.siblingTriggerStamps[key]; !ok {
+		return false
+	}
+	delete(r.siblingTriggerStamps, key)
+	return true
+}
+
+func (r *DatabaseSecretClaimReconciler) clearSiblingTrigger(key string) {
+	r.triggerMu.Lock()
+	defer r.triggerMu.Unlock()
+	delete(r.siblingTriggerStamps, key)
+}
+
+func (r *DatabaseSecretClaimReconciler) consumeRotationTrigger(key, current string) bool {
+	r.triggerMu.Lock()
+	defer r.triggerMu.Unlock()
+	if r.rotationTriggerValues == nil {
+		r.rotationTriggerValues = make(map[string]string)
+	}
+	previous, seen := r.rotationTriggerValues[key]
+	r.rotationTriggerValues[key] = current
+	return seen && current != "" && current != previous
+}
+
+func (r *DatabaseSecretClaimReconciler) clearRotationTrigger(key string) {
+	r.triggerMu.Lock()
+	defer r.triggerMu.Unlock()
+	delete(r.rotationTriggerValues, key)
 }
 
 func (r *DatabaseSecretClaimReconciler) buildOwnedSecret(

--- a/dbaas-operator/internal/controller/databasesecretclaim_controller.go
+++ b/dbaas-operator/internal/controller/databasesecretclaim_controller.go
@@ -104,7 +104,7 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 		return result, nil
 	}
 	trigger := r.triggerForSecretClaim(key, s)
-	recordReconcileTrigger(controllerDS, trigger)
+	recordReconcileTrigger(controllerDSC, trigger)
 
 	original := s.DeepCopy()
 	defer func() {
@@ -138,7 +138,7 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	aggStart := time.Now()
 	dbResp, err := r.Aggregator.GetDatabaseByClassifier(ctx, s.Namespace, s.Spec.Type, aggReq)
-	recordAggregatorCall(controllerDS, operationGetDatabase, aggStart, err)
+	recordAggregatorCall(controllerDSC, operationGetDatabase, aggStart, err)
 	if err != nil {
 		return r.handleAggregatorErr(ctx, s, err, requestID)
 	}

--- a/dbaas-operator/internal/controller/databasesecretclaim_controller.go
+++ b/dbaas-operator/internal/controller/databasesecretclaim_controller.go
@@ -90,17 +90,20 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	key := s.Namespace + "/" + s.Name
-	trigger := r.triggerForSecretClaim(key, s)
 
 	owned, result, err := checkOwnership(ctx, r.Ownership, s.Namespace, s.Name, "DatabaseSecretClaim")
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	if !owned {
-		r.clearBindingTrigger(key)
-		r.clearSiblingTrigger(key)
+		if r.Ownership.GetState(s.Namespace) == ownership.Foreign {
+			r.clearBindingTrigger(key)
+			r.clearSiblingTrigger(key)
+			r.clearRotationTrigger(key)
+		}
 		return result, nil
 	}
+	trigger := r.triggerForSecretClaim(key, s)
 	recordReconcileTrigger(controllerDS, trigger)
 
 	original := s.DeepCopy()

--- a/dbaas-operator/internal/controller/internaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller.go
@@ -129,7 +129,7 @@ func (r *InternalDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	} else if dd.Status.TrackingID != "" {
 		trigger = triggerPolling
 	}
-	recordReconcileTrigger(controllerDD, trigger)
+	recordReconcileTrigger(controllerIDB, trigger)
 
 	if dd.Status.TrackingID != "" {
 		return r.reconcilePoll(ctx, dd)
@@ -151,7 +151,7 @@ func (r *InternalDatabaseReconciler) reconcileSubmit(ctx context.Context, dd *db
 	dd.Status.LastRequestID = requestID
 	aggStart := time.Now()
 	resp, err := r.Aggregator.ApplyConfig(ctx, payload)
-	recordAggregatorCall(controllerDD, operationApplyConfig, aggStart, err)
+	recordAggregatorCall(controllerIDB, operationApplyConfig, aggStart, err)
 	if err != nil {
 		log.ErrorC(ctx, "failed to apply InternalDatabase to dbaas-aggregator: %v", err)
 		return handleAggregatorError(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, r.Recorder, dd, err, requestID)
@@ -195,7 +195,7 @@ func (r *InternalDatabaseReconciler) reconcilePoll(ctx context.Context, dd *dbaa
 
 	aggStart := time.Now()
 	resp, err := r.Aggregator.GetOperationStatus(ctx, trackingID)
-	recordAggregatorCall(controllerDD, operationPollStatus, aggStart, err)
+	recordAggregatorCall(controllerIDB, operationPollStatus, aggStart, err)
 	if err != nil {
 		return r.handlePollError(ctx, dd, trackingID, requestID, err)
 	}

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -47,11 +47,12 @@ const (
 	triggerSiblingSecretClaim     = "sibling_secret_claim_change"
 	triggerSafetyNet              = "safety_net"
 
-	resultSuccess       = "success"
-	resultAuthError     = "auth_error"
-	resultSpecRejection = "spec_rejection"
-	resultServerError   = "server_error"
-	resultNetworkError  = "network_error"
+	resultSuccess          = "success"
+	resultAuthError        = "auth_error"
+	resultSpecRejection    = "spec_rejection"
+	resultDatabaseNotFound = "database_not_found"
+	resultServerError      = "server_error"
+	resultNetworkError     = "network_error"
 
 	asyncResultFailed     = "failed"
 	asyncResultTerminated = "terminated"
@@ -123,8 +124,9 @@ var dbaasAggregatorRequestDurationSeconds = prometheus.NewHistogramVec(
 
 // dbaasAggregatorRequestsTotal counts aggregator calls by controller, operation,
 // and result. The result label distinguishes user errors (spec_rejection) from
-// platform errors (auth_error, server_error) so each can be routed to the
-// correct owner.
+// platform errors (auth_error, server_error). database_not_found is a normal
+// DatabaseSecretClaim waiting state and should not be routed as an aggregator
+// server failure.
 var dbaasAggregatorRequestsTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "dbaas_aggregator_requests_total",
@@ -181,6 +183,9 @@ func aggregatorResult(err error) string {
 		}
 		if aggErr.IsSpecRejection() {
 			return resultSpecRejection
+		}
+		if aggErr.IsDatabaseNotFound() {
+			return resultDatabaseNotFound
 		}
 		return resultServerError
 	}

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -34,11 +34,18 @@ const (
 	controllerDD  = "internaldatabase"
 	controllerDP  = "databaseaccesspolicy"
 	controllerBR  = "balancingrule"
+	controllerDS  = "databasesecretclaim"
+	controllerMBR = "microservicebalancingrule"
+	controllerNBR = "namespacebalancingrule"
+	controllerPBR = "permanentbalancingrule"
 
 	triggerSpecChange             = "spec_change"
 	triggerSecretChange           = "secret_change"
 	triggerNamespaceBindingChange = "namespace_binding_change"
 	triggerPolling                = "polling"
+	triggerRotation               = "rotation_trigger"
+	triggerSiblingSecretClaim     = "sibling_secret_claim_change"
+	triggerSafetyNet              = "safety_net"
 
 	resultSuccess       = "success"
 	resultAuthError     = "auth_error"
@@ -58,6 +65,7 @@ const (
 	operationRegisterEDB = "register_external_database"
 	operationApplyConfig = "apply_config"
 	operationPollStatus  = "poll_status"
+	operationGetDatabase = "get_database_by_classifier"
 
 	operationApplyMicroserviceRule   = "apply_microservice_balancing_rule"
 	operationCleanupMicroserviceRule = "cleanup_microservice_balancing_rule"

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -31,10 +31,10 @@ import (
 // Keeping the constants here because they are only relevant to Prometheus metrics.
 const (
 	controllerEDB = "externaldatabase"
-	controllerDD  = "internaldatabase"
-	controllerDP  = "databaseaccesspolicy"
+	controllerIDB = "internaldatabase"
+	controllerDAP = "databaseaccesspolicy"
 	controllerBR  = "balancingrule"
-	controllerDS  = "databasesecretclaim"
+	controllerDSC = "databasesecretclaim"
 	controllerMBR = "microservicebalancingrule"
 	controllerNBR = "namespacebalancingrule"
 	controllerPBR = "permanentbalancingrule"

--- a/dbaas-operator/internal/controller/metrics_test.go
+++ b/dbaas-operator/internal/controller/metrics_test.go
@@ -17,6 +17,7 @@ func TestAggregatorResultClassifiesOwnershipBuckets(t *testing.T) {
 		{name: "success", err: nil, want: resultSuccess},
 		{name: "auth", err: &aggregatorclient.AggregatorError{StatusCode: 401}, want: resultAuthError},
 		{name: "spec rejection", err: &aggregatorclient.AggregatorError{StatusCode: 409}, want: resultSpecRejection},
+		{name: "database not found", err: &aggregatorclient.AggregatorError{StatusCode: 404, TmfCode: "CORE-DBAAS-4006"}, want: resultDatabaseNotFound},
 		{name: "server", err: &aggregatorclient.AggregatorError{StatusCode: 500}, want: resultServerError},
 		{name: "wrapped server", err: fmt.Errorf("wrapped: %w", &aggregatorclient.AggregatorError{StatusCode: 503}), want: resultServerError},
 		{name: "network", err: errors.New("dial tcp: connection refused"), want: resultNetworkError},

--- a/dbaas-operator/internal/controller/resource_metrics.go
+++ b/dbaas-operator/internal/controller/resource_metrics.go
@@ -1,0 +1,508 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	dbaasv1 "github.com/netcracker/qubership-dbaas/dbaas-operator/api/v1"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/ownership"
+)
+
+const (
+	resourceKindExternalDatabase           = "ExternalDatabase"
+	resourceKindInternalDatabase           = "InternalDatabase"
+	resourceKindDatabaseAccessPolicy       = "DatabaseAccessPolicy"
+	resourceKindDatabaseSecretClaim        = "DatabaseSecretClaim"
+	resourceKindMicroserviceBalancingRule  = "MicroserviceBalancingRule"
+	resourceKindNamespaceBalancingRule     = "NamespaceBalancingRule"
+	resourceKindPermanentBalancingRule     = "PermanentBalancingRule"
+	resourceKindNamespaceBinding           = "NamespaceBinding"
+	namespaceBindingStateMine              = "mine"
+	namespaceBindingStateForeign           = "foreign"
+	namespaceBindingStateDeleting          = "deleting"
+	namespaceBindingStateDeletingFinalizer = "deleting_with_finalizer"
+	resourceDeletionStateDeleting          = "deleting"
+	resourceDeletionStateDeletingFinalizer = "deleting_with_finalizer"
+	balancingTargetTypeMicroservice        = "microservice"
+	balancingTargetTypeRule                = "rule"
+	balancingTargetTypeNamespace           = "namespace"
+	resourceMetricsCollectionTimeout       = 10 * time.Second
+)
+
+var (
+	resourcePhaseDesc = prometheus.NewDesc(
+		"dbaas_resource_phase",
+		"Current phase of dbaas operator resources that expose OperatorStatus. Emits one series for the current phase of each resource owned by this operator instance.",
+		[]string{"kind", "resource_namespace", "name", "phase"},
+		nil,
+	)
+	resourceConditionDesc = prometheus.NewDesc(
+		"dbaas_resource_condition",
+		"Current status conditions of dbaas operator resources that expose OperatorStatus. Emits current condition type, status, and reason for each resource owned by this operator instance.",
+		[]string{"kind", "resource_namespace", "name", "condition", "status", "reason"},
+		nil,
+	)
+	resourceGenerationLagDesc = prometheus.NewDesc(
+		"dbaas_resource_observed_generation_lag",
+		"Difference between metadata.generation and status.observedGeneration for dbaas operator resources owned by this operator instance.",
+		[]string{"kind", "resource_namespace", "name"},
+		nil,
+	)
+	namespaceBindingStateDesc = prometheus.NewDesc(
+		"dbaas_namespace_binding_state",
+		"Current NamespaceBinding state from this operator instance's point of view. deleting_with_finalizer means deletion is in progress and the protection finalizer is still present; it does not prove blocking resources still exist.",
+		[]string{"resource_namespace", "name", "state"},
+		nil,
+	)
+	resourceDeletionStateDesc = prometheus.NewDesc(
+		"dbaas_resource_deletion_state",
+		"Current deletion state for dbaas operator resources. deleting_with_finalizer means deletion is in progress and at least one finalizer is still present.",
+		[]string{"kind", "resource_namespace", "name", "state"},
+		nil,
+	)
+	balancingRuleDesiredTargetsDesc = prometheus.NewDesc(
+		"dbaas_balancing_rule_desired_targets",
+		"Current desired balancing-rule target count from spec. This is operator intent only; it does not prove the referenced physical database exists or that dbaas-aggregator has applied the rule.",
+		[]string{"kind", "resource_namespace", "name", "target_type"},
+		nil,
+	)
+	balancingRuleAppliedTargetsDesc = prometheus.NewDesc(
+		"dbaas_balancing_rule_applied_targets",
+		"Current applied balancing-rule target count recorded in status. This reflects the last operator-applied state, not an independent readback from dbaas-aggregator or a guarantee that referenced physical databases still exist.",
+		[]string{"kind", "resource_namespace", "name", "target_type"},
+		nil,
+	)
+	secretClaimLastRotationTimestampDesc = prometheus.NewDesc(
+		"dbaas_secret_claim_last_rotation_timestamp_seconds",
+		"Unix timestamp of the most recent connection-properties rotation applied by a DatabaseSecretClaim. Absence or old values do not by themselves prove the rotation poller is broken; the controller also has a per-CR safety-net reconcile.",
+		[]string{"resource_namespace", "name"},
+		nil,
+	)
+	secretClaimNotFoundAgeDesc = prometheus.NewDesc(
+		"dbaas_secret_claim_not_found_age_seconds",
+		"Age in seconds of the current DatabaseNotFound streak for a DatabaseSecretClaim.",
+		[]string{"resource_namespace", "name"},
+		nil,
+	)
+	resourceCollectorSuccessDesc = prometheus.NewDesc(
+		"dbaas_resource_collector_success",
+		"Whether the latest resource metrics collection for a CR kind succeeded.",
+		[]string{"kind"},
+		nil,
+	)
+	registerResourceMetricsOnce sync.Once
+)
+
+// RegisterResourceMetrics registers kube-state-style current-state metrics for
+// dbaas CRs. The metrics intentionally expose CR name only on gauges that
+// represent current state; counters and histograms remain low-cardinality.
+func RegisterResourceMetrics(c client.Client, resolver *ownership.OwnershipResolver, operatorNamespace string) {
+	registerResourceMetricsOnce.Do(func() {
+		metrics.Registry.MustRegister(&resourceMetricsCollector{
+			client:            c,
+			ownership:         resolver,
+			operatorNamespace: operatorNamespace,
+		})
+	})
+}
+
+type resourceMetricsCollector struct {
+	client            client.Client
+	ownership         *ownership.OwnershipResolver
+	operatorNamespace string
+}
+
+func (c *resourceMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- resourcePhaseDesc
+	ch <- resourceConditionDesc
+	ch <- resourceGenerationLagDesc
+	ch <- namespaceBindingStateDesc
+	ch <- resourceDeletionStateDesc
+	ch <- balancingRuleDesiredTargetsDesc
+	ch <- balancingRuleAppliedTargetsDesc
+	ch <- secretClaimLastRotationTimestampDesc
+	ch <- secretClaimNotFoundAgeDesc
+	ch <- resourceCollectorSuccessDesc
+}
+
+func (c *resourceMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), resourceMetricsCollectionTimeout)
+	defer cancel()
+
+	c.collectExternalDatabases(ctx, ch)
+	c.collectInternalDatabases(ctx, ch)
+	c.collectDatabaseAccessPolicies(ctx, ch)
+	c.collectDatabaseSecretClaims(ctx, ch)
+	c.collectMicroserviceBalancingRules(ctx, ch)
+	c.collectNamespaceBalancingRules(ctx, ch)
+	c.collectPermanentBalancingRules(ctx, ch)
+	c.collectNamespaceBindings(ctx, ch)
+}
+
+func (c *resourceMetricsCollector) collectExternalDatabases(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.ExternalDatabaseList{}
+	if !c.collectList(ctx, ch, resourceKindExternalDatabase, list) {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if c.ownsNamespace(item.Namespace) {
+			collectOperatorStatus(ch, resourceKindExternalDatabase, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+			collectDeletionState(ch, resourceKindExternalDatabase, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		}
+	}
+}
+
+func (c *resourceMetricsCollector) collectInternalDatabases(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.InternalDatabaseList{}
+	if !c.collectList(ctx, ch, resourceKindInternalDatabase, list) {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if c.ownsNamespace(item.Namespace) {
+			collectOperatorStatus(ch, resourceKindInternalDatabase, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+			collectDeletionState(ch, resourceKindInternalDatabase, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		}
+	}
+}
+
+func (c *resourceMetricsCollector) collectDatabaseAccessPolicies(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.DatabaseAccessPolicyList{}
+	if !c.collectList(ctx, ch, resourceKindDatabaseAccessPolicy, list) {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if c.ownsNamespace(item.Namespace) {
+			collectOperatorStatus(ch, resourceKindDatabaseAccessPolicy, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+			collectDeletionState(ch, resourceKindDatabaseAccessPolicy, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		}
+	}
+}
+
+func (c *resourceMetricsCollector) collectDatabaseSecretClaims(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.DatabaseSecretClaimList{}
+	if !c.collectList(ctx, ch, resourceKindDatabaseSecretClaim, list) {
+		return
+	}
+	now := time.Now()
+	for i := range list.Items {
+		item := &list.Items[i]
+		if !c.ownsNamespace(item.Namespace) {
+			continue
+		}
+		collectOperatorStatus(ch, resourceKindDatabaseSecretClaim, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+		collectDeletionState(ch, resourceKindDatabaseSecretClaim, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		if item.Status.LastRotatedAt != nil {
+			ch <- prometheus.MustNewConstMetric(
+				secretClaimLastRotationTimestampDesc,
+				prometheus.GaugeValue,
+				float64(item.Status.LastRotatedAt.Unix()),
+				item.Namespace,
+				item.Name,
+			)
+		}
+		if item.Status.FirstNotFoundAt != nil {
+			age := now.Sub(item.Status.FirstNotFoundAt.Time).Seconds()
+			if age < 0 {
+				age = 0
+			}
+			ch <- prometheus.MustNewConstMetric(
+				secretClaimNotFoundAgeDesc,
+				prometheus.GaugeValue,
+				age,
+				item.Namespace,
+				item.Name,
+			)
+		}
+	}
+}
+
+func (c *resourceMetricsCollector) collectMicroserviceBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.MicroserviceBalancingRuleList{}
+	if !c.collectList(ctx, ch, resourceKindMicroserviceBalancingRule, list) {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if !c.ownsNamespace(item.Namespace) {
+			continue
+		}
+		collectOperatorStatus(ch, resourceKindMicroserviceBalancingRule, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+		collectDeletionState(ch, resourceKindMicroserviceBalancingRule, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		ch <- prometheus.MustNewConstMetric(
+			balancingRuleDesiredTargetsDesc,
+			prometheus.GaugeValue,
+			float64(microserviceDesiredTargetCount(item.Spec.Rules)),
+			resourceKindMicroserviceBalancingRule,
+			item.Namespace,
+			item.Name,
+			balancingTargetTypeMicroservice,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			balancingRuleAppliedTargetsDesc,
+			prometheus.GaugeValue,
+			float64(microserviceAppliedTargetCount(item.Status.AppliedRules)),
+			resourceKindMicroserviceBalancingRule,
+			item.Namespace,
+			item.Name,
+			balancingTargetTypeMicroservice,
+		)
+	}
+}
+
+func (c *resourceMetricsCollector) collectNamespaceBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.NamespaceBalancingRuleList{}
+	if !c.collectList(ctx, ch, resourceKindNamespaceBalancingRule, list) {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		if !c.ownsNamespace(item.Namespace) {
+			continue
+		}
+		collectOperatorStatus(ch, resourceKindNamespaceBalancingRule, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+		collectDeletionState(ch, resourceKindNamespaceBalancingRule, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		ch <- prometheus.MustNewConstMetric(
+			balancingRuleDesiredTargetsDesc,
+			prometheus.GaugeValue,
+			float64(len(item.Spec.Rules)),
+			resourceKindNamespaceBalancingRule,
+			item.Namespace,
+			item.Name,
+			balancingTargetTypeRule,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			balancingRuleAppliedTargetsDesc,
+			prometheus.GaugeValue,
+			float64(len(item.Status.AppliedRules)),
+			resourceKindNamespaceBalancingRule,
+			item.Namespace,
+			item.Name,
+			balancingTargetTypeRule,
+		)
+	}
+}
+
+func (c *resourceMetricsCollector) collectPermanentBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.PermanentBalancingRuleList{}
+	if err := c.client.List(ctx, list, client.InNamespace(c.operatorNamespace)); err != nil {
+		ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 0, resourceKindPermanentBalancingRule)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 1, resourceKindPermanentBalancingRule)
+	if c.operatorNamespace == "" {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		collectOperatorStatus(ch, resourceKindPermanentBalancingRule, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
+		collectDeletionState(ch, resourceKindPermanentBalancingRule, item.Namespace, item.Name, item.DeletionTimestamp, item.Finalizers)
+		ch <- prometheus.MustNewConstMetric(
+			balancingRuleDesiredTargetsDesc,
+			prometheus.GaugeValue,
+			float64(permanentDesiredTargetCount(item.Spec.Rules)),
+			resourceKindPermanentBalancingRule,
+			item.Namespace,
+			item.Name,
+			balancingTargetTypeNamespace,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			balancingRuleAppliedTargetsDesc,
+			prometheus.GaugeValue,
+			float64(permanentAppliedTargetCount(item.Status.AppliedRules)),
+			resourceKindPermanentBalancingRule,
+			item.Namespace,
+			item.Name,
+			balancingTargetTypeNamespace,
+		)
+	}
+}
+
+func (c *resourceMetricsCollector) collectNamespaceBindings(ctx context.Context, ch chan<- prometheus.Metric) {
+	list := &dbaasv1.NamespaceBindingList{}
+	if !c.collectList(ctx, ch, resourceKindNamespaceBinding, list) {
+		return
+	}
+	for i := range list.Items {
+		item := &list.Items[i]
+		state := namespaceBindingState(item, c.operatorNamespace)
+		ch <- prometheus.MustNewConstMetric(
+			namespaceBindingStateDesc,
+			prometheus.GaugeValue,
+			1,
+			item.Namespace,
+			item.Name,
+			state,
+		)
+	}
+}
+
+func (c *resourceMetricsCollector) collectList(
+	ctx context.Context,
+	ch chan<- prometheus.Metric,
+	kind string,
+	list client.ObjectList,
+) bool {
+	if err := c.client.List(ctx, list); err != nil {
+		ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 0, kind)
+		return false
+	}
+	ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 1, kind)
+	return true
+}
+
+func (c *resourceMetricsCollector) ownsNamespace(namespace string) bool {
+	if c.ownership == nil {
+		return false
+	}
+	return c.ownership.GetState(namespace) == ownership.Mine
+}
+
+func collectOperatorStatus(
+	ch chan<- prometheus.Metric,
+	kind string,
+	namespace string,
+	name string,
+	generation int64,
+	status dbaasv1.OperatorStatus,
+) {
+	phase := string(status.Phase)
+	if phase == "" {
+		phase = string(dbaasv1.PhaseUnknown)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		resourcePhaseDesc,
+		prometheus.GaugeValue,
+		1,
+		kind,
+		namespace,
+		name,
+		phase,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		resourceGenerationLagDesc,
+		prometheus.GaugeValue,
+		float64(generationLag(generation, status.ObservedGeneration)),
+		kind,
+		namespace,
+		name,
+	)
+	for _, condition := range status.Conditions {
+		ch <- prometheus.MustNewConstMetric(
+			resourceConditionDesc,
+			prometheus.GaugeValue,
+			1,
+			kind,
+			namespace,
+			name,
+			condition.Type,
+			string(condition.Status),
+			condition.Reason,
+		)
+	}
+}
+
+func generationLag(generation, observedGeneration int64) int64 {
+	if generation <= observedGeneration {
+		return 0
+	}
+	return generation - observedGeneration
+}
+
+func namespaceBindingState(binding *dbaasv1.NamespaceBinding, operatorNamespace string) string {
+	if !binding.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(binding, dbaasv1.NamespaceBindingProtectionFinalizer) {
+			return namespaceBindingStateDeletingFinalizer
+		}
+		return namespaceBindingStateDeleting
+	}
+	if binding.Spec.OperatorNamespace == operatorNamespace {
+		return namespaceBindingStateMine
+	}
+	return namespaceBindingStateForeign
+}
+
+func collectDeletionState(
+	ch chan<- prometheus.Metric,
+	kind string,
+	namespace string,
+	name string,
+	deletionTimestamp *metav1.Time,
+	finalizers []string,
+) {
+	if deletionTimestamp == nil || deletionTimestamp.IsZero() {
+		return
+	}
+	state := resourceDeletionStateDeleting
+	if len(finalizers) > 0 {
+		state = resourceDeletionStateDeletingFinalizer
+	}
+	ch <- prometheus.MustNewConstMetric(
+		resourceDeletionStateDesc,
+		prometheus.GaugeValue,
+		1,
+		kind,
+		namespace,
+		name,
+		state,
+	)
+}
+
+func microserviceDesiredTargetCount(rules []dbaasv1.MicroserviceBalancingRuleItem) int {
+	count := 0
+	for _, rule := range rules {
+		count += len(rule.Microservices)
+	}
+	return count
+}
+
+func microserviceAppliedTargetCount(rules []dbaasv1.MicroserviceBalancingRuleAppliedRule) int {
+	count := 0
+	for _, rule := range rules {
+		count += len(rule.Microservices)
+	}
+	return count
+}
+
+func permanentDesiredTargetCount(rules []dbaasv1.PermanentBalancingRuleItem) int {
+	count := 0
+	for _, rule := range rules {
+		count += len(rule.Namespaces)
+	}
+	return count
+}
+
+func permanentAppliedTargetCount(rules []dbaasv1.PermanentBalancingRuleAppliedRule) int {
+	count := 0
+	for _, rule := range rules {
+		count += len(rule.Namespaces)
+	}
+	return count
+}
+
+var _ prometheus.Collector = (*resourceMetricsCollector)(nil)

--- a/dbaas-operator/internal/controller/resource_metrics.go
+++ b/dbaas-operator/internal/controller/resource_metrics.go
@@ -101,9 +101,9 @@ var (
 		[]string{"resource_namespace", "name"},
 		nil,
 	)
-	secretClaimNotFoundAgeDesc = prometheus.NewDesc(
-		"dbaas_secret_claim_not_found_age_seconds",
-		"Age in seconds of the current DatabaseNotFound streak for a DatabaseSecretClaim.",
+	secretClaimFirstNotFoundTimestampDesc = prometheus.NewDesc(
+		"dbaas_secret_claim_first_not_found_timestamp_seconds",
+		"Unix timestamp when the current DatabaseNotFound streak started for a DatabaseSecretClaim.",
 		[]string{"resource_namespace", "name"},
 		nil,
 	)
@@ -144,7 +144,7 @@ func (c *resourceMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- balancingRuleDesiredTargetsDesc
 	ch <- balancingRuleAppliedTargetsDesc
 	ch <- secretClaimLastRotationTimestampDesc
-	ch <- secretClaimNotFoundAgeDesc
+	ch <- secretClaimFirstNotFoundTimestampDesc
 	ch <- resourceCollectorSuccessDesc
 }
 
@@ -209,7 +209,6 @@ func (c *resourceMetricsCollector) collectDatabaseSecretClaims(ctx context.Conte
 	if !c.collectList(ctx, ch, resourceKindDatabaseSecretClaim, list) {
 		return
 	}
-	now := time.Now()
 	for i := range list.Items {
 		item := &list.Items[i]
 		if !c.ownsNamespace(item.Namespace) {
@@ -227,14 +226,10 @@ func (c *resourceMetricsCollector) collectDatabaseSecretClaims(ctx context.Conte
 			)
 		}
 		if item.Status.FirstNotFoundAt != nil {
-			age := now.Sub(item.Status.FirstNotFoundAt.Time).Seconds()
-			if age < 0 {
-				age = 0
-			}
 			ch <- prometheus.MustNewConstMetric(
-				secretClaimNotFoundAgeDesc,
+				secretClaimFirstNotFoundTimestampDesc,
 				prometheus.GaugeValue,
-				age,
+				float64(item.Status.FirstNotFoundAt.Unix()),
 				item.Namespace,
 				item.Name,
 			)
@@ -309,15 +304,16 @@ func (c *resourceMetricsCollector) collectNamespaceBalancingRules(ctx context.Co
 }
 
 func (c *resourceMetricsCollector) collectPermanentBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
+	if c.operatorNamespace == "" {
+		ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 0, resourceKindPermanentBalancingRule)
+		return
+	}
 	list := &dbaasv1.PermanentBalancingRuleList{}
 	if err := c.client.List(ctx, list, client.InNamespace(c.operatorNamespace)); err != nil {
 		ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 0, resourceKindPermanentBalancingRule)
 		return
 	}
 	ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 1, resourceKindPermanentBalancingRule)
-	if c.operatorNamespace == "" {
-		return
-	}
 	for i := range list.Items {
 		item := &list.Items[i]
 		collectOperatorStatus(ch, resourceKindPermanentBalancingRule, item.Namespace, item.Name, item.Generation, item.Status.OperatorStatus)
@@ -412,7 +408,12 @@ func collectOperatorStatus(
 		namespace,
 		name,
 	)
+	seenConditions := make(map[string]struct{}, len(status.Conditions))
 	for _, condition := range status.Conditions {
+		if _, ok := seenConditions[condition.Type]; ok {
+			continue
+		}
+		seenConditions[condition.Type] = struct{}{}
 		ch <- prometheus.MustNewConstMetric(
 			resourceConditionDesc,
 			prometheus.GaugeValue,

--- a/dbaas-operator/internal/controller/resource_metrics_test.go
+++ b/dbaas-operator/internal/controller/resource_metrics_test.go
@@ -3,9 +3,14 @@ package controller
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dbaasv1 "github.com/netcracker/qubership-dbaas/dbaas-operator/api/v1"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/ownership"
 )
 
 func TestGenerationLag(t *testing.T) {
@@ -28,6 +33,181 @@ func TestGenerationLag(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectOperatorStatusDeduplicatesConditionsByType(t *testing.T) {
+	collector := duplicateConditionCollector{}
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() returned error for duplicate conditions: %v", err)
+	}
+
+	var conditionCount int
+	for _, metricFamily := range metrics {
+		if metricFamily.GetName() == "dbaas_resource_condition" {
+			conditionCount = len(metricFamily.GetMetric())
+		}
+	}
+	if conditionCount != 1 {
+		t.Fatalf("dbaas_resource_condition count = %d, want 1", conditionCount)
+	}
+}
+
+func TestResourceMetricsCollectorFiltersByOwnedNamespace(t *testing.T) {
+	scheme := testResourceMetricsScheme(t)
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&dbaasv1.ExternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: "owned-db", Namespace: "owned-ns", Generation: 1},
+				Status:     dbaasv1.ExternalDatabaseStatus{OperatorStatus: dbaasv1.OperatorStatus{Phase: dbaasv1.PhaseSucceeded}},
+			},
+			&dbaasv1.ExternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: "foreign-db", Namespace: "foreign-ns", Generation: 1},
+				Status:     dbaasv1.ExternalDatabaseStatus{OperatorStatus: dbaasv1.OperatorStatus{Phase: dbaasv1.PhaseSucceeded}},
+			},
+		).
+		Build()
+	resolver := ownership.NewOwnershipResolver("operator-ns", cl)
+	resolver.SetOwner("owned-ns", "operator-ns")
+	resolver.SetOwner("foreign-ns", "other-operator-ns")
+
+	metrics := gatherResourceMetrics(t, &resourceMetricsCollector{
+		client:            cl,
+		ownership:         resolver,
+		operatorNamespace: "operator-ns",
+	})
+
+	if got := countMetrics(metrics, "dbaas_resource_phase", map[string]string{"kind": resourceKindExternalDatabase}); got != 1 {
+		t.Fatalf("ExternalDatabase phase metrics = %d, want 1", got)
+	}
+	if got := countMetrics(metrics, "dbaas_resource_phase", map[string]string{"resource_namespace": "foreign-ns"}); got != 0 {
+		t.Fatalf("foreign namespace phase metrics = %d, want 0", got)
+	}
+}
+
+func TestResourceMetricsCollectorReportsListErrors(t *testing.T) {
+	cl := fake.NewClientBuilder().Build()
+
+	metrics := gatherResourceMetrics(t, &resourceMetricsCollector{
+		client:            cl,
+		ownership:         ownership.NewOwnershipResolver("operator-ns", cl),
+		operatorNamespace: "operator-ns",
+	})
+
+	if got := metricValue(metrics, "dbaas_resource_collector_success", map[string]string{"kind": resourceKindExternalDatabase}); got != 0 {
+		t.Fatalf("ExternalDatabase collector success = %v, want 0", got)
+	}
+}
+
+func TestPermanentBalancingRuleCollectorRequiresOperatorNamespace(t *testing.T) {
+	scheme := testResourceMetricsScheme(t)
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&dbaasv1.PermanentBalancingRule{
+			ObjectMeta: metav1.ObjectMeta{Name: dbaasv1.PermanentBalancingRuleName, Namespace: "operator-ns", Generation: 1},
+			Status:     dbaasv1.PermanentBalancingRuleStatus{OperatorStatus: dbaasv1.OperatorStatus{Phase: dbaasv1.PhaseSucceeded}},
+		}).
+		Build()
+
+	metrics := gatherResourceMetrics(t, &resourceMetricsCollector{
+		client:    cl,
+		ownership: ownership.NewOwnershipResolver("", cl),
+	})
+
+	if got := metricValue(metrics, "dbaas_resource_collector_success", map[string]string{"kind": resourceKindPermanentBalancingRule}); got != 0 {
+		t.Fatalf("PermanentBalancingRule collector success = %v, want 0", got)
+	}
+	if got := countMetrics(metrics, "dbaas_resource_phase", map[string]string{"kind": resourceKindPermanentBalancingRule}); got != 0 {
+		t.Fatalf("PermanentBalancingRule phase metrics = %d, want 0", got)
+	}
+}
+
+func testResourceMetricsScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := dbaasv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+	return scheme
+}
+
+func gatherResourceMetrics(t *testing.T, collector prometheus.Collector) []*dto.MetricFamily {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	return metrics
+}
+
+func countMetrics(metrics []*dto.MetricFamily, name string, labels map[string]string) int {
+	var count int
+	for _, family := range metrics {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricHasLabels(metric, labels) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func metricValue(metrics []*dto.MetricFamily, name string, labels map[string]string) float64 {
+	for _, family := range metrics {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricHasLabels(metric, labels) {
+				return metric.GetGauge().GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+func metricHasLabels(metric *dto.Metric, want map[string]string) bool {
+	for key, value := range want {
+		found := false
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == key && label.GetValue() == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+type duplicateConditionCollector struct{}
+
+func (duplicateConditionCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- resourcePhaseDesc
+	ch <- resourceGenerationLagDesc
+	ch <- resourceConditionDesc
+}
+
+func (duplicateConditionCollector) Collect(ch chan<- prometheus.Metric) {
+	collectOperatorStatus(ch, resourceKindExternalDatabase, "ns", "db", 1, dbaasv1.OperatorStatus{
+		Phase:              dbaasv1.PhaseProcessing,
+		ObservedGeneration: 1,
+		Conditions: []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "BackingOff"},
+			{Type: "Ready", Status: metav1.ConditionFalse, Reason: "BackingOff"},
+		},
+	})
 }
 
 func TestNamespaceBindingState(t *testing.T) {

--- a/dbaas-operator/internal/controller/resource_metrics_test.go
+++ b/dbaas-operator/internal/controller/resource_metrics_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dbaasv1 "github.com/netcracker/qubership-dbaas/dbaas-operator/api/v1"
+)
+
+func TestGenerationLag(t *testing.T) {
+	tests := []struct {
+		name               string
+		generation         int64
+		observedGeneration int64
+		want               int64
+	}{
+		{name: "caught up", generation: 5, observedGeneration: 5, want: 0},
+		{name: "not caught up", generation: 6, observedGeneration: 5, want: 1},
+		{name: "never negative", generation: 5, observedGeneration: 6, want: 0},
+		{name: "new object not observed", generation: 1, observedGeneration: 0, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generationLag(tt.generation, tt.observedGeneration); got != tt.want {
+				t.Fatalf("generationLag() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNamespaceBindingState(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name string
+		nb   *dbaasv1.NamespaceBinding
+		want string
+	}{
+		{
+			name: "mine",
+			nb: &dbaasv1.NamespaceBinding{
+				Spec: dbaasv1.NamespaceBindingSpec{OperatorNamespace: "operator-ns"},
+			},
+			want: namespaceBindingStateMine,
+		},
+		{
+			name: "foreign",
+			nb: &dbaasv1.NamespaceBinding{
+				Spec: dbaasv1.NamespaceBindingSpec{OperatorNamespace: "other-ns"},
+			},
+			want: namespaceBindingStateForeign,
+		},
+		{
+			name: "deleting",
+			nb: &dbaasv1.NamespaceBinding{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now},
+			},
+			want: namespaceBindingStateDeleting,
+		},
+		{
+			name: "deleting with finalizer",
+			nb: &dbaasv1.NamespaceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+					Finalizers:        []string{dbaasv1.NamespaceBindingProtectionFinalizer},
+				},
+			},
+			want: namespaceBindingStateDeletingFinalizer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := namespaceBindingState(tt.nb, "operator-ns"); got != tt.want {
+				t.Fatalf("namespaceBindingState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBalancingRuleAppliedTargetCounts(t *testing.T) {
+	if got := microserviceDesiredTargetCount([]dbaasv1.MicroserviceBalancingRuleItem{
+		{Microservices: []string{"a", "b"}},
+		{Microservices: []string{"c"}},
+	}); got != 3 {
+		t.Fatalf("microserviceDesiredTargetCount() = %d, want 3", got)
+	}
+
+	if got := microserviceAppliedTargetCount([]dbaasv1.MicroserviceBalancingRuleAppliedRule{
+		{Microservices: []string{"a", "b"}},
+		{Microservices: []string{"c"}},
+	}); got != 3 {
+		t.Fatalf("microserviceAppliedTargetCount() = %d, want 3", got)
+	}
+
+	if got := permanentDesiredTargetCount([]dbaasv1.PermanentBalancingRuleItem{
+		{Namespaces: []string{"ns-a", "ns-b"}},
+		{Namespaces: []string{"ns-c"}},
+	}); got != 3 {
+		t.Fatalf("permanentDesiredTargetCount() = %d, want 3", got)
+	}
+
+	if got := permanentAppliedTargetCount([]dbaasv1.PermanentBalancingRuleAppliedRule{
+		{Namespaces: []string{"ns-a", "ns-b"}},
+		{Namespaces: []string{"ns-c"}},
+	}); got != 3 {
+		t.Fatalf("permanentAppliedTargetCount() = %d, want 3", got)
+	}
+}


### PR DESCRIPTION
Summary:
- Adds current-state CR metrics for phase, conditions, observed generation lag, deletion/finalizer state, NamespaceBinding state, SecretClaim rotation/not-found state, and balancing-rule desired vs applied target counts.
- Registers the custom resource metrics collector with the manager metrics registry.
- Extends existing operation metrics to cover DatabaseSecretClaim aggregator calls and reconcile trigger sources.
- Splits balancing-rule reconcile trigger metrics by rule kind.
- Updates the Grafana dashboard with CR health, SecretClaim, balancing-rule, NamespaceBinding, and deletion-state panels.
