### PR TITLE
feat(operator): materialize pinned-tenant database for tenant InternalDatabase

### DIFF
--- a/dbaas-operator/dev/README.md
+++ b/dbaas-operator/dev/README.md
@@ -8,7 +8,7 @@ in a local [kind](https://kind.sigs.k8s.io/) cluster.
 | Resource | Namespace | Description |
 |---|---|---|
 | `aggregator-mock` Deployment + Service | `dbaas-system` | HTTP stub for dbaas-aggregator |
-| `aggregator-mock-rules` ConfigMap | `dbaas-system` | Per-request routing rules: `rules.json` (EDB by `dbName`), `apply-rules.json` (DatabaseAccessPolicy/InternalDatabase by `microserviceName`), `poll-rules.json` (InternalDatabase async poll by `trackingId`), `changed.json` (rotation feed), `get-by-classifier.json` (DatabaseSecretClaim connection properties by `originService`) |
+| `aggregator-mock-rules` ConfigMap | `dbaas-system` | Per-request routing rules: `rules.json` (EDB by `dbName`), `apply-rules.json` (DatabaseAccessPolicy/InternalDatabase by `microserviceName`), `poll-rules.json` (InternalDatabase async poll by `trackingId`), `changed.json` (rotation feed), `get-by-classifier.json` (DatabaseSecretClaim connection properties by `originService`), `create-db-rules.json` (InternalDatabase tenant get-or-create by `originService`) |
 | `dbaas-operator` Deployment | `dbaas-system` | Operator — watches CRs cluster-wide; Secret access is **namespaced** (no cluster-wide Secret RBAC) |
 | `Role`/`RoleBinding` `dbaas-operator` | `dbaas-system` | Operator's own-namespace RBAC (leases, events, permanentbalancingrules) — **no Secret access** |
 | Namespace `test-ns` | — | Working namespace for CRs |
@@ -176,6 +176,14 @@ For `InternalDatabase` the default response is HTTP 202 (async) with
 `trackingId = "tracking-<microserviceName>"`. Poll responses are controlled by
 `poll-rules.json` (keyed by `trackingId`); missing rule → `COMPLETED`.
 
+For a **tenant-scoped** declaration that pins a `tenantId`, the controller additionally
+issues a get-or-create (`PUT /api/v3/dbaas/{ns}/databases`) once the apply completes, to
+materialize the concrete `{scope=tenant, tenantId}` database (a tenant declaration is
+otherwise a tenant-agnostic template, so the pinned tenant would never get a database and
+a matching `DatabaseSecretClaim` would wait forever). The mock answers the get-or-create
+from `create-db-rules.json` (keyed by `originService`); missing rule → 200. See
+`idb-tenant-materialize.yaml`.
+
 Expected output (`kubectl get internaldatabase -n test-ns`):
 
 ```
@@ -183,6 +191,7 @@ NAME                    PHASE                  TYPE
 idb-success-sync         Succeeded              postgresql
 idb-success-async        Succeeded              postgresql
 idb-custom-keys          Succeeded              postgresql
+idb-tenant-materialize   Succeeded              postgresql
 idb-400-bad-request      InvalidConfiguration   postgresql
 idb-401-unauthorized     BackingOff             postgresql
 idb-500-server-error     BackingOff             postgresql
@@ -197,6 +206,7 @@ idb-invalid-no-source    InvalidConfiguration   postgresql
 | `idb-success-sync.yaml` | `idb-svc-sync` | 200 (rule) | — | `Succeeded` | `DatabaseProvisioned` | `False` |
 | `idb-success-async.yaml` | `idb-svc-async` | 202 (default) | `COMPLETED` (default) | `Succeeded` | `DatabaseProvisioned` | `False` |
 | `idb-custom-keys.yaml` | `idb-svc-custom-keys` | 202 (default) | `COMPLETED` (default) | `Succeeded` | `DatabaseProvisioned` | `False` |
+| `idb-tenant-materialize.yaml` | `idb-tenant` | 202 (default) | `COMPLETED` (default) + get-or-create 200 | `Succeeded` | `DatabaseProvisioned` | `False` |
 | `idb-400-bad-request.yaml` | `idb-svc-400` | 400 (rule) | — | `InvalidConfiguration` | `AggregatorRejected` | `True` |
 | `idb-401-unauthorized.yaml` | `idb-svc-401` | 401 (rule) | — | `BackingOff` | `Unauthorized` | `False` |
 | `idb-500-server-error.yaml` | `idb-svc-500` | 500 (rule) | — | `BackingOff` | `AggregatorError` | `False` |
@@ -301,6 +311,35 @@ It applies `dsc-extra-keys.yaml` and asserts:
 The `extra-svc` entries in `changed.json` and `get-by-classifier.json` are already
 wired into the mock ConfigMap, so a fresh `kind-up.sh` is all the setup it needs.
 Pass `KEEP=1` to leave the CR and Secret in place after the run.
+
+#### tenant materialization end-to-end (`dev/e2e-tenant-materialize.sh`)
+
+A tenant declaration is a tenant-agnostic template — the aggregator materializes a concrete
+tenant database lazily on the first runtime tenant connection, so a tenant
+`DatabaseSecretClaim` would otherwise find nothing. The operator closes that gap: for a tenant
+`InternalDatabase` that pins a `tenantId`, it issues a get-or-create
+(`PUT /api/v3/dbaas/{ns}/databases`) after the declarative apply, materializing the concrete
+`{scope=tenant, tenantId}` database.
+
+The aggregator-mock is **stateful for tenant databases**: get-by-classifier answers a tenant
+lookup with 404 (`DatabaseNotFound`) until the matching get-or-create has recorded it — so the
+script proves the dependency, not just two independent successes:
+
+```bash
+./dev/kind-up.sh                 # if not already up
+./dev/e2e-tenant-materialize.sh
+```
+
+It asserts:
+
+1. the tenant `InternalDatabase` (`idb-tenant-materialize.yaml`) reaches `Succeeded` and the
+   mock logs the get-or-create call for `tenantId=acme` (the database is materialized);
+2. the `DatabaseSecretClaim` (`dsc-tenant-materialize.yaml`, same classifier) reaches
+   `Succeeded` and its Secret carries the tenant identity (`scope=tenant`, `tenantId=acme`).
+
+Restart the mock (`kubectl rollout restart deployment/dbaas-aggregator -n dbaas-system`) to
+clear the in-memory store, then apply the claim alone — it backs off on `DatabaseNotFound`
+until the `InternalDatabase` materializes its database. Pass `KEEP=1` to keep the CRs and Secret.
 
 ### Changing rules without rebuilding
 

--- a/dbaas-operator/dev/aggregator-mock/main.go
+++ b/dbaas-operator/dev/aggregator-mock/main.go
@@ -54,6 +54,13 @@ limitations under the License.
 //	                      POST /api/v3/dbaas/{ns}/databases/get-by-classifier/{type}
 //	                      (default: /config/get-by-classifier.json). No rule →
 //	                      a synthetic default property set.
+//	MOCK_CREATEDB_RULES_FILE – path to a JSON file mapping originService → MockRule
+//	                      for the get-or-create database call
+//	                      PUT /api/v3/dbaas/{namespace}/databases — the operator issues
+//	                      it to materialize the concrete {scope=tenant, tenantId} database
+//	                      for a tenant declaration that pins a tenantId
+//	                      (default: /config/create-db-rules.json). Missing = not an error;
+//	                      no rule → 200 with a synthetic database descriptor.
 package main
 
 import (
@@ -67,6 +74,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -133,6 +141,12 @@ var (
 	// POST /api/v3/dbaas/{namespace}/databases/get-by-classifier/{type}
 	reGetByClassifier = regexp.MustCompile(
 		`^/api/v3/dbaas/([^/]+)/databases/get-by-classifier/([^/]+)$`)
+
+	// PUT /api/v3/dbaas/{namespace}/databases — get-or-create database (the
+	// operator's pinned-tenant materialization call). Anchored on a bare
+	// /databases suffix so it never matches the longer .../databases/registration/…
+	// or .../databases/get-by-classifier/… paths.
+	reCreateDB = regexp.MustCompile(`^/api/v3/dbaas/([^/]+)/databases$`)
 )
 
 // ChangedEntry is one database in the rotation feed (changed.json). Its JSON tags
@@ -144,6 +158,47 @@ type ChangedEntry struct {
 	Type          string         `json:"type"`
 	LastRotatedAt string         `json:"lastRotatedAt"`
 	Classifier    map[string]any `json:"classifier"`
+}
+
+// dbStore is the mock's in-memory record of databases materialized via the get-or-create
+// call (PUT .../databases). It lets get-by-classifier emulate the real aggregator's
+// lazy-tenant behaviour: a tenant database exists only after it has been created, so a
+// DatabaseSecretClaim for a not-yet-materialized tenant gets a 404 (DatabaseNotFound) —
+// exactly what the operator's pinned-tenant materialization is there to prevent. State is
+// per-process and lost on restart.
+type dbStore struct {
+	mu   sync.Mutex
+	seen map[string]bool
+}
+
+func newDBStore() *dbStore { return &dbStore{seen: map[string]bool{}} }
+
+func (s *dbStore) add(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seen[key] = true
+}
+
+func (s *dbStore) has(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.seen[key]
+}
+
+// classifierKey is a deterministic identity for a (classifier, type) pair. Both the
+// get-or-create and get-by-classifier handlers compute it from the same flat classifier the
+// operator sends (ClassifierFlatMap), so a database created by one is found by the other.
+// json.Marshal sorts map keys, making the encoding stable.
+func classifierKey(classifier map[string]any, dbType string) string {
+	b, _ := json.Marshal(classifier)
+	return dbType + "|" + string(b)
+}
+
+// isTenant reports whether a classifier is tenant-scoped (scope=tenant), matched
+// case-insensitively like the operator and aggregator do.
+func isTenant(classifier map[string]any) bool {
+	scope, _ := classifier["scope"].(string)
+	return strings.EqualFold(scope, "tenant")
 }
 
 func main() {
@@ -160,6 +215,8 @@ func main() {
 	changed := loadChanged(changedFile)
 	gbcFile := envOr("MOCK_GETBYCLASSIFIER_FILE", "/config/get-by-classifier.json")
 	gbcRules := loadGbcRules(gbcFile)
+	createDbFile := envOr("MOCK_CREATEDB_RULES_FILE", "/config/create-db-rules.json")
+	createDbRules := loadRules(createDbFile)
 
 	log.Printf("mock dbaas-aggregator starting on :%s", port)
 	log.Printf("  PUT  .../externally_manageable → default httpCode=%d  (%d per-dbName rules loaded)",
@@ -170,11 +227,13 @@ func main() {
 		len(pollRules))
 	log.Printf("  POST .../get-by-classifier/{type} → 200 connectionProperties (%d per-originService rules loaded)",
 		len(gbcRules))
+	log.Printf("  PUT  .../databases → 200 get-or-create database (%d per-originService create-db rules loaded)",
+		len(createDbRules))
 	log.Printf("  GET  .../databases/changed → rotation feed (%d changed entries loaded; seed reports no history)",
 		len(changed))
 	log.Printf("  auth: Basic Auth or Bearer token required (value not validated — both modes accepted)")
 
-	h := handler(defaultRule, rules, applyRules, pollRules, changed, gbcRules)
+	h := handler(defaultRule, rules, applyRules, pollRules, changed, gbcRules, createDbRules)
 	if err := http.ListenAndServe(":"+port, h); err != nil {
 		log.Fatalf("listen: %v", err)
 	}
@@ -264,8 +323,12 @@ func handler(
 	defaultRule MockRule, rules map[string]MockRule,
 	applyRules map[string]MockRule, pollRules map[string]MockPollRule,
 	changed []ChangedEntry, gbcRules map[string]map[string]any,
+	createDbRules map[string]MockRule,
 ) http.Handler {
 	mux := http.NewServeMux()
+	// store records databases materialized via PUT .../databases so get-by-classifier
+	// can emulate the real aggregator's lazy-tenant 404 before materialization.
+	store := newDBStore()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		body := logRequest(r)
 
@@ -287,7 +350,10 @@ func handler(
 			handleChanged(w, r, changed)
 
 		case reGetByClassifier.MatchString(r.URL.Path) && r.Method == http.MethodPost:
-			handleGetByClassifier(w, r, body, gbcRules)
+			handleGetByClassifier(w, r, body, gbcRules, store)
+
+		case reCreateDB.MatchString(r.URL.Path) && r.Method == http.MethodPut:
+			handleCreateDatabase(w, r, body, createDbRules, store)
 
 		case reMicroserviceBalancingRule.MatchString(r.URL.Path) && r.Method == http.MethodPut:
 			handleMicroserviceBalancingRule(w, r)
@@ -586,7 +652,10 @@ func handleChanged(w http.ResponseWriter, r *http.Request, changed []ChangedEntr
 // default. Editing a rule's password (and restarting the mock) lets a subsequent
 // rotation fan-out surface a real SecretRotated; the stable default yields the
 // content-aware no-op (SecretUpToDate) on re-fetch.
-func handleGetByClassifier(w http.ResponseWriter, r *http.Request, body []byte, gbcRules map[string]map[string]any) {
+func handleGetByClassifier(
+	w http.ResponseWriter, r *http.Request, body []byte,
+	gbcRules map[string]map[string]any, store *dbStore,
+) {
 	m := reGetByClassifier.FindStringSubmatch(r.URL.Path)
 	namespace, dbType := m[1], m[2]
 
@@ -607,9 +676,23 @@ func handleGetByClassifier(w http.ResponseWriter, r *http.Request, body []byte, 
 	}
 
 	props, ok := gbcRules[key]
-	if ok && len(props) > 0 {
+	switch {
+	case ok && len(props) > 0:
 		log.Printf("  → get-by-classifier originService=%q type=%q role=%q → 200 (rule props)", key, dbType, role)
-	} else {
+	case isTenant(req.Classifier) && !store.has(classifierKey(req.Classifier, dbType)):
+		// Tenant database that was never materialized (no get-or-create yet) — the real
+		// aggregator returns DatabaseNotFound. This is the gap the operator's pinned-tenant
+		// materialization closes; without it the claim would wait here forever.
+		log.Printf("  → get-by-classifier originService=%q type=%q tenantId=%v → 404 (tenant database not materialized)",
+			key, dbType, req.Classifier["tenantId"])
+		writeTmfError(w, MockRule{
+			HTTPCode: http.StatusNotFound,
+			TmfCode:  "CORE-DBAAS-4001",
+			Reason:   "Database not found",
+			Message:  "Database not found by classifier and type",
+		})
+		return
+	default:
 		props = defaultConnProps(role)
 		log.Printf("  → get-by-classifier originService=%q type=%q role=%q → 200 (default props)", key, dbType, role)
 	}
@@ -646,6 +729,71 @@ func defaultConnProps(role string) map[string]any {
 		"url":      "jdbc:postgresql://pg.example.com:5432/app_db",
 		"role":     role,
 	}
+}
+
+// handleCreateDatabase serves PUT /api/v3/dbaas/{namespace}/databases — the get-or-create
+// database call the operator issues to materialize a concrete {scope=tenant, tenantId}
+// database for a tenant declaration that pins a tenantId. The response code comes from the
+// per-originService createDbRules rule when present (e.g. to simulate a 500); otherwise the
+// mock returns 200 with a DatabaseResponseV3-shaped body. The operator ignores the body and
+// inspects only the status code, so a minimal descriptor is enough.
+func handleCreateDatabase(
+	w http.ResponseWriter, r *http.Request, body []byte,
+	createDbRules map[string]MockRule, store *dbStore,
+) {
+	m := reCreateDB.FindStringSubmatch(r.URL.Path)
+	namespace := m[1]
+
+	var req struct {
+		Classifier    map[string]any `json:"classifier"`
+		Type          string         `json:"type"`
+		OriginService string         `json:"originService"`
+	}
+	_ = json.Unmarshal(body, &req)
+
+	key := req.OriginService
+	if key == "" {
+		key, _ = req.Classifier["microserviceName"].(string)
+	}
+	tenantID, _ := req.Classifier["tenantId"].(string)
+
+	if rule, ok := createDbRules[key]; ok {
+		log.Printf("  → create database originService=%q tenantId=%q namespace=%q → httpCode=%d (rule)",
+			key, tenantID, namespace, rule.HTTPCode)
+		if rule.HTTPCode >= 400 {
+			writeTmfError(w, rule)
+			return
+		}
+		store.add(classifierKey(req.Classifier, req.Type))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(rule.HTTPCode)
+		writeCreatedDatabase(w, namespace, req.Type, key, tenantID)
+		return
+	}
+
+	store.add(classifierKey(req.Classifier, req.Type))
+	log.Printf("  → create database originService=%q tenantId=%q namespace=%q → 200 (default, recorded)",
+		key, tenantID, namespace)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	writeCreatedDatabase(w, namespace, req.Type, key, tenantID)
+}
+
+// writeCreatedDatabase writes a minimal DatabaseResponseV3-shaped success body for the
+// get-or-create call. The operator does not read it (it checks only the status code); it
+// exists so the mock returns a well-formed JSON object rather than an empty body.
+func writeCreatedDatabase(w http.ResponseWriter, namespace, dbType, originService, tenantID string) {
+	name := originService + "-db"
+	if tenantID != "" {
+		name = originService + "-" + tenantID + "-db"
+	}
+	writeJSON(w, map[string]any{
+		"id":                   "db-" + name,
+		"name":                 name,
+		"namespace":            namespace,
+		"type":                 dbType,
+		"connectionProperties": defaultConnProps("admin"),
+	})
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/dbaas-operator/dev/aggregator-mock/main_test.go
+++ b/dbaas-operator/dev/aggregator-mock/main_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestHandler builds the mock handler with no per-key rules except the given
+// create-db rules, mirroring how the real mock is wired in main().
+func newTestHandler(defaultCode int, createDbRules map[string]MockRule) http.Handler {
+	return handler(MockRule{HTTPCode: defaultCode}, nil, nil, nil, nil, nil, createDbRules)
+}
+
+// tenantCreateBody builds a get-or-create request body for a tenant-scoped database,
+// keeping the test lines short (the inline JSON literal would otherwise trip the
+// line-length linter).
+func tenantCreateBody(t *testing.T, microservice, tenant string) string {
+	t.Helper()
+	classifier := map[string]any{
+		"microserviceName": microservice,
+		"scope":            "tenant",
+		"namespace":        "test-ns",
+	}
+	if tenant != "" {
+		classifier["tenantId"] = tenant
+	}
+	b, err := json.Marshal(map[string]any{
+		"classifier":    classifier,
+		"type":          "postgresql",
+		"originService": microservice,
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return string(b)
+}
+
+const gbcPath = "/api/v3/dbaas/test-ns/databases/get-by-classifier/postgresql"
+
+// gbcReqBody builds a get-by-classifier request body for the given classifier.
+func gbcReqBody(t *testing.T, classifier map[string]any, origin string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"classifier":    classifier,
+		"originService": origin,
+		"userRole":      "admin",
+	})
+	if err != nil {
+		t.Fatalf("marshal gbc body: %v", err)
+	}
+	return string(b)
+}
+
+func doReq(t *testing.T, h http.Handler, method, path, body string, withAuth bool) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	if withAuth {
+		r.SetBasicAuth("operator", "x")
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+// TestCreateDatabase_DefaultSuccess: a tenant get-or-create with no rule returns 200
+// and a well-formed descriptor that echoes the namespace, type, and pinned tenantId.
+func TestCreateDatabase_DefaultSuccess(t *testing.T) {
+	h := newTestHandler(http.StatusOK, nil)
+	body := tenantCreateBody(t, "quarkus-test-app-service", "acme")
+
+	w := doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases", body, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+		Type      string `json:"type"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if resp.Namespace != "test-ns" {
+		t.Errorf("namespace: want test-ns, got %q", resp.Namespace)
+	}
+	if resp.Type != "postgresql" {
+		t.Errorf("type: want postgresql, got %q", resp.Type)
+	}
+	if !strings.Contains(resp.Name, "acme") {
+		t.Errorf("expected tenantId in db name, got %q", resp.Name)
+	}
+}
+
+// TestCreateDatabase_RequiresAuth: an unauthenticated get-or-create is rejected with 401.
+func TestCreateDatabase_RequiresAuth(t *testing.T) {
+	h := newTestHandler(http.StatusOK, nil)
+	w := doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases", `{"type":"postgresql"}`, false)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", w.Code)
+	}
+}
+
+// TestCreateDatabase_ErrorRule: a per-originService error rule is returned as a TMF error,
+// letting the dev environment simulate a materialization failure.
+func TestCreateDatabase_ErrorRule(t *testing.T) {
+	rules := map[string]MockRule{
+		"failing-svc": {HTTPCode: http.StatusInternalServerError, TmfCode: "CORE-DBAAS-5000", Message: "boom"},
+	}
+	h := newTestHandler(http.StatusOK, rules)
+	body := tenantCreateBody(t, "failing-svc", "acme")
+
+	w := doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases", body, true)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "boom") {
+		t.Errorf("expected TMF message in body, got %s", w.Body.String())
+	}
+}
+
+// TestCreateDatabase_RouteIsolation: the bare /databases route must not collide with the
+// longer .../databases/registration/externally_manageable route, and only PUT is accepted.
+func TestCreateDatabase_RouteIsolation(t *testing.T) {
+	// defaultCode 201 lets us tell the two PUT handlers apart: external-db honours the
+	// default (201); create-db has its own fixed 200 default independent of it.
+	h := newTestHandler(http.StatusCreated, nil)
+
+	wExt := doReq(t, h, http.MethodPut,
+		"/api/v3/dbaas/test-ns/databases/registration/externally_manageable",
+		`{"dbName":"x"}`, true)
+	if wExt.Code != http.StatusCreated {
+		t.Errorf("externally_manageable: want 201 (external-db handler), got %d", wExt.Code)
+	}
+
+	wCreate := doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases",
+		`{"type":"postgresql","originService":"svc"}`, true)
+	if wCreate.Code != http.StatusOK {
+		t.Errorf("create-db: want 200 (create-db handler), got %d", wCreate.Code)
+	}
+
+	wGet := doReq(t, h, http.MethodGet, "/api/v3/dbaas/test-ns/databases", "", true)
+	if wGet.Code != http.StatusNotFound {
+		t.Errorf("GET /databases (wrong method): want 404, got %d", wGet.Code)
+	}
+}
+
+// TestGetByClassifier_TenantRequiresMaterialization is the dependency the kind e2e relies on:
+// a tenant database is 404 (DatabaseNotFound) until it is materialized via the get-or-create
+// call, after which the same classifier resolves with 200. This is exactly the gap the
+// operator's pinned-tenant materialization closes for a DatabaseSecretClaim.
+func TestGetByClassifier_TenantRequiresMaterialization(t *testing.T) {
+	h := newTestHandler(http.StatusOK, nil)
+	classifier := map[string]any{
+		"microserviceName": "idb-tenant",
+		"scope":            "tenant",
+		"tenantId":         "acme",
+		"namespace":        "test-ns",
+	}
+
+	// Before materialization → 404.
+	w := doReq(t, h, http.MethodPost, gbcPath, gbcReqBody(t, classifier, "idb-tenant"), true)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("pre-materialize: want 404, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	// Materialize the same {classifier, type} via the get-or-create call.
+	wc := doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases",
+		tenantCreateBody(t, "idb-tenant", "acme"), true)
+	if wc.Code != http.StatusOK {
+		t.Fatalf("create: want 200, got %d", wc.Code)
+	}
+
+	// After materialization → 200.
+	w2 := doReq(t, h, http.MethodPost, gbcPath, gbcReqBody(t, classifier, "idb-tenant"), true)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("post-materialize: want 200, got %d (%s)", w2.Code, w2.Body.String())
+	}
+}
+
+// TestGetByClassifier_ServiceNoMaterializationNeeded asserts the materialization gate is
+// tenant-only: a service classifier resolves with 200 without any prior get-or-create,
+// preserving the behaviour the existing service-scoped dev scenarios depend on.
+func TestGetByClassifier_ServiceNoMaterializationNeeded(t *testing.T) {
+	h := newTestHandler(http.StatusOK, nil)
+	classifier := map[string]any{
+		"microserviceName": "svc",
+		"scope":            "service",
+		"namespace":        "test-ns",
+	}
+	w := doReq(t, h, http.MethodPost, gbcPath, gbcReqBody(t, classifier, "svc"), true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("service get-by-classifier: want 200 (no materialization needed), got %d", w.Code)
+	}
+}

