### PR TITLE
docs(operator): normalize operator docs and comments to US English

### DIFF
--- a/dbaas-operator/AGENTS.md
+++ b/dbaas-operator/AGENTS.md
@@ -119,7 +119,7 @@ import "github.com/netcracker/qubership-core-lib-go-error-handling/v3/tmf"
 
 All errors from external services must be classified into:
 
-| Category | HTTP codes | Operator behaviour | Phase |
+| Category | HTTP codes | Operator behavior | Phase |
 |---|---|---|---|
 | **Spec rejection** (permanent) | 400, 403, 409, 410, 422 | No retry, wait for spec change | `InvalidConfiguration` |
 | **Auth error** (transient) | 401 | Retry with backoff | `BackingOff` |
@@ -312,7 +312,7 @@ Grafana dashboard (`templates/Dashboard.yaml` +
 `DBAAS_OPERATOR_ENABLED && MONITORING_ENABLED`.
 
 **Reference:** [`docs/monitoring/DBaaS Operator Metrics.md`](docs/monitoring/DBaaS%20Operator%20Metrics.md)
-— the user-facing catalogue of every metric, its labels and label values, the dashboard panels, and
+— the user-facing catalog of every metric, its labels and label values, the dashboard panels, and
 example PromQL.
 
 > **Keep the docs in sync — mandatory.** Any change to the metrics surface MUST be reflected in

--- a/dbaas-operator/cmd/credentials.go
+++ b/dbaas-operator/cmd/credentials.go
@@ -89,7 +89,7 @@ func loadAggregatorCredentials(log logging.Logger, dir string) (username, passwo
 // events on "..data". Direct Write events on users.json are also handled for
 // local-dev mounts.
 //
-// The function blocks until ctx is cancelled. Errors starting the watcher are logged
+// The function blocks until ctx is canceled. Errors starting the watcher are logged
 // and treated as non-fatal (credential auto-reload is simply disabled).
 func watchCredentials(ctx context.Context, log logging.Logger, dir string, client credentialsSetter) error {
 	watcher, err := fsnotify.NewWatcher()

--- a/dbaas-operator/cmd/credentials_test.go
+++ b/dbaas-operator/cmd/credentials_test.go
@@ -173,7 +173,7 @@ func TestWatchCredentials_ReloadsOnFileChange(t *testing.T) {
 // Linux-only: inotify (production platform) generates IN_MOVED_TO → Create
 // for the destination of a rename, which our filter catches as base="..data".
 // macOS kqueue does not generate Create events for symlink creation, so this
-// test is skipped there — cross-platform watcher behaviour is covered by
+// test is skipped there — cross-platform watcher behavior is covered by
 // TestWatchCredentials_ReloadsOnFileChange.
 func TestWatchCredentials_ReloadsOnKubernetesSymlinkSwap(t *testing.T) {
 	if runtime.GOOS != "linux" {
@@ -234,7 +234,7 @@ func TestWatchCredentials_ReloadsOnKubernetesSymlinkSwap(t *testing.T) {
 }
 
 // TestWatchCredentials_StopsOnContextCancel verifies that the watcher goroutine
-// exits cleanly when the context is cancelled.
+// exits cleanly when the context is canceled.
 func TestWatchCredentials_StopsOnContextCancel(t *testing.T) {
 	t.Parallel()
 

--- a/dbaas-operator/dev/aggregator-mock/main.go
+++ b/dbaas-operator/dev/aggregator-mock/main.go
@@ -87,7 +87,7 @@ import (
 //
 // For 2xx codes TmfCode/Reason/Message are ignored (no error body is returned).
 // For 4xx/5xx codes omitted fields produce empty strings in the JSON output,
-// which faithfully reproduces aggregator behaviour for codes without an ErrorCode.
+// which faithfully reproduces aggregator behavior for codes without an ErrorCode.
 type MockRule struct {
 	HTTPCode int    `json:"httpCode"`
 	TmfCode  string `json:"tmfCode,omitempty"` // e.g. "CORE-DBAAS-4010"
@@ -162,7 +162,7 @@ type ChangedEntry struct {
 
 // dbStore is the mock's in-memory record of databases materialized via the get-or-create
 // call (PUT .../databases). It lets get-by-classifier emulate the real aggregator's
-// lazy-tenant behaviour: a tenant database exists only after it has been created, so a
+// lazy-tenant behavior: a tenant database exists only after it has been created, so a
 // DatabaseSecretClaim for a not-yet-materialized tenant gets a 404 (DatabaseNotFound) —
 // exactly what the operator's pinned-tenant materialization is there to prevent. State is
 // per-process and lost on restart.
@@ -463,7 +463,7 @@ func handleExternalDB(
 
 // handleApply serves POST /api/declarations/v1/apply.
 //
-// Behaviour by subKind (when no rule matches):
+// Behavior by subKind (when no rule matches):
 //   - "DbPolicy"             → 200 COMPLETED (synchronous)
 //   - "DatabaseDeclaration"  → 202 IN_PROGRESS with deterministic trackingId
 //
@@ -488,7 +488,7 @@ func handleApply(w http.ResponseWriter, body []byte, applyRules map[string]MockR
 			writeTmfError(w, rule)
 			return
 		}
-		// 2xx rule: honour the exact code.
+		// 2xx rule: honor the exact code.
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(rule.HTTPCode)
 		writeJSON(w, map[string]any{
@@ -498,7 +498,7 @@ func handleApply(w http.ResponseWriter, body []byte, applyRules map[string]MockR
 		return
 	}
 
-	// Default behaviour depends on subKind.
+	// Default behavior depends on subKind.
 	if req.SubKind == "DatabaseDeclaration" {
 		// InternalDatabase is always async: return 202 with a deterministic trackingId.
 		trackingID := "tracking-" + msName

--- a/dbaas-operator/dev/aggregator-mock/main_test.go
+++ b/dbaas-operator/dev/aggregator-mock/main_test.go
@@ -205,7 +205,7 @@ func TestGetByClassifier_TenantRequiresMaterialization(t *testing.T) {
 
 // TestGetByClassifier_ServiceNoMaterializationNeeded asserts the materialization gate is
 // tenant-only: a service classifier resolves with 200 without any prior get-or-create,
-// preserving the behaviour the existing service-scoped dev scenarios depend on.
+// preserving the behavior the existing service-scoped dev scenarios depend on.
 func TestGetByClassifier_ServiceNoMaterializationNeeded(t *testing.T) {
 	h := newTestHandler(http.StatusOK, nil)
 	classifier := map[string]any{

--- a/dbaas-operator/dev/test-resources/idb-poll-terminated.yaml
+++ b/dbaas-operator/dev/test-resources/idb-poll-terminated.yaml
@@ -4,7 +4,7 @@
 # No apply-rule → default 202 with trackingId="tracking-idb-poll-terminated"
 # poll-rules.json key: "tracking-idb-poll-terminated" → TERMINATED
 #
-# Expected behaviour (new):
+# Expected behavior (new):
 #   Phase=WaitingForDependency → Phase=BackingOff (OperationTerminated, Stalled=False)
 #   trackingID cleared → next reconcile resubmits → Phase=WaitingForDependency again
 #   The operator retries continuously (NOT stuck in InvalidConfiguration).

--- a/dbaas-operator/docs/howto/DBaaS Operator.md
+++ b/dbaas-operator/docs/howto/DBaaS Operator.md
@@ -208,7 +208,7 @@ After a `202 Accepted` from the apply endpoint, the controller polls this endpoi
 | `status=COMPLETED` | Provisioning finished | `Succeeded` — `Ready=True`, reason `DatabaseProvisioned`; `trackingID` cleared |
 | `status=IN_PROGRESS` / `NOT_STARTED` | Still running | `WaitingForDependency` — requeued after the poll interval, reason `ProvisioningStarted` |
 | `status=FAILED` | Provisioning failed | `InvalidConfiguration` — `Ready=False`, `Stalled=True`, reason `AggregatorRejected`; `trackingID` cleared |
-| `status=TERMINATED` | Cancelled mid-flight (aggregator restart or admin terminate) | `BackingOff` — `trackingID` cleared and the operation is **resubmitted** on the next reconcile, reason `OperationTerminated` |
+| `status=TERMINATED` | Canceled mid-flight (aggregator restart or admin terminate) | `BackingOff` — `trackingID` cleared and the operation is **resubmitted** on the next reconcile, reason `OperationTerminated` |
 | HTTP `401` | Missing or invalid credentials | `BackingOff` — `trackingID` kept, retried, reason `Unauthorized` |
 | HTTP `404` | `trackingId` expired or unknown | `BackingOff` — `trackingID` cleared, operation **resubmitted** next reconcile, reason `AggregatorError` |
 | HTTP `5xx` / Network error | Aggregator error / unreachable | `BackingOff` — `trackingID` kept, retried, reason `AggregatorError` |
@@ -1207,7 +1207,7 @@ spec:
 
 | Field | Required | Description |
 |-------|:--------:|-------------|
-| `approach` | No | `clone` (clone from `sourceClassifier`) or `new` (create an empty database). Default behaviour when the field is absent is `new` |
+| `approach` | No | `clone` (clone from `sourceClassifier`) or `new` (create an empty database). Default behavior when the field is absent is `new` |
 | `sourceClassifier` | Required when `approach=clone` | Classifier of the source database to clone from. **Constraint:** `sourceClassifier.microserviceName` must equal `classifier.microserviceName` (enforced by the controller) |
 
 > **Note on async provisioning:** the operator stores the aggregator's `trackingId` in `status.trackingID` and polls until the operation completes (every 5 s). While polling, `status.phase` is `WaitingForDependency` and `status.conditions[].reason` is `ProvisioningStarted`. Spec changes during polling clear the stale `trackingID` and start a fresh submission — see [Status Reference](#internaldatabase-status-reference).
@@ -1285,7 +1285,7 @@ PUT /api/v3/dbaas/{namespace}/databases
 
 This materializes the database exactly as the tenant's first runtime connection would, so a matching `DatabaseSecretClaim` resolves immediately instead of waiting on `DatabaseNotFound`. The call is:
 
-- **scoped** — a no-op for `scope=service`, or for a tenant declaration **without** a pinned `tenantId` (the tenant-agnostic template behaviour is unchanged);
+- **scoped** — a no-op for `scope=service`, or for a tenant declaration **without** a pinned `tenantId` (the tenant-agnostic template behavior is unchanged);
 - **idempotent** — get-or-create returns the existing database on subsequent reconciles;
 - **gating** — if it fails, the CR does **not** become `Succeeded`: a transient/5xx failure surfaces as `BackingOff` and is retried on the next reconcile, exactly like the `apply` call;
 - **observable** — recorded on `dbaas_aggregator_requests_total` and `dbaas_aggregator_request_duration_seconds` under `operation="create_database"`.
@@ -1801,7 +1801,7 @@ CR created / spec changed / rotation-trigger annotation changed
   RequeueAfter 1h (safety-net re-poll)
 ```
 
-Two behaviours are worth calling out:
+Two behaviors are worth calling out:
 
 - **Content-aware update** — on a rotation-triggered reconcile the operator compares the existing Secret's `connectionProperties.json` (and managed labels) against what it would write. If they already match, it skips the write entirely: no Secret update, no event, `lastRotatedAt` unchanged. This avoids needlessly waking every pod that mounts the Secret (the kubelet reloads mounted Secrets on change). Only a genuine content change is written and reported as `SecretRotated`.
 - **Sibling-conflict tiebreak** — if two CRs in the namespace target the same `secretName`, the older one (by `creationTimestamp`, falling back to UID lexical order on a tie) wins and proceeds; the younger one moves to `SecretConflict`. The loser recovers automatically — without a spec change — once the winner is deleted or rebinds, because the controller watches sibling `DatabaseSecretClaim`s by `secretName`.
@@ -1856,7 +1856,7 @@ The cache index the poller queries is keyed by `(classifier, type)` **only** —
 1. The same `spec.userRole` on two CRs can resolve to two different effective roles, and an empty `spec.userRole` can resolve to *anything* the policy dictates. There is no static, CR-local function from `spec.userRole` to the aggregator's effective role.
 2. A `DatabaseAccessPolicy` edit changes the effective role of existing `DatabaseSecretClaim` CRs **without** changing those CRs — so any operator-side mapping would have to be invalidated and recomputed every time a policy changes, duplicating the aggregator's resolution and racing its cache.
 
-Matching a specific rotated role to the affected CRs would require the operator to replicate all of the above. Rather than do that, **the poller wakes every `DatabaseSecretClaim` that shares the changed database's `(classifier, type)`, regardless of role.** Each woken CR then re-fetches its own credentials through get-by-classifier — where the aggregator performs the authoritative role resolution — and the [content-aware update](#how-databasesecretclaim-works) writes nothing when the returned credentials are unchanged. So CRs bound to a role other than the one that rotated simply perform a cheap no-op; only the CR(s) whose effective role actually changed get a Secret write and a `SecretRotated` event.
+Matching a specific rotated role to the affected CRs would require the operator to replicate all of the above. Rather than do that, **the poller wakes every `DatabaseSecretClaim` that shares the changed database's `(classifier, type)`, regardless of role.** Each woken CR then re-fetches its own credentials through get-by-classifier — where the aggregator performs the authoritative role resolution — and the [content-aware update](#how-databasesecretclaim-works) writes nothing when the returned credentials are unchanged. So CRs bound to a role other than the one that rotated perform a cheap no-op; only the CR(s) whose effective role actually changed get a Secret write and a `SecretRotated` event.
 
 The over-fetch is bounded and cheap: a classifier is typically referenced by 1–3 `DatabaseSecretClaim` CRs (one per role), each costing one get-by-classifier round-trip and no Secret churn on a no-op. Trading a couple of redundant reads for not reimplementing — and not having to keep coherent — the aggregator's role-resolution rules is the right balance.
 
@@ -2007,7 +2007,7 @@ The following parameters control the operator's deployment and behavior. They ar
 
 When a reconcile attempt fails with a transient error (Secret not found, aggregator 5xx, network error, etc.), the controller does not retry immediately. It uses an **exponential backoff** rate limiter: the delay doubles on each consecutive failure for the same object, up to a configured maximum.
 
-This behaviour is controlled by two operator startup flags, which can be set via `args` in the Deployment:
+This behavior is controlled by two operator startup flags, which can be set via `args` in the Deployment:
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -146,7 +146,7 @@ Prometheus/VictoriaMetrics data source.
 **To open it:** in Grafana, open the **DBaaS Operator** dashboard (the name may differ per
 installation), select the **datasource**, and set the time range.
 
-The dashboard is organised into rows that mirror the metric groups above.
+The dashboard is organized into rows that mirror the metric groups above.
 
 ### Credentials & Secret Resolution
 

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -509,7 +509,7 @@
                        "id":  16,
                        "type":  "timeseries",
                        "title":  "Async Completion Rate by Outcome",
-                       "description":  "Rate of async operations completing per second, split by result (success / failed / terminated). Terminated means the aggregator cancelled and the operator will resubmit.",
+                       "description":  "Rate of async operations completing per second, split by result (success / failed / terminated). Terminated means the aggregator canceled and the operator will resubmit.",
                        "gridPos":  {
                                        "h":  8,
                                        "w":  12,

--- a/dbaas-operator/internal/client/aggregator_client_test.go
+++ b/dbaas-operator/internal/client/aggregator_client_test.go
@@ -325,7 +325,7 @@ func TestRegisterExternalDatabase_ContextCancellation(t *testing.T) {
 	c := newClient(srv.URL, staticToken("test-token"))
 	err := c.RegisterExternalDatabase(ctx, "ns", minimalExtDBRequest())
 	if err == nil {
-		t.Error("expected error on cancelled context, got nil")
+		t.Error("expected error on canceled context, got nil")
 	}
 }
 
@@ -477,7 +477,7 @@ func TestDeleteNamespaceBalancingRule_ContextCancellation(t *testing.T) {
 
 	c := newClient("http://127.0.0.1", staticToken("test-token"))
 	if err := c.DeleteNamespaceBalancingRule(ctx, "payments", "pg-fast"); err == nil {
-		t.Fatal("expected error on cancelled context, got nil")
+		t.Fatal("expected error on canceled context, got nil")
 	}
 }
 

--- a/dbaas-operator/internal/controller/databasesecretclaim_controller.go
+++ b/dbaas-operator/internal/controller/databasesecretclaim_controller.go
@@ -604,8 +604,8 @@ func isOlderClaimant(a, b *dbaasv1.DatabaseSecretClaim) bool {
 // would otherwise be filtered out and never reconciled.
 //
 // Create and Delete fall through to the embedded predicate.Funcs defaults
-// (both return true), preserving the standard behaviour for new and removed
-// CRs. Only Update is customised.
+// (both return true), preserving the standard behavior for new and removed
+// CRs. Only Update is customized.
 type specOrRotationTriggerPredicate struct{ predicate.Funcs }
 
 func (specOrRotationTriggerPredicate) Update(e event.UpdateEvent) bool {

--- a/dbaas-operator/internal/controller/externaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller.go
@@ -278,7 +278,7 @@ func (r *ExternalDatabaseReconciler) applySecretCredentials(
 		}
 	}
 
-	// Defence-in-depth duplicate name check — CRD CEL validation should catch this
+	// Defense-in-depth duplicate name check — CRD CEL validation should catch this
 	// first, but we guard here too in case validation is bypassed.
 	seen := make(map[string]string, len(ref.Keys))
 	for _, km := range ref.Keys {
@@ -321,8 +321,8 @@ func (r *ExternalDatabaseReconciler) applySecretCredentials(
 // generation and would otherwise be filtered out.
 //
 // Create and Delete fall through to the embedded predicate.Funcs defaults
-// (both return true), preserving standard behaviour for new and removed CRs.
-// Only Update is customised.
+// (both return true), preserving standard behavior for new and removed CRs.
+// Only Update is customized.
 type specOrRefreshTriggerPredicate struct{ predicate.Funcs }
 
 func (specOrRefreshTriggerPredicate) Update(e event.UpdateEvent) bool {
@@ -347,7 +347,7 @@ func (specOrRefreshTriggerPredicate) Update(e event.UpdateEvent) bool {
 // periodic resync (ResyncInterval) via RequeueAfter on a successful reconcile, or
 // immediately via the refresh annotation above.
 //
-// opts allows callers to customise the controller's behaviour — most notably
+// opts allows callers to customize the controller's behavior — most notably
 // the RateLimiter, which controls the exponential backoff applied when
 // Reconcile returns an error (BackingOff phase).  Pass
 // ctrlcontroller.Options{} to keep the controller-runtime defaults.

--- a/dbaas-operator/internal/controller/externaldatabase_controller_test.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller_test.go
@@ -550,7 +550,7 @@ var _ = Describe("ExternalDatabase Controller", func() {
 		})
 	})
 
-	Context("duplicate name in credentialsSecretRef.keys (defence-in-depth)", func() {
+	Context("duplicate name in credentialsSecretRef.keys (defense-in-depth)", func() {
 		It("sets Phase=InvalidConfiguration, InvalidSpec, message mentions duplicate name", func() {
 			spec := baseSpec()
 			spec.ConnectionProperties[0].CredentialsSecretRef = &dbaasv1.CredentialsSecretRef{
@@ -1175,7 +1175,7 @@ var _ = Describe("ExternalDatabase Controller — rate limiter", func() {
 	//
 	//  2. A rate limiter created with the parameters used by --backoff-base-delay
 	//     and --backoff-max-delay exhibits true exponential doubling.  This serves
-	//     as a living spec for the BackingOff retry behaviour visible to operators.
+	//     as a living spec for the BackingOff retry behavior visible to operators.
 
 	It("registers the controller with a custom exponential rate limiter", func() {
 		// Create a throw-away manager backed by the same envtest API server.
@@ -1204,7 +1204,7 @@ var _ = Describe("ExternalDatabase Controller — rate limiter", func() {
 		}).SetupWithManager(mgr, ctrlcontroller.Options{RateLimiter: rateLimiter})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Verify the exponential doubling behaviour of the rate limiter we
+		// Verify the exponential doubling behavior of the rate limiter we
 		// injected.  This is the contract that BackingOff retries rely on:
 		// each consecutive failure doubles the wait time up to --backoff-max-delay.
 		//

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -90,12 +90,12 @@ var dbaasReconcileTriggerTotal = prometheus.NewCounterVec(
 )
 
 // dbaasSecretResolutionErrorsTotal counts failures reading credential Secrets,
-// labelled by error category. A non-zero value means a credential rotation
+// labeled by error category. A non-zero value means a credential rotation
 // left a database without valid credentials - direct service impact.
 var dbaasSecretResolutionErrorsTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "dbaas_secret_resolution_errors_total",
-		Help: "Failures reading credential Secrets referenced by ExternalDatabase, scoped to namespaces owned by this operator instance. Labelled by namespace and failure category (secret_not_found, key_missing, key_empty, forbidden, secret_read_failed).",
+		Help: "Failures reading credential Secrets referenced by ExternalDatabase, scoped to namespaces owned by this operator instance. Labeled by namespace and failure category (secret_not_found, key_missing, key_empty, forbidden, secret_read_failed).",
 	},
 	[]string{"namespace", "reason"},
 )
@@ -119,7 +119,7 @@ var dbaasAggregatorRequestDurationSeconds = prometheus.NewHistogramVec(
 var dbaasAggregatorRequestsTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "dbaas_aggregator_requests_total",
-		Help: "Total calls to dbaas-aggregator, labelled by controller, operation, and result.",
+		Help: "Total calls to dbaas-aggregator, labeled by controller, operation, and result.",
 	},
 	[]string{"controller", "operation", "result"},
 )

--- a/dbaas-operator/internal/poller/rotation_poller.go
+++ b/dbaas-operator/internal/poller/rotation_poller.go
@@ -74,7 +74,7 @@ type RotationPoller struct {
 // cursor owner drives the fan-out.
 func (p *RotationPoller) NeedLeaderElection() bool { return true }
 
-// Start runs the poll loop until ctx is cancelled. It implements manager.Runnable.
+// Start runs the poll loop until ctx is canceled. It implements manager.Runnable.
 func (p *RotationPoller) Start(ctx context.Context) error {
 	limit := p.Limit
 	if limit <= 0 {


### PR DESCRIPTION
Apply the english-us-developer-style skill: normalize British spellings to American across the operator's user-facing docs, the Grafana dashboard description, metric Help strings, AGENTS.md, and code/dev/test comments; drop one filler word. Text-only, no logic changes.