### PR TITLE
feat(operator): force-reconcile ExternalDatabase via refresh annotation

### DIFF
--- a/dbaas-operator/api/v1/annotations.go
+++ b/dbaas-operator/api/v1/annotations.go
@@ -27,3 +27,19 @@ package v1
 // Consumer: a controller-side predicate that fires reconcile on annotation
 // changes, in addition to the standard generation-change predicate.
 const AnnotationRotationTrigger = "dbaas.netcracker.com/rotation-trigger"
+
+// AnnotationRefresh forces an immediate reconcile of an ExternalDatabase. The
+// ExternalDatabase controller does not watch Secrets (to avoid cluster-wide
+// Secret list/watch RBAC), so a change to a referenced credential Secret is
+// otherwise only picked up on the periodic resync (RequeueAfter). Changing this
+// annotation's value (e.g. to a fresh timestamp) makes the underlying Kubernetes
+// watch fire, triggering an immediate re-read of the referenced Secret and a
+// re-register with dbaas-aggregator. The value is opaque; only a change matters
+// (an identical patch is a no-op), so callers should write a changing value:
+//
+//	kubectl annotate externaldatabase <name> dbaas.netcracker.com/refresh="$(date +%s)" --overwrite
+//
+// Producer: an operator/admin (manual or automation), not the operator itself.
+// Consumer: a controller-side predicate that fires reconcile on annotation
+// changes, in addition to the standard generation-change predicate.
+const AnnotationRefresh = "dbaas.netcracker.com/refresh"

--- a/dbaas-operator/internal/controller/externaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -310,13 +311,41 @@ func (r *ExternalDatabaseReconciler) applySecretCredentials(
 	return nil
 }
 
+// specOrRefreshTriggerPredicate fires a reconcile on (a) a spec change
+// (generation bump) or (b) a change to the refresh annotation (AnnotationRefresh).
+// The ExternalDatabase controller does not watch Secrets, so a referenced
+// credential Secret change is normally only picked up on the periodic resync;
+// touching the refresh annotation forces an immediate reconcile — re-read the
+// Secret and re-register with dbaas-aggregator — without a spec change. Plain
+// GenerationChangedPredicate is not enough: an annotation change does not bump
+// generation and would otherwise be filtered out.
+//
+// Create and Delete fall through to the embedded predicate.Funcs defaults
+// (both return true), preserving standard behaviour for new and removed CRs.
+// Only Update is customised.
+type specOrRefreshTriggerPredicate struct{ predicate.Funcs }
+
+func (specOrRefreshTriggerPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+	if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+		return true
+	}
+	return e.ObjectOld.GetAnnotations()[dbaasv1.AnnotationRefresh] !=
+		e.ObjectNew.GetAnnotations()[dbaasv1.AnnotationRefresh]
+}
+
 // SetupWithManager sets up the controller with the Manager.
-// GenerationChangedPredicate ensures the controller reconciles only when the
-// spec changes (metadata.generation increments), not on its own status updates.
+// The For-predicate (specOrRefreshTriggerPredicate) reconciles on spec changes
+// (metadata.generation) and on a change to the AnnotationRefresh annotation — the
+// latter is a manual escape hatch to apply a referenced-Secret change at once
+// instead of waiting for the resync.
 //
 // There is intentionally no Secret watch: the operator holds only namespaced Secret
 // RBAC (no cluster-wide list/watch), so credential-Secret changes are picked up by the
-// periodic resync (ResyncInterval) via RequeueAfter on a successful reconcile.
+// periodic resync (ResyncInterval) via RequeueAfter on a successful reconcile, or
+// immediately via the refresh annotation above.
 //
 // opts allows callers to customise the controller's behaviour — most notably
 // the RateLimiter, which controls the exponential backoff applied when