--- a/dbaas-operator/dev/e2e-tenant-materialize.sh
+++ b/dbaas-operator/dev/e2e-tenant-materialize.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# e2e-tenant-materialize.sh — end-to-end check that a tenant-scoped InternalDatabase with a
+# pinned tenantId materializes a concrete tenant database, and a matching DatabaseSecretClaim
+# then resolves that database into a Secret.
+#
+# Prerequisite: the dev environment is up (./dev/kind-up.sh).
+#
+# Flow (against the aggregator-mock, which is stateful for tenant databases):
+#   1. Apply idb-tenant-materialize.yaml — a tenant InternalDatabase pinning tenantId=acme.
+#      Beyond the declarative apply, the operator issues a get-or-create
+#      (PUT /api/v3/dbaas/test-ns/databases) that materializes {scope=tenant, tenantId=acme}.
+#      The mock records that database.
+#   2. Apply dsc-tenant-materialize.yaml — a DatabaseSecretClaim with the SAME classifier.
+#      The operator calls get-by-classifier; the mock returns the database (200) BECAUSE it
+#      was materialized in step 1 (without it the mock answers 404 / DatabaseNotFound and the
+#      claim would wait). The operator writes the Secret dsc-tenant-materialize-secret.
+#
+# Usage:
+#   ./dev/kind-up.sh
+#   ./dev/e2e-tenant-materialize.sh
+#
+# Override the kept-resource cleanup with KEEP=1 to leave the CRs and Secret in place.
+set -euo pipefail
+
+NS="test-ns"
+IDB="idb-tenant-materialize"
+DSC="dsc-tenant-materialize"
+SECRET="dsc-tenant-materialize-secret"
+TENANT="acme"
+MOCK_DEPLOY="deployment/dbaas-aggregator"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗ %s\033[0m\n' "$1"; exit 1; }
+info() { printf '\033[1m%s\033[0m\n' "$1"; }
+
+for bin in kubectl jq base64; do
+  command -v "$bin" >/dev/null 2>&1 || fail "required tool not found: $bin"
+done
+
+info "0. Preconditions"
+kubectl get ns "$NS" >/dev/null 2>&1 || fail "namespace $NS not found — run ./dev/kind-up.sh first"
+kubectl -n dbaas-system get deploy/dbaas-operator >/dev/null 2>&1 \
+  || fail "dbaas-operator not deployed — run ./dev/kind-up.sh first"
+pass "kind dev environment is up"
+
+info "1. Materialize the tenant database (InternalDatabase, tenantId=$TENANT)"
+kubectl apply -f "$SCRIPT_DIR/test-resources/idb-tenant-materialize.yaml" >/dev/null
+if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
+    "internaldatabase/$IDB" -n "$NS" --timeout=90s >/dev/null 2>&1; then
+  pass "InternalDatabase reached Phase=Succeeded"
+else
+  phase=$(kubectl get "internaldatabase/$IDB" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "?")
+  fail "InternalDatabase did not reach Succeeded (phase=$phase)"
+fi
+
+# Confirm the operator issued the get-or-create (materialization) call to the mock.
+if kubectl logs -n dbaas-system "$MOCK_DEPLOY" 2>/dev/null \
+    | grep -qE "create database .*tenantId=\"$TENANT\""; then
+  pass "mock saw the get-or-create call for tenantId=$TENANT (database materialized)"
+else
+  fail "mock did NOT log the get-or-create call — tenant database was not materialized"
+fi
+
+info "2. Claim resolves the tenant database into a Secret"
+kubectl apply -f "$SCRIPT_DIR/test-resources/dsc-tenant-materialize.yaml" >/dev/null
+if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
+    "databasesecretclaim/$DSC" -n "$NS" --timeout=90s >/dev/null 2>&1; then
+  pass "DatabaseSecretClaim reached Phase=Succeeded"
+else
+  phase=$(kubectl get "databasesecretclaim/$DSC" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "?")
+  fail "DatabaseSecretClaim did not reach Succeeded (phase=$phase) — get-by-classifier likely 404 (DB not materialized)"
+fi
+
+kubectl get "secret/$SECRET" -n "$NS" >/dev/null 2>&1 || fail "Secret $SECRET was not created"
+meta="$(kubectl get "secret/$SECRET" -n "$NS" -o jsonpath='{.data.metadata\.json}' | base64 -d)"
+echo "    metadata.json .classifier = $(echo "$meta" | jq -c '.classifier')"
+echo "$meta" | jq -e ".classifier.scope == \"tenant\" and .classifier.tenantId == \"$TENANT\" and .classifier.microserviceName == \"idb-tenant\"" >/dev/null \
+  || fail "Secret descriptor classifier is not the expected tenant identity"
+pass "Secret carries the tenant classifier (scope=tenant, tenantId=$TENANT)"
+
+info "RESULT: PASS — tenant InternalDatabase materialized the database; the claim resolved it into a Secret"
+
+if [ "${KEEP:-0}" != "1" ]; then
+  kubectl delete -f "$SCRIPT_DIR/test-resources/dsc-tenant-materialize.yaml" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete -f "$SCRIPT_DIR/test-resources/idb-tenant-materialize.yaml" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete "secret/$SECRET" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+fi

--- a/dbaas-operator/dev/k8s/mock-aggregator.yaml
+++ b/dbaas-operator/dev/k8s/mock-aggregator.yaml
@@ -154,6 +154,19 @@ data:
         "role": "admin"
       }
     }
+  # Per-originService response rules for the get-or-create database call
+  # PUT /api/v3/dbaas/{ns}/databases — the operator's pinned-tenant materialization
+  # for a tenant InternalDatabase. Falls back to 200 (success) when no rule matches;
+  # the rule below is illustrative, to simulate a materialization failure on demand.
+  create-db-rules.json: |
+    {
+      "tenant-svc-500": {
+        "httpCode": 500,
+        "tmfCode": "CORE-DBAAS-2000",
+        "reason": "Unexpected exception",
+        "message": "Unexpected exception"
+      }
+    }
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -194,6 +207,8 @@ spec:
               value: /config/changed.json
             - name: MOCK_GETBYCLASSIFIER_FILE
               value: /config/get-by-classifier.json
+            - name: MOCK_CREATEDB_RULES_FILE
+              value: /config/create-db-rules.json
           volumeMounts:
             - name: rules
               mountPath: /config

--- a/dbaas-operator/dev/test-resources/dsc-tenant-materialize.yaml
+++ b/dbaas-operator/dev/test-resources/dsc-tenant-materialize.yaml
@@ -1,0 +1,28 @@
+# DatabaseSecretClaim — tenant scope; materializes a Secret from the tenant database
+# that idb-tenant-materialize.yaml provisions.
+#
+# The claim's classifier matches idb-tenant-materialize's:
+#   {microserviceName: idb-tenant, scope: tenant, tenantId: acme, namespace: test-ns}.
+# The operator calls get-by-classifier; the mock returns the tenant database ONLY because
+# the InternalDatabase materialized it first via the get-or-create call — otherwise it
+# answers 404 (DatabaseNotFound) and the claim waits. On 200 the operator writes the Secret
+# "dsc-tenant-materialize-secret".
+#
+# The app.kubernetes.io/name label is REQUIRED — its value is sent as originService.
+# See dev/e2e-tenant-materialize.sh for the end-to-end check.
+apiVersion: dbaas.netcracker.com/v1
+kind: DatabaseSecretClaim
+metadata:
+  name: dsc-tenant-materialize
+  namespace: test-ns
+  labels:
+    app.kubernetes.io/name: idb-tenant
+spec:
+  type: postgresql
+  userRole: admin
+  secretName: dsc-tenant-materialize-secret
+  classifier:
+    microserviceName: idb-tenant
+    scope: tenant
+    tenantId: acme
+    namespace: test-ns