@@ -329,7 +358,7 @@ func (r *ExternalDatabaseReconciler) SetupWithManager(mgr ctrl.Manager, opts ctr
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dbaasv1.ExternalDatabase{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(specOrRefreshTriggerPredicate{})).
 		// Re-enqueue all ExternalDatabases in a namespace when its NamespaceBinding
 		// is created or updated, so existing CRs are reconciled without waiting for
 		// a spec change.

--- a/dbaas-operator/internal/controller/externaldatabase_controller_test.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller_test.go
@@ -33,6 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	config "sigs.k8s.io/controller-runtime/pkg/config"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	httpserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -1218,5 +1219,56 @@ var _ = Describe("ExternalDatabase Controller — rate limiter", func() {
 		// After Forget the counter is reset; the next failure starts from base again.
 		rateLimiter.Forget(req)
 		Expect(rateLimiter.When(req)).To(Equal(base))
+	})
+})
+
+// ── specOrRefreshTriggerPredicate ────────────────────────────────────────────
+
+var _ = Describe("ExternalDatabase Controller — refresh-trigger predicate", func() {
+	pred := specOrRefreshTriggerPredicate{}
+
+	edbWith := func(generation int64, refresh string) *dbaasv1.ExternalDatabase {
+		edb := &dbaasv1.ExternalDatabase{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "edb",
+				Namespace:  "default",
+				Generation: generation,
+			},
+		}
+		if refresh != "" {
+			edb.Annotations = map[string]string{dbaasv1.AnnotationRefresh: refresh}
+		}
+		return edb
+	}
+
+	Describe("Update", func() {
+		It("fires when the generation changed (spec update)", func() {
+			ok := pred.Update(event.UpdateEvent{ObjectOld: edbWith(1, ""), ObjectNew: edbWith(2, "")})
+			Expect(ok).To(BeTrue())
+		})
+
+		It("fires when the refresh annotation changed", func() {
+			ok := pred.Update(event.UpdateEvent{ObjectOld: edbWith(1, "t1"), ObjectNew: edbWith(1, "t2")})
+			Expect(ok).To(BeTrue())
+		})
+
+		It("fires when the refresh annotation is first added", func() {
+			ok := pred.Update(event.UpdateEvent{ObjectOld: edbWith(1, ""), ObjectNew: edbWith(1, "t1")})
+			Expect(ok).To(BeTrue())
+		})
+
+		It("does NOT fire on a status-only update (no generation or annotation change)", func() {
+			ok := pred.Update(event.UpdateEvent{ObjectOld: edbWith(3, "t1"), ObjectNew: edbWith(3, "t1")})
+			Expect(ok).To(BeFalse())
+		})
+
+		It("does NOT fire when only an unrelated annotation changed", func() {
+			old := edbWith(1, "t1")
+			old.Annotations["unrelated"] = "a"
+			updated := edbWith(1, "t1")
+			updated.Annotations["unrelated"] = "b"
+			ok := pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated})
+			Expect(ok).To(BeFalse())
+		})
 	})
 })

--- a/docs/howto/DBaaS Operator.md
+++ b/docs/howto/DBaaS Operator.md
@@ -738,6 +738,12 @@ the controller sends the following `classifier` to dbaas-aggregator:
 
 > **Credential rotation:** the operator does **not** watch Secrets. Each `ExternalDatabase` is re-reconciled on a periodic resync (`DBAAS_EXTERNAL_DATABASE_RESYNC_INTERVAL`, default `10m`); every reconcile re-reads the referenced Secrets and pushes any changed credentials to dbaas-aggregator without a manual spec change. So a credential rotation is picked up within one resync interval rather than instantly. Secret bodies are not cached — they are fetched from the API server only at reconcile time.
 
+> **Force an immediate refresh:** to apply a referenced-Secret change at once (instead of waiting for the resync), change the `dbaas.netcracker.com/refresh` annotation on the CR — the controller reconciles immediately, re-reads the Secret, and re-registers with dbaas-aggregator. Use a changing value (e.g. a timestamp) so the underlying watch fires:
+
+```bash
+kubectl annotate externaldatabase <name> dbaas.netcracker.com/refresh="$(date +%s)" --overwrite
+```
+
 #### How ExternalDatabase Works
 
 A reconcile is triggered when any of the following happens:
@@ -745,6 +751,7 @@ A reconcile is triggered when any of the following happens:
 - The CR is created.
 - The CR spec changes (i.e., `metadata.generation` increments).
 - The periodic resync fires (every `DBAAS_EXTERNAL_DATABASE_RESYNC_INTERVAL`, default `10m`). Each reconcile re-reads the referenced Secrets, so a credential rotation is picked up on the next resync — the operator does **not** watch Secrets, so the reaction is bounded by this interval rather than instant.
+- The `dbaas.netcracker.com/refresh` annotation changes — a manual escape hatch to apply a referenced-Secret change at once, without waiting for the resync (see below).
 - The covering `NamespaceBinding` is created or updated (e.g., the namespace is being claimed for the first time).
 
 On each reconcile, the controller:


### PR DESCRIPTION
ExternalDatabase uses GenerationChangedPredicate, so a change to a referenced credential Secret is only picked up on the periodic resync (the operator runs no Secret watch). Add a manual escape hatch: changing the dbaas.netcracker.com/refresh annotation now triggers an immediate reconcile (re-read the Secret, re-register with dbaas-aggregator), mirroring the DatabaseSecretClaim rotation-trigger predicate.

- api/v1: add AnnotationRefresh constant
- externaldatabase_controller: specOrRefreshTriggerPredicate (fires on a generation OR refresh-annotation change); wire into For(); import event
- test: predicate unit cases (generation / annotation add+change / unrelated-annotation / status-only)
- docs: reconcile-trigger bullet + force-refresh recipe

Usage:
  kubectl annotate externaldatabase <name> \ dbaas.netcracker.com/refresh="$(date +%s)" --overwrite