--- a/dbaas-operator/dev/test-resources/idb-tenant-materialize.yaml
+++ b/dbaas-operator/dev/test-resources/idb-tenant-materialize.yaml
@@ -1,0 +1,17 @@
+# InternalDatabase — tenant scope with a pinned tenantId.
+# Beyond the declarative apply, the controller issues a get-or-create
+# (PUT /api/v3/dbaas/{ns}/databases) to materialize the concrete
+# {scope=tenant, tenantId=acme} database, so a matching DatabaseSecretClaim
+# would resolve. The mock returns 200 for the get-or-create by default.
+# Expected: Phase=Succeeded; mock logs show one "create database ... tenantId=acme" line.
+apiVersion: dbaas.netcracker.com/v1
+kind: InternalDatabase
+metadata:
+  name: idb-tenant-materialize
+  namespace: test-ns
+spec:
+  classifier:
+      microserviceName: idb-tenant
+      scope: tenant
+      tenantId: acme
+  type: postgresql

--- a/dbaas-operator/docs/howto/DBaaS Operator.md
+++ b/dbaas-operator/docs/howto/DBaaS Operator.md
@@ -38,6 +38,7 @@
   - [InternalDatabase](#internaldatabase)
     - [Resource Fields](#internaldatabase-resource-fields)
     - [How It Works](#how-internaldatabase-works)
+    - [Tenant database materialization](#tenant-database-materialization)
     - [Status Reference](#internaldatabase-status-reference)
     - [Usage Examples](#internaldatabase-usage-examples)
   - [Balancing Rule CRDs](#balancing-rule-crds)
@@ -127,6 +128,7 @@ The operator calls the following dbaas-aggregator endpoints:
 | `PUT` | `/api/v3/dbaas/{namespace}/databases/registration/externally_manageable` | `ExternalDatabase` reconciler | Register or update an externally managed database |
 | `POST` | `/api/declarations/v1/apply` | `DatabaseAccessPolicy` and `InternalDatabase` reconcilers | Apply a declarative database role policy (`subKind=DbPolicy`) or database declaration (`subKind=DatabaseDeclaration`) |
 | `GET` | `/api/declarations/v1/operation/{trackingId}/status` | `InternalDatabase` reconciler | Poll the status of an asynchronous provisioning operation |
+| `PUT` | `/api/v3/dbaas/{namespace}/databases` | `InternalDatabase` reconciler (tenant declarations with a pinned `tenantId`) | Get-or-create the concrete `{scope=tenant, tenantId}` database after the declarative apply — see [Tenant database materialization](#tenant-database-materialization) |
 | `POST` | `/api/v3/dbaas/{namespace}/databases/get-by-classifier/{type}` | `DatabaseSecretClaim` reconciler (and rotation-poller fan-out) | Fetch the connection properties of a registered database |
 | `PUT` | `/api/v3/dbaas/{namespace}/physical_databases/rules/onMicroservices` | `MicroserviceBalancingRule` reconciler | Apply the microservice balancing rule set for a business namespace |
 | `PUT` | `/api/v3/dbaas/{namespace}/physical_databases/balancing/rules/{ruleName}` | `NamespaceBalancingRule` reconciler | Create or update one named namespace balancing rule |
@@ -1177,7 +1179,7 @@ spec:
 | `microserviceName` | Yes | Name of the owning microservice |
 | `scope` | Yes | `service` or `tenant` |
 | `namespace` | No | If set, must equal `metadata.namespace` — controller-side validation; mismatch causes `InvalidConfiguration`/`InvalidSpec`. If absent, the aggregator uses `metadata.namespace` from the request |
-| `tenantId` | No | Only meaningful when `scope=tenant`. When absent, the aggregator applies the declaration for every tenant already registered in the namespace |
+| `tenantId` | No | Only meaningful when `scope=tenant`. **When absent**, the declaration is a tenant-agnostic template — the aggregator applies it to tenants already registered in the namespace and materializes a per-tenant database lazily, on each tenant's first runtime connection. **When set**, the operator additionally eagerly materializes that concrete tenant's database after the declarative apply — see [Tenant database materialization](#tenant-database-materialization) |
 | `customKeys` | No | Adapter-specific identifiers, emitted as a **nested** `customKeys` object on the wire (`classifier.customKeys.*`). Values can be any JSON type (string, number, boolean, nested object). Not validated by the aggregator — passed through as-is |
 | `extraKeys` | No | Arbitrary additional identity fields **flattened onto the classifier top level** (legacy open-classifier compatibility). The reserved keys `microserviceName`, `scope`, `namespace`, `tenantId`, `customKeys` are not allowed — the controller rejects the spec with `InvalidConfiguration`. Both the operator and every consuming dbaas-client must produce the same keys/values for identity to match |
 
@@ -1262,6 +1264,32 @@ CR created / spec changed
                                 └─────────────────────────┘
 ```
 
+> For a `scope=tenant` declaration that pins a `tenantId`, the **Succeeded** transition (both the
+> `200 OK` and `COMPLETED` paths) is preceded by a get-or-create that materializes the concrete
+> tenant database — see [Tenant database materialization](#tenant-database-materialization) below.
+
+#### Tenant database materialization
+
+A `scope=tenant` declaration is, by default, a **tenant-agnostic template**: the aggregator drops `tenantId` when it stores a tenant declaration and provisions a concrete per-tenant database only when that tenant first connects at runtime (plus for tenants already registered in the namespace). A freshly declared tenant that has never connected therefore has **no database** — and a `DatabaseSecretClaim` for `{scope=tenant, tenantId}` would call the [connection-lookup endpoint](#databasesecretclaim-connection-lookup-endpoint), get `DatabaseNotFound`, and wait indefinitely.
+
+When the classifier **pins a concrete `tenantId`**, the operator closes that gap. After the declarative apply succeeds — on both the synchronous `200 OK` and the asynchronous `COMPLETED` paths — and **before** marking the CR `Succeeded`, it issues a get-or-create for that exact tenant database:
+
+```
+PUT /api/v3/dbaas/{namespace}/databases
+  {
+    "classifier": { …, "scope": "tenant", "tenantId": "<tenantId>" },
+    "type": "<type>",
+    "originService": "<microserviceName>"
+  }
+```
+
+This materializes the database exactly as the tenant's first runtime connection would, so a matching `DatabaseSecretClaim` resolves immediately instead of waiting on `DatabaseNotFound`. The call is:
+
+- **scoped** — a no-op for `scope=service`, or for a tenant declaration **without** a pinned `tenantId` (the tenant-agnostic template behaviour is unchanged);
+- **idempotent** — get-or-create returns the existing database on subsequent reconciles;
+- **gating** — if it fails, the CR does **not** become `Succeeded`: a transient/5xx failure surfaces as `BackingOff` and is retried on the next reconcile, exactly like the `apply` call;
+- **observable** — recorded on `dbaas_aggregator_requests_total` and `dbaas_aggregator_request_duration_seconds` under `operation="create_database"`.
+
 #### InternalDatabase Status Reference
 
 **`status.phase`** — human-readable summary for `kubectl get dbidb`.
@@ -1338,6 +1366,24 @@ spec:
     scope: service
   type: postgresql
 ```
+
+**Tenant-scoped with a pinned `tenantId` (eager materialization):**
+
+```yaml
+apiVersion: dbaas.netcracker.com/v1
+kind: InternalDatabase
+metadata:
+  name: my-app-db-acme
+  namespace: my-namespace
+spec:
+  classifier:
+    microserviceName: my-service
+    scope: tenant
+    tenantId: acme        # operator materializes this concrete tenant's database after apply
+  type: postgresql
+```
+
+After the declarative apply, the operator get-or-creates the `{scope=tenant, tenantId: acme}` database, so a `DatabaseSecretClaim` with the same classifier resolves without waiting on `DatabaseNotFound` — see [Tenant database materialization](#tenant-database-materialization).
 
 **Clone from an existing database:**
 

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -230,9 +230,13 @@ The dashboard is organised into rows that mirror the metric groups above.
 
 **`operation`** (which aggregator call):
 `register_external_database`, `apply_config`, `poll_status`, `get_database_by_classifier`,
-`apply_microservice_balancing_rule`, `cleanup_microservice_balancing_rule`,
+`create_database`, `apply_microservice_balancing_rule`, `cleanup_microservice_balancing_rule`,
 `apply_namespace_balancing_rule`, `delete_namespace_balancing_rule`,
 `apply_permanent_balancing_rule`, `delete_permanent_balancing_rule`.
+
+`create_database` is the get-or-create call (`PUT /api/v3/dbaas/{ns}/databases`) the
+`InternalDatabase` controller issues to eagerly materialize the concrete
+`{scope=tenant, tenantId}` database for a tenant declaration that pins a `tenantId`.
 
 **`result`** (aggregator call outcome — `dbaas_aggregator_requests_total`):
 

--- a/dbaas-operator/internal/client/aggregator_client.go
+++ b/dbaas-operator/internal/client/aggregator_client.go
@@ -243,6 +243,19 @@ func (c *AggregatorClient) RegisterExternalDatabase(ctx context.Context, namespa
 	return err
 }
 
+// CreateDatabase materializes (get-or-create) a logical database for the given classifier at
+// PUT /api/v3/dbaas/{namespace}/databases — the same call a microservice's dbaas client makes at
+// runtime. The operator uses it to eagerly create a concrete {scope=tenant, tenantId} database that
+// the declarative tenant InternalDatabase does not materialize on its own. The call is synchronous
+// for the postgresql-family adapters used here (the response body — the database descriptor — is not
+// needed, only the success status). Returns *AggregatorError on non-2xx.
+func (c *AggregatorClient) CreateDatabase(ctx context.Context, namespace string, req *CreateDatabaseRequest) error {
+	_, err := c.doRequest(ctx, http.MethodPut,
+		fmt.Sprintf("/api/v3/dbaas/%s/databases", namespace), req, nil,
+		http.StatusOK, http.StatusCreated)
+	return err
+}
+
 // ApplyMicroserviceBalancingRules sends on-microservice balancing rules to
 // PUT /api/v3/dbaas/{namespace}/physical_databases/rules/onMicroservices.
 func (c *AggregatorClient) ApplyMicroserviceBalancingRules(ctx context.Context, namespace string, req []OnMicroserviceRuleRequest) error {

--- a/dbaas-operator/internal/client/types.go
+++ b/dbaas-operator/internal/client/types.go
@@ -97,6 +97,17 @@ type ExternalDatabaseRequest struct {
 	UpdateConnectionProperties bool                `json:"updateConnectionProperties,omitempty"`
 }
 
+// CreateDatabaseRequest is the body for PUT /api/v3/dbaas/{namespace}/databases — the
+// get-or-create call a microservice's dbaas client makes at runtime. The operator uses it to
+// eagerly materialize a concrete {scope=tenant, tenantId} database that a declarative tenant
+// InternalDatabase does not create on its own. Classifier carries the full identity
+// (microserviceName, namespace, scope, tenantId, …) as map[string]any to preserve wire fidelity.
+type CreateDatabaseRequest struct {
+	Classifier    map[string]any `json:"classifier"`
+	Type          string         `json:"type"`
+	OriginService string         `json:"originService,omitempty"`
+}
+
 // OnMicroserviceRuleRequest is the request item for
 // PUT /api/v3/dbaas/{namespace}/physical_databases/rules/onMicroservices.
 type OnMicroserviceRuleRequest struct {

--- a/dbaas-operator/internal/controller/internaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -176,6 +177,10 @@ func (r *InternalDatabaseReconciler) reconcileSubmit(ctx context.Context, dd *db
 
 	// HTTP 200 OK — synchronous completion.
 	log.InfoC(ctx, "database provisioned synchronously. microserviceName = %v", dd.Spec.Classifier.MicroserviceName)
+	if err := r.materializeTenantDatabaseIfPinned(ctx, dd); err != nil {
+		log.ErrorC(ctx, "failed to materialize pinned tenant database: %v", err)
+		return handleAggregatorError(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, r.Recorder, dd, err, requestID)
+	}
 	markSucceeded(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, EventReasonDatabaseProvisioned)
 	r.Recorder.Eventf(dd, corev1.EventTypeNormal, EventReasonDatabaseProvisioned,
 		"database provisioned synchronously (microserviceName=%s)",
@@ -218,6 +223,31 @@ func (r *InternalDatabaseReconciler) buildPayload(dd *dbaasv1.InternalDatabase) 
 		},
 		Spec: toWireSpec(dd.Spec, dd.Namespace),
 	}
+}
+
+// materializeTenantDatabaseIfPinned eagerly creates the concrete {scope=tenant, tenantId} database for
+// a tenant-scoped InternalDatabase that pins an explicit tenantId. The declarative apply only registers
+// a tenant-agnostic template: the aggregator drops tenantId from a tenant declaration and materializes
+// per-tenant databases only for tenants that already exist, so a freshly declared, never-yet-connected
+// tenant has no database. Without this, a DatabaseSecretClaim for {scope=tenant, tenantId} does a
+// read-only get-by-classifier and waits forever (DatabaseNotFound). Calling the get-or-create database
+// API materializes the database exactly as the first runtime tenant connection would, after which the
+// claim resolves. No-op for service scope or a tenant declaration without a pinned tenantId.
+func (r *InternalDatabaseReconciler) materializeTenantDatabaseIfPinned(ctx context.Context, dd *dbaasv1.InternalDatabase) error {
+	if !strings.EqualFold(dd.Spec.Classifier.Scope, "tenant") || dd.Spec.Classifier.TenantId == "" {
+		return nil
+	}
+	req := &aggregatorclient.CreateDatabaseRequest{
+		Classifier:    dbaasv1.ClassifierFlatMap(dbaasv1.EffectiveClassifier(dd.Spec.Classifier, dd.Namespace)),
+		Type:          dd.Spec.Type,
+		OriginService: dd.Spec.Classifier.MicroserviceName,
+	}
+	log.InfoC(ctx, "materializing pinned tenant database tenantId=%v microserviceName=%v",
+		dd.Spec.Classifier.TenantId, dd.Spec.Classifier.MicroserviceName)
+	start := time.Now()
+	err := r.Aggregator.CreateDatabase(ctx, dd.Namespace, req)
+	recordAggregatorCall(controllerIDB, operationCreateDatabase, start, err)
+	return err
 }
 
 // toWireSpec converts a InternalDatabaseSpec (CRD shape) into the wire format
@@ -452,6 +482,10 @@ func (r *InternalDatabaseReconciler) handlePollResponse(
 			trackingID, dd.Spec.Classifier.MicroserviceName)
 		clearPendingOperation(dd)
 		r.observeAsyncCompletion(dd, resultSuccess)
+		if err := r.materializeTenantDatabaseIfPinned(ctx, dd); err != nil {
+			log.ErrorC(ctx, "failed to materialize pinned tenant database: %v", err)
+			return handleAggregatorError(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, r.Recorder, dd, err, requestID)
+		}
 		markSucceeded(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, EventReasonDatabaseProvisioned)
 		r.Recorder.Eventf(dd, corev1.EventTypeNormal, EventReasonDatabaseProvisioned,
 			"database provisioned (microserviceName=%s, trackingId=%s)",

--- a/dbaas-operator/internal/controller/internaldatabase_controller_test.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller_test.go
@@ -56,15 +56,19 @@ var _ = Describe("InternalDatabase Controller", func() {
 	)
 
 	var (
-		applyCode         int
-		applyBody         string
-		pollCode          int
-		pollBody          string
-		capturedApplyBody []byte
-		mockServer        *httptest.Server
-		reconciler        *InternalDatabaseReconciler
-		fakeRecorder      *record.FakeRecorder
-		namespacedName    types.NamespacedName
+		applyCode          int
+		applyBody          string
+		pollCode           int
+		pollBody           string
+		capturedApplyBody  []byte
+		createCode         int
+		capturedCreateBody []byte
+		createPath         string
+		createReqCount     int
+		mockServer         *httptest.Server
+		reconciler         *InternalDatabaseReconciler
+		fakeRecorder       *record.FakeRecorder
+		namespacedName     types.NamespacedName
 	)
 
 	// baseSpec returns a minimal valid InternalDatabase spec.
@@ -84,6 +88,10 @@ var _ = Describe("InternalDatabase Controller", func() {
 		pollCode = http.StatusOK
 		pollBody = statusCompleted
 		capturedApplyBody = nil
+		createCode = http.StatusOK
+		capturedCreateBody = nil
+		createPath = ""
+		createReqCount = 0
 
 		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -102,6 +110,18 @@ var _ = Describe("InternalDatabase Controller", func() {
 				if pollBody != "" {
 					_, _ = w.Write([]byte(pollBody))
 				}
+				return
+			}
+
+			// get-or-create database: PUT /api/v3/dbaas/{namespace}/databases — the
+			// pinned-tenant materialization call. Match the exact suffix so the
+			// externally_manageable registration path (…/databases/registration/…)
+			// does not collide.
+			if r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/databases") {
+				capturedCreateBody, _ = io.ReadAll(r.Body)
+				createPath = r.URL.Path
+				createReqCount++
+				w.WriteHeader(createCode)
 				return
 			}
 
@@ -344,6 +364,118 @@ var _ = Describe("InternalDatabase Controller", func() {
 
 			expectRecordedEvent(fakeRecorder.Events, corev1.EventTypeWarning, EventReasonInvalidSpec)
 			expectNoRecordedEvent(fakeRecorder.Events)
+		})
+	})
+
+	// ── pinned-tenant database materialization ───────────────────────────────
+	// A tenant-scoped InternalDatabase that pins an explicit tenantId must, after the
+	// declarative apply, also get-or-create the concrete {scope=tenant, tenantId} database
+	// (PUT /api/v3/dbaas/{ns}/databases) so a matching DatabaseSecretClaim resolves. Service
+	// scope and tenant-without-tenantId must NOT trigger that extra call.
+
+	tenantSpec := func(tenantID string) dbaasv1.InternalDatabaseSpec {
+		spec := baseSpec()
+		spec.Classifier.Scope = "tenant"
+		spec.Classifier.TenantId = tenantID
+		return spec
+	}
+
+	Context("scope=tenant with a pinned tenantId (synchronous apply)", func() {
+		It("materializes the concrete tenant database via PUT /databases and succeeds", func() {
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       tenantSpec("acme"),
+			})).To(Succeed())
+
+			dd, result, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
+
+			Expect(createReqCount).To(Equal(1), "pinned tenant must be materialized exactly once")
+			Expect(createPath).To(Equal("/api/v3/dbaas/" + ns + "/databases"))
+
+			var sent struct {
+				Classifier    map[string]any `json:"classifier"`
+				Type          string         `json:"type"`
+				OriginService string         `json:"originService"`
+			}
+			Expect(json.Unmarshal(capturedCreateBody, &sent)).To(Succeed())
+			Expect(sent.Type).To(Equal("postgresql"))
+			Expect(sent.OriginService).To(Equal("test-service"))
+			Expect(sent.Classifier["scope"]).To(Equal("tenant"))
+			Expect(sent.Classifier["tenantId"]).To(Equal("acme"))
+			Expect(sent.Classifier["microserviceName"]).To(Equal("test-service"))
+			Expect(sent.Classifier["namespace"]).To(Equal(ns))
+		})
+	})
+
+	Context("scope=tenant with a pinned tenantId (asynchronous apply)", func() {
+		It("materializes the tenant database only after the async operation completes", func() {
+			applyCode = http.StatusAccepted
+			applyBody = `{"status":"IN_PROGRESS","trackingId":"trk-1"}`
+
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       tenantSpec("acme"),
+			})).To(Succeed())
+
+			// First reconcile: async submit (202) — must NOT materialize yet.
+			dd, result, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(pollRequeueAfter))
+			Expect(dd.Status.TrackingID).To(Equal("trk-1"))
+			Expect(createReqCount).To(Equal(0), "must not materialize before provisioning completes")
+
+			// Second reconcile: poll returns COMPLETED (BeforeEach default) — now materialize.
+			dd, _, err = reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
+			Expect(createReqCount).To(Equal(1))
+		})
+	})
+
+	Context("scope=service", func() {
+		It("succeeds without any get-or-create call", func() {
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       baseSpec(),
+			})).To(Succeed())
+
+			dd, _, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
+			Expect(createReqCount).To(Equal(0), "service scope must not materialize a tenant database")
+		})
+	})
+
+	Context("scope=tenant without a pinned tenantId (tenant-agnostic template)", func() {
+		It("succeeds without any get-or-create call", func() {
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       tenantSpec(""),
+			})).To(Succeed())
+
+			dd, _, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
+			Expect(createReqCount).To(Equal(0), "a tenant template without a pinned tenantId must not materialize")
+		})
+	})
+
+	Context("scope=tenant with a pinned tenantId — materialization fails", func() {
+		It("does not mark Succeeded and requeues with an error", func() {
+			createCode = http.StatusInternalServerError
+
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       tenantSpec("acme"),
+			})).To(Succeed())
+
+			dd, _, err := reconcileAndFetch()
+			Expect(err).To(HaveOccurred())
+			Expect(createReqCount).To(Equal(1))
+			Expect(dd.Status.Phase).NotTo(Equal(dbaasv1.PhaseSucceeded))
 		})
 	})
 

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -62,10 +62,11 @@ const (
 	secretReasonForbidden  = "forbidden"
 	secretReasonReadFailed = "secret_read_failed"
 
-	operationRegisterEDB = "register_external_database"
-	operationApplyConfig = "apply_config"
-	operationPollStatus  = "poll_status"
-	operationGetDatabase = "get_database_by_classifier"
+	operationRegisterEDB    = "register_external_database"
+	operationApplyConfig    = "apply_config"
+	operationPollStatus     = "poll_status"
+	operationGetDatabase    = "get_database_by_classifier"
+	operationCreateDatabase = "create_database"
 
 	operationApplyMicroserviceRule   = "apply_microservice_balancing_rule"
 	operationCleanupMicroserviceRule = "cleanup_microservice_balancing_rule"

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/OperatorHelper.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/OperatorHelper.java
@@ -317,6 +317,24 @@ public class OperatorHelper {
             String expectedType,
             String expectedUserRole
     ) {
+        assertSecretContainsMetadata(secret, expectedMicroserviceName, expectedNamespace,
+                expectedType, expectedUserRole, "service", null);
+    }
+
+    /**
+     * Tenant-aware variant of {@link #assertSecretContainsMetadata(Secret, String, String, String, String)}:
+     * asserts classifier.scope == expectedScope and, when expectedTenantId is non-null,
+     * classifier.tenantId == expectedTenantId.
+     */
+    public static void assertSecretContainsMetadata(
+            Secret secret,
+            String expectedMicroserviceName,
+            String expectedNamespace,
+            String expectedType,
+            String expectedUserRole,
+            String expectedScope,
+            String expectedTenantId
+    ) {
         assertNotNull(secret.getData(), "Secret data must not be null");
         assertTrue(
                 secret.getData().containsKey(METADATA_KEY),
@@ -342,8 +360,12 @@ public class OperatorHelper {
                 "metadata.classifier.microserviceName");
         assertEquals(expectedNamespace, classifier.path("namespace").asText(),
                 "metadata.classifier.namespace");
-        assertEquals("service", classifier.path("scope").asText(),
+        assertEquals(expectedScope, classifier.path("scope").asText(),
                 "metadata.classifier.scope");
+        if (expectedTenantId != null) {
+            assertEquals(expectedTenantId, classifier.path("tenantId").asText(),
+                    "metadata.classifier.tenantId");
+        }
 
         if (expectedUserRole == null || expectedUserRole.isBlank()) {
             assertFalse(meta.has("userRole"),
@@ -429,6 +451,19 @@ public class OperatorHelper {
         }
 
         cr.setAdditionalProperty("spec", specBody);
+        return cr;
+    }
+
+    /**
+     * Marks an InternalDatabase / DatabaseSecretClaim / ExternalDatabase CR as tenant-scoped:
+     * sets spec.classifier.scope=tenant and spec.classifier.tenantId. Returns the same CR for chaining.
+     */
+    @SuppressWarnings("unchecked")
+    public static GenericKubernetesResource asTenant(GenericKubernetesResource cr, String tenantId) {
+        Map<String, Object> spec = (Map<String, Object>) cr.getAdditionalProperties().get("spec");
+        Map<String, Object> classifier = (Map<String, Object>) spec.get("classifier");
+        classifier.put("scope", "tenant");
+        classifier.put("tenantId", tenantId);
         return cr;
     }
 

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/OperatorIT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/OperatorIT.java
@@ -1516,6 +1516,336 @@ public class OperatorIT extends AbstractIT {
                 }
             }
 
+            // Tenant counterpart of DatabaseSecretClaim: the same flows with a tenant-scoped
+            // classifier (scope=tenant + a per-test tenantId). The InternalDatabase-backed cases
+            // (Created/ApplyRotation/RotationFanOut) additionally exercise the operator's
+            // pinned-tenant materialization — without it the concrete {scope=tenant, tenantId}
+            // database is never created and the claim stays on DatabaseNotFound.
+            @Nested
+            @EnableExtension
+            class DatabaseSecretClaimTenant {
+                @Test
+                void testDatabaseSecretClaimTenantCreatedSuccessfully() throws IOException {
+                    String internalDatabaseCRName = generateName();
+                    String dbSecretCRName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+
+                    var internalDatabaseCR = asTenant(
+                            buildInternalDatabaseCR(internalDatabaseCRName, microserviceName, NAMESPACE, POSTGRES_TYPE), tenantId);
+                    createCR(CRD_INTERNAL_DATABASE, internalDatabaseCR);
+                    waitForDesiredState(CRD_INTERNAL_DATABASE, internalDatabaseCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE);
+
+                    var tenantClassifier = new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build();
+                    var expectedConnections = helperV3.getDatabaseByClassifierAsPOJO(helperV3.getClusterDbaAuthorization(), tenantClassifier, NAMESPACE, POSTGRES_TYPE, 200).getConnectionProperties();
+
+                    var databaseSecretCR = asTenant(
+                            buildDatabaseSecretClaimCR(dbSecretCRName, microserviceName, microserviceName, NAMESPACE, secretName, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var secret = getSecret(secretName);
+                    assertSecretOwnedByCR(secret, createdDatabaseSecretClaimCR);
+                    assertSecretContainsConnectionProperties(secret, CONNECTION_PROPERTIES_KEY, expectedConnections);
+                    // userRole is empty in this CR → descriptor must omit it; scope/tenantId must be carried.
+                    assertSecretContainsMetadata(secret, microserviceName, NAMESPACE, POSTGRES_TYPE, "", "tenant", tenantId);
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantDbNotExist() throws IOException {
+                    String crName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+                    var tenantClassifier = new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build();
+
+                    helperV3.getDatabaseByClassifierAsPOJO(helperV3.getClusterDbaAuthorization(),
+                            tenantClassifier, NAMESPACE, POSTGRES_TYPE, 404);
+
+                    var databaseSecretCR = asTenant(
+                            buildDatabaseSecretClaimCR(crName, microserviceName, microserviceName, NAMESPACE, secretName, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_BACKING_OFF, STATUS_FALSE, REASON_DATABASE_NOT_FOUND, STATUS_FALSE);
+
+                    assertNull(getSecret(secretName));
+
+                    var expectedConnections = helperV3.createDatabase(tenantClassifier, POSTGRES_TYPE, 201).getConnectionProperties();
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var secret = getSecret(secretName);
+                    assertSecretOwnedByCR(secret, createdDatabaseSecretClaimCR);
+                    assertSecretContainsConnectionProperties(secret, CONNECTION_PROPERTIES_KEY, expectedConnections);
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantCascadeDeleting() throws IOException {
+                    String crName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+
+                    helperV3.createDatabase(new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build(), POSTGRES_TYPE, 201);
+
+                    var databaseSecretCR = asTenant(
+                            buildDatabaseSecretClaimCR(crName, microserviceName, microserviceName, NAMESPACE, secretName, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var secret = getSecret(secretName);
+                    assertSecretOwnedByCR(secret, createdDatabaseSecretClaimCR);
+
+                    kubernetesClient.genericKubernetesResources(CRD_DATABASE_SECRET_CLAIM)
+                            .withName(crName)
+                            .delete();
+
+                    var deletedDatabaseSecretClaimCR = kubernetesClient.genericKubernetesResources(CRD_DATABASE_SECRET_CLAIM)
+                            .inNamespace(NAMESPACE)
+                            .withName(crName)
+                            .delete();
+                    assertTrue(deletedDatabaseSecretClaimCR.isEmpty());
+
+                    waitForSecretDeleted(secretName);
+                    assertNull(getSecret(secretName));
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantApplyDatabaseAccessPolicy() throws IOException {
+                    String dbSecretCrName = generateName();
+                    String databaseAccessPolicyCrName = generateName();
+                    String microserviceName = generateName();
+                    String originService = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+
+                    var expectedConnections = helperV3.createDatabase(
+                            new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build(),
+                            POSTGRES_TYPE, 201
+                    ).getConnectionProperties();
+
+                    var databaseSecretCR = asTenant(
+                            buildDatabaseSecretClaimCR(dbSecretCrName, originService, microserviceName, NAMESPACE, secretName, "admin", POSTGRES_TYPE), tenantId);
+                    var failedDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, failedDatabaseSecretClaimCR, PHASE_INVALID_CONFIGURATION, STATUS_FALSE, REASON_AGGREGATOR_REJECTED, STATUS_TRUE);
+                    assertNull(getSecret(secretName));
+
+                    kubernetesClient.genericKubernetesResources(CRD_DATABASE_SECRET_CLAIM)
+                            .withName(dbSecretCrName)
+                            .delete();
+
+                    OperatorIT.this.testDatabaseAccessPolicyOnlyServicesSet(databaseAccessPolicyCrName, microserviceName, originService, List.of("admin"));
+                    var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+                    var secret = getSecret(secretName);
+                    assertSecretContainsConnectionProperties(secret, CONNECTION_PROPERTIES_KEY, expectedConnections);
+                    // userRole "admin" is requested in this CR → descriptor must carry it, plus scope/tenantId.
+                    assertSecretContainsMetadata(secret, microserviceName, NAMESPACE, POSTGRES_TYPE, "admin", "tenant", tenantId);
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantApplyRotation() throws IOException {
+                    String internalDatabaseCRName = generateName();
+                    String dbSecretCRName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+                    var classifier = new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build();
+
+                    var internalDatabaseCR = asTenant(
+                            buildInternalDatabaseCR(internalDatabaseCRName, microserviceName, NAMESPACE, POSTGRES_TYPE), tenantId);
+                    createCR(CRD_INTERNAL_DATABASE, internalDatabaseCR);
+                    waitForDesiredState(CRD_INTERNAL_DATABASE, internalDatabaseCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE);
+
+                    var databaseSecretCR = asTenant(
+                            buildDatabaseSecretClaimCR(dbSecretCRName, microserviceName, microserviceName, NAMESPACE, secretName, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var secretBefore = getSecret(secretName);
+                    assertNotNull(secretBefore, "secret must exist");
+                    var passwordBefore = extractPasswordFromSecret(secretBefore);
+
+                    helperV3.changePassword(classifier, POSTGRES_TYPE, 200, NAMESPACE);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_ROTATED, STATUS_FALSE);
+
+                    var secretAfter = getSecret(secretName);
+                    assertNotNull(secretAfter, "secret must exist after rotation");
+                    var passwordAfter = extractPasswordFromSecret(secretAfter);
+
+                    assertNotEquals(passwordBefore, passwordAfter, "password must change after rotation");
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantRotationFanOutToSameClassifier() throws IOException {
+                    String internalDatabaseCRName = generateName();
+                    String dbSecretCRName1 = generateName();
+                    String dbSecretCRName2 = generateName();
+                    String microserviceName = generateName();
+                    String secretName1 = generateName();
+                    String secretName2 = generateName();
+                    String tenantId = generateName();
+                    var classifier = new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build();
+
+                    var internalDatabaseCR = asTenant(
+                            buildInternalDatabaseCR(internalDatabaseCRName, microserviceName, NAMESPACE, POSTGRES_TYPE), tenantId);
+                    createCR(CRD_INTERNAL_DATABASE, internalDatabaseCR);
+                    waitForDesiredState(CRD_INTERNAL_DATABASE, internalDatabaseCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_PROVISIONED, STATUS_FALSE);
+
+                    var databaseSecretCR1 = asTenant(
+                            buildDatabaseSecretClaimCR(dbSecretCRName1, microserviceName, microserviceName, NAMESPACE, secretName1, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR1 = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR1);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR1, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var databaseSecretCR2 = asTenant(
+                            buildDatabaseSecretClaimCR(dbSecretCRName2, microserviceName, microserviceName, NAMESPACE, secretName2, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR2 = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR2);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR2, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var passwordBefore1 = extractPasswordFromSecret(getSecret(secretName1));
+                    var passwordBefore2 = extractPasswordFromSecret(getSecret(secretName2));
+
+                    helperV3.changePassword(classifier, POSTGRES_TYPE, 200, NAMESPACE);
+
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR1, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_ROTATED, STATUS_FALSE);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR2, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_ROTATED, STATUS_FALSE);
+
+                    var passwordAfter1 = extractPasswordFromSecret(getSecret(secretName1));
+                    var passwordAfter2 = extractPasswordFromSecret(getSecret(secretName2));
+
+                    assertNotEquals(passwordBefore1, passwordAfter1, "secret 1 password must change after rotation");
+                    assertNotEquals(passwordBefore2, passwordAfter2, "secret 2 password must change after rotation");
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantRotationTriggeredByBackupRestore() throws IOException {
+                    String dbSecretCRName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+                    var classifier = new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build();
+
+                    helperV3.createDatabase(classifier, POSTGRES_TYPE, 201);
+
+                    var databaseSecretCR = asTenant(
+                            buildDatabaseSecretClaimCR(dbSecretCRName, microserviceName, microserviceName, NAMESPACE, secretName, "", POSTGRES_TYPE), tenantId);
+                    var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var passwordBefore = extractPasswordFromSecret(getSecret(secretName));
+
+                    var backupRequest = new BackupRequestBuilder()
+                            .filterCriteria(fc -> fc.include(f -> f.ms(microserviceName)))
+                            .build();
+                    var backupResponse = backupHelperV1.runBackupAndWait(backupRequest, false);
+                    assertEquals(BackupStatus.COMPLETED, backupResponse.getStatus());
+
+                    var restoreRequest = new RestoreRequestBuilder().build();
+                    var restoreResponse = backupHelperV1.runRestoreAndWait(backupRequest.getBackupName(), restoreRequest, false);
+                    assertEquals(RestoreStatus.COMPLETED, restoreResponse.getStatus());
+
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_ROTATED, STATUS_FALSE);
+                    var passwordAfter = extractPasswordFromSecret(getSecret(secretName));
+                    assertNotEquals(passwordBefore, passwordAfter, "secret password must change after rotation");
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantUpdatedAfterBackupRestoreV3() throws IOException {
+                    String sourceNamespace = helperV3.generateTestNamespace();
+                    String dbSecretCRName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+                    var sourceClassifier = new ClassifierBuilder().ms(microserviceName).ns(sourceNamespace).tenant().tenantId(tenantId).build();
+
+                    try {
+                        helperV3.createDatabase(sourceClassifier, POSTGRES_TYPE, 201);
+
+                        var targetClassifier = new ClassifierBuilder().ms(microserviceName).ns(NAMESPACE).tenant().tenantId(tenantId).build();
+                        helperV3.createDatabase(targetClassifier, POSTGRES_TYPE, 201);
+
+                        var databaseSecretCR = asTenant(
+                                buildDatabaseSecretClaimCR(dbSecretCRName, microserviceName, microserviceName, NAMESPACE, secretName, "", POSTGRES_TYPE), tenantId);
+                        var createdDatabaseSecretClaimCR = createCR(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR);
+                        waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDatabaseSecretClaimCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                        String passwordBefore = extractPasswordFromSecret(getSecret(secretName));
+
+                        var namespaceBackup = backupHelperV3.collectBackup(helperV3.getBackupDaemonAuthorization(), sourceNamespace, false);
+                        assertTrue(namespaceBackup.canRestore(), "backup must be in restorable state");
+
+                        var namespaceRestoreResult = backupHelperV3.restoreBackup(helperV3.getBackupDaemonAuthorization(), namespaceBackup, NAMESPACE);
+                        assertEquals(Status.SUCCESS, namespaceRestoreResult.getStatus(), "restore must succeed");
+
+                        waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, databaseSecretCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_ROTATED, STATUS_FALSE);
+
+                        String passwordAfter = extractPasswordFromSecret(getSecret(secretName));
+                        assertNotEquals(passwordBefore, passwordAfter, "secret password must change after cross-namespace restore");
+                    } finally {
+                        deleteDb(sourceClassifier, POSTGRES_TYPE);
+                    }
+                }
+
+                @Test
+                void testDatabaseSecretClaimTenantExtraKeysAndCustomKeysClassifierShape() throws IOException {
+                    String edbCRName = generateName();
+                    String dscCRName = generateName();
+                    String microserviceName = generateName();
+                    String secretName = generateName();
+                    String tenantId = generateName();
+                    String extraKeyValue = "eu-west";
+                    String customKeyValue = "billing";
+
+                    // ExternalDatabase with a tenant classifier plus extraKeys and customKeys.
+                    var edbCR = asTenant(buildExternalDatabaseCR(edbCRName, microserviceName, NAMESPACE, "billing-db", ""), tenantId);
+                    Map<String, Object> spec = (Map<String, Object>) edbCR.getAdditionalProperties().get("spec");
+                    Map<String, Object> classifier = (Map<String, Object>) spec.get("classifier");
+                    classifier.put("extraKeys", Map.of("region", extraKeyValue));
+                    classifier.put("customKeys", Map.of("logicalDBName", customKeyValue));
+
+                    createCR(CRD_EXTERNAL_DATABASE, edbCR);
+                    waitForDesiredState(CRD_EXTERNAL_DATABASE, edbCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_DATABASE_REGISTERED, STATUS_FALSE);
+
+                    // DatabaseSecretClaim with the same tenant classifier.
+                    var dscCR = asTenant(buildDatabaseSecretClaimCR(dscCRName, microserviceName, microserviceName, NAMESPACE, secretName, "admin", POSTGRES_TYPE), tenantId);
+                    Map<String, Object> dscSpec = (Map<String, Object>) dscCR.getAdditionalProperties().get("spec");
+                    Map<String, Object> dscClassifier = (Map<String, Object>) dscSpec.get("classifier");
+                    dscClassifier.put("extraKeys", Map.of("region", extraKeyValue));
+                    dscClassifier.put("customKeys", Map.of("logicalDBName", customKeyValue));
+
+                    var createdDscCR = createCR(CRD_DATABASE_SECRET_CLAIM, dscCR);
+                    waitForDesiredState(CRD_DATABASE_SECRET_CLAIM, createdDscCR, PHASE_SUCCEEDED, STATUS_TRUE, REASON_SECRET_CREATED, STATUS_FALSE);
+
+                    var secret = getSecret(secretName);
+                    assertSecretOwnedByCR(secret, createdDscCR);
+                    assertSecretContainsMetadata(secret, microserviceName, NAMESPACE, POSTGRES_TYPE, "admin", "tenant", tenantId);
+
+                    // Decode metadata.json to verify classifier shape.
+                    String decodedJson = new String(
+                            java.util.Base64.getDecoder().decode(secret.getData().get(METADATA_KEY)),
+                            java.nio.charset.StandardCharsets.UTF_8
+                    );
+                    JsonNode metaClassifier =
+                            new ObjectMapper()
+                                    .readTree(decodedJson)
+                                    .path("classifier");
+
+                    // extraKeys must be flattened to the top level alongside microserviceName/scope/tenantId.
+                    assertEquals(extraKeyValue, metaClassifier.path("region").asText(),
+                            "extraKeys entry 'region' must sit at classifier top level");
+                    assertFalse(metaClassifier.has("extraKeys"),
+                            "extraKeys wrapper key must not appear in the flattened classifier");
+
+                    // customKeys must remain nested, not promoted to the top level.
+                    JsonNode customKeys = metaClassifier.path("customKeys");
+                    assertFalse(customKeys.isMissingNode(),
+                            "customKeys must be a nested object inside the classifier");
+                    assertEquals(customKeyValue, customKeys.path("logicalDBName").asText(),
+                            "customKeys entry 'logicalDBName' must be nested under classifier.customKeys");
+                    assertFalse(metaClassifier.has("logicalDBName"),
+                            "customKeys entry 'logicalDBName' must not be promoted to classifier top level");
+                }
+            }
+
             // BalancingRules CRs are singletons (fixed names), so unlike the sibling
             // classes these tests cannot use generateName() per test. They run
             // sequentially within this class (JUnit only parallelises the sibling


### PR DESCRIPTION
## Problem

A `scope=tenant` `InternalDatabase` is a **tenant-agnostic template**: the aggregator drops
`tenantId` when it stores a tenant declaration and materializes a concrete per-tenant database
only on that tenant's first runtime connection. A freshly declared tenant that pins a concrete
`tenantId` therefore had **no database**, and a matching `DatabaseSecretClaim` for
`{scope=tenant, tenantId}` did a read-only get-by-classifier, got `DatabaseNotFound`, and waited
indefinitely — the consuming pod stayed blocked on its tenant secret.

## Solution (operator-side, Option B)

After a successful declarative apply (both the synchronous `200 OK` and the asynchronous
`COMPLETED` paths), and **before** marking the CR `Succeeded`, the `InternalDatabase` controller
issues a get-or-create for the concrete tenant database:

```
PUT /api/v3/dbaas/{namespace}/databases
  { "classifier": { …, "scope": "tenant", "tenantId": "<id>" }, "type": "<type>", "originService": "<ms>" }
```

This materializes the database exactly as the first tenant connection would, so a matching
`DatabaseSecretClaim` resolves immediately. The call is:

- **scoped** — no-op for `scope=service` or a tenant declaration without a pinned `tenantId`;
- **idempotent** — get-or-create returns the existing database on repeat reconciles;
- **gating** — a failure keeps the CR out of `Succeeded` and requeues (transient/5xx → `BackingOff`);
- **observable** — recorded as `operation="create_database"`.

No aggregator changes; the declarative engine and tenant-agnostic template behaviour are untouched.

## What changed

- **client**: `CreateDatabase` + `CreateDatabaseRequest`
- **controller**: `materializeTenantDatabaseIfPinned` on both success paths; `create_database` metric label
- **controller tests**: sync/async materialize, service & tenant-without-tenantId no-op, materialization-failure gating
- **dev aggregator-mock**: `PUT /databases` get-or-create endpoint; **stateful** tenant get-by-classifier (404 `DatabaseNotFound` until materialized); `main_test.go`; tenant test-resources + `e2e-tenant-materialize.sh`
- **docs**: howto `InternalDatabase` section (new "Tenant database materialization"), metrics `operation` label, dev README
- **integration-tests**: `DatabaseSecretClaimTenant` suite (9 tests mirroring the service DSC set) + `asTenant` / tenant `assertSecretContainsMetadata` helpers

## Verification

- `make lint` → 0 issues; `make test` → all green (controller, client, `dev/aggregator-mock`)
- **kind e2e proven** (`e2e-tenant-materialize.sh`): tenant `InternalDatabase` materializes the DB → `DatabaseSecretClaim` resolves → Secret created. Causality confirmed live: with the mock store cleared, the claim alone backs off on `DatabaseNotFound`, then recovers to `Succeeded` once the `InternalDatabase` materializes the database.
- integration-tests module: `mvn test-compile` passes (the `DatabaseSecretClaimTenant` suite runs only in the full dbaas environment against an operator built with this fix).
