### PR TITLE
test(sample-apps): add Phase C — direct M2M REST to the aggregator

### DIFF
--- a/.github/scripts/deploy-sample-services.sh
+++ b/.github/scripts/deploy-sample-services.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-# Deploy all three sample services (go / spring / quarkus) with a given aggregator URL and
-# secret-mount mode, so the integration test can be run in two phases:
-#   - mount proof:   <broken aggregator URL> true   (working DML can only come from the mount)
-#   - REST fallback: <working aggregator URL> false  (no mount → client resolves via the REST API)
+# Deploy all three sample services (go / spring / quarkus) with a given aggregator URL, secret-mount
+# mode, and (optionally) direct-M2M mode, so the integration test can be run in three phases:
+#   - mount proof:   <broken aggregator URL> true         (working DML can only come from the mount)
+#   - REST fallback: <working agent URL>     false         (no mount -> client resolves via the agent)
+#   - direct M2M:    <aggregator URL>        false  true   (no mount -> client calls the aggregator
+#                                                           directly with a `dbaas`-audience token)
 #
-# Usage: deploy-sample-services.sh <AGG_URL> <MOUNT_SECRETS>
+# Usage: deploy-sample-services.sh <AGG_URL> <MOUNT_SECRETS> [M2M_ENABLED=false]
 # Relies on job-level env: TEST_NAMESPACE and the {GO,SPRING,QUARKUS}_SERVICE_NAME /
 # _IMAGE_REPOSITORY / _IMAGE_TAG variables.
 set -euo pipefail
 
 AGG_URL="$1"
 MOUNT_SECRETS="$2"
+M2M_ENABLED="${3:-false}"
 
 helm upgrade --install "$GO_SERVICE_NAME" \
   test-apps/go-test-app-service/helm-templates/go-test-app-service \
@@ -21,7 +24,9 @@ helm upgrade --install "$GO_SERVICE_NAME" \
   --set TAG="$GO_IMAGE_TAG" \
   --set IMAGE_PULL_POLICY="Never" \
   --set MOUNT_SECRETS="$MOUNT_SECRETS" \
-  --set DBAAS_AGENT="$AGG_URL"
+  --set M2M_ENABLED="$M2M_ENABLED" \
+  --set DBAAS_AGENT="$AGG_URL" \
+  --set API_DBAAS_ADDRESS="$AGG_URL"
 
 helm upgrade --install "$SPRING_SERVICE_NAME" \
   test-apps/spring-test-app-service/helm-templates/spring-test-app-service \
@@ -32,6 +37,7 @@ helm upgrade --install "$SPRING_SERVICE_NAME" \
   --set TAG="$SPRING_IMAGE_TAG" \
   --set IMAGE_PULL_POLICY="Never" \
   --set MOUNT_SECRETS="$MOUNT_SECRETS" \
+  --set M2M_ENABLED="$M2M_ENABLED" \
   --set API_DBAAS_ADDRESS="$AGG_URL"
 
 helm upgrade --install "$QUARKUS_SERVICE_NAME" \
@@ -43,4 +49,5 @@ helm upgrade --install "$QUARKUS_SERVICE_NAME" \
   --set TAG="$QUARKUS_IMAGE_TAG" \
   --set IMAGE_PULL_POLICY="Never" \
   --set MOUNT_SECRETS="$MOUNT_SECRETS" \
+  --set M2M_ENABLED="$M2M_ENABLED" \
   --set API_DBAAS_ADDRESS="$AGG_URL"

--- a/.github/workflows/integration-tests-sample-service.yml
+++ b/.github/workflows/integration-tests-sample-service.yml
@@ -154,6 +154,19 @@ jobs:
           kubectl rollout status deployment/dbaas-aggregator -n "$TEST_NAMESPACE" --timeout=300s
           kubectl rollout status deployment/dbaas-operator -n "$TEST_NAMESPACE" --timeout=300s
 
+      # Phase C authenticates with `dbaas`-audience projected tokens, which the aggregator verifies by
+      # OIDC discovery against the kube-apiserver (/.well-known/openid-configuration + JWKS). Grant the
+      # aggregator ServiceAccount the issuer-discovery role and restart so the verifier re-runs
+      # discovery with the permission. Test-only — the product chart does not ship this binding.
+      - name: Grant aggregator OIDC issuer-discovery (for direct-M2M verification)
+        run: |
+          kubectl create clusterrolebinding dbaas-aggregator-issuer-discovery \
+            --clusterrole=system:service-account-issuer-discovery \
+            --serviceaccount="$TEST_NAMESPACE":dbaas-aggregator \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n "$TEST_NAMESPACE" rollout restart deployment/dbaas-aggregator
+          kubectl rollout status deployment/dbaas-aggregator -n "$TEST_NAMESPACE" --timeout=300s
+
       - name: Wait for PostgreSQL readiness
         run: |
           PATRONI_POD="$(kubectl -n postgres get pods -o name | grep '^pod/pg-patroni-' | head -1 | cut -d/ -f2)"
@@ -250,6 +263,33 @@ jobs:
 
       - name: "Pass B — run integration tests (REST fallback)"
         id: tests_b
+        working-directory: test-apps/test-apps-integration-tests
+        run: >
+          mvn --batch-mode
+          -DskipIT=false
+          -Dclouds.cloud.name=kind
+          -Dclouds.cloud.namespaces.namespace=$TEST_NAMESPACE
+          test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ─────────────────────── Phase C — direct M2M REST ───────────────────────
+      # Redeploy all three apps pointing DIRECTLY at the real aggregator, no mounted secrets, with a
+      # `dbaas`-audience projected token (M2M_ENABLED=true). Each client authenticates its aggregator
+      # call with its own Kubernetes token (no dbaas-agent), so a working /postgres* round-trip
+      # proves the direct-M2M path in every library.
+      - name: "Phase C — deploy sample services (direct M2M + real aggregator)"
+        run: |
+          .github/scripts/deploy-sample-services.sh "http://dbaas-aggregator.$TEST_NAMESPACE:8080" false true
+
+      - name: "Phase C — wait for sample services"
+        run: |
+          kubectl -n "$TEST_NAMESPACE" rollout status deployment/"$GO_SERVICE_NAME" --timeout=300s
+          kubectl -n "$TEST_NAMESPACE" rollout status deployment/"$SPRING_SERVICE_NAME" --timeout=300s
+          kubectl -n "$TEST_NAMESPACE" rollout status deployment/"$QUARKUS_SERVICE_NAME" --timeout=300s
+
+      - name: "Phase C — run integration tests (direct M2M)"
+        id: tests_c
         working-directory: test-apps/test-apps-integration-tests
         run: >
           mvn --batch-mode

--- a/helm-templates/dbaas-aggregator/data/service-account-roles.yaml
+++ b/helm-templates/dbaas-aggregator/data/service-account-roles.yaml
@@ -1,3 +1,13 @@
 dbaas-operator:
   - DB_CLIENT
   - CLUSTER_OPERATOR
+# Sample services used by the direct-M2M integration phase. Each authenticates with a
+# `dbaas`-audience projected token whose subject SA name is looked up here; DB_CLIENT is enough to
+# get-or-create its own databases. (These SAs never exist in a real deployment — harmless there;
+# the augmentor also defaults unknown SAs to DB_CLIENT.)
+go-test-app-service:
+  - DB_CLIENT
+spring-test-app-service:
+  - DB_CLIENT
+quarkus-test-app-service:
+  - DB_CLIENT

--- a/test-apps/go-test-app-service/README.md
+++ b/test-apps/go-test-app-service/README.md
@@ -17,3 +17,26 @@ The mounted-secret feature lives in `qubership-core-lib-go-dbaas-base-client`. T
 - `DELETE /postgres/items`
 - `POST /postgres/items`
 - `GET /postgres/items`
+
+## Integration test phases
+
+The `Sample Services Integration Tests` workflow deploys this service three times against the same
+black-box contract, toggling how the DBaaS connection is resolved:
+
+- **Pass A — mounted secret**: secrets mounted, aggregator URL unreachable → a working round-trip can
+  only come from the mount.
+- **Pass B — REST fallback**: no mount, `DBAAS_AGENT` at the `dbaas-agent` stub → the client resolves
+  each database over REST through the agent.
+- **Pass C — direct M2M**: no mount, `M2M_ENABLED=true`, `API_DBAAS_ADDRESS` at the real aggregator. A
+  `dbaas`-audience projected token is mounted at `/var/run/secrets/tokens/dbaas/token`;
+  `restclient.NewDbaasRestClient()` sends it as a Bearer straight to the aggregator — no dbaas-agent.
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `MICROSERVICE_NAME` / `MICROSERVICE_NAMESPACE` | dbaas classifier identity | service name / `default` |
+| `DBAAS_AGENT` | agent URL (koanf `dbaas.agent`), used in Pass B | `http://dbaas-aggregator:8080` |
+| `API_DBAAS_ADDRESS` | direct aggregator URL (koanf `api.dbaas.address`), used in Pass C | — |
+| `KUBERNETES_M2M_ENABLED` | Pass C: authenticate the aggregator with a projected `dbaas` token | `false` |
+
+The integration test lives in
+[`test-apps/test-apps-integration-tests`](../test-apps-integration-tests) as `GoTestAppServiceIT`.

--- a/test-apps/go-test-app-service/helm-templates/go-test-app-service/templates/Deployment.yaml
+++ b/test-apps/go-test-app-service/helm-templates/go-test-app-service/templates/Deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
         app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
     spec:
+      # Dedicated ServiceAccount so its projected token identifies this app to the aggregator
+      # (sub = system:serviceaccount:<ns>:go-test-app-service) in the direct-M2M phase.
+      serviceAccountName: '{{ .Values.SERVICE_NAME }}'
       nodeSelector:
         {{ .Values.NODE_SELECTOR_DBAAS_KEY }}: '{{ .Values.REGION_DBAAS }}'
       securityContext:
@@ -35,6 +38,18 @@ spec:
           secret:
             secretName: '{{ .secretName }}'
         {{- end }}
+        {{- end }}
+        # Direct-M2M phase: a Kubernetes projected service-account token scoped to the `dbaas`
+        # audience. The DBaaS base client reads it from /var/run/secrets/tokens/dbaas/token and
+        # sends it as a Bearer straight to the aggregator (no dbaas-agent).
+        {{- if .Values.M2M_ENABLED }}
+        - name: dbaas-m2m-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: dbaas
+                  expirationSeconds: 3600
+                  path: token
         {{- end }}
       containers:
         - name: '{{ .Values.SERVICE_NAME }}'
@@ -51,6 +66,12 @@ spec:
               value: '{{ lower .Values.LOG_LEVEL }}'
             - name: DBAAS_AGENT
               value: '{{ .Values.DBAAS_AGENT }}'
+            # Direct aggregator URL for the M2M phase (koanf key api.dbaas.address). When
+            # KUBERNETES_M2M_ENABLED=true and this is set, the base client calls it directly.
+            - name: API_DBAAS_ADDRESS
+              value: '{{ .Values.API_DBAAS_ADDRESS }}'
+            - name: KUBERNETES_M2M_ENABLED
+              value: '{{ .Values.M2M_ENABLED | default false }}'
             - name: BASECLIENT_RETRY_MAX_ATTEMPTS
               value: '{{ .Values.BASECLIENT_RETRY_MAX_ATTEMPTS }}'
             - name: BASECLIENT_RETRY_DELAY_MS
@@ -66,6 +87,11 @@ spec:
               mountPath: /etc/secrets/dbaas-secrets/{{ .secretName }}
               readOnly: true
             {{- end }}
+            {{- end }}
+            {{- if .Values.M2M_ENABLED }}
+            - name: dbaas-m2m-token
+              mountPath: /var/run/secrets/tokens/dbaas
+              readOnly: true
             {{- end }}
           livenessProbe:
             httpGet:

--- a/test-apps/go-test-app-service/helm-templates/go-test-app-service/templates/ServiceAccount.yaml
+++ b/test-apps/go-test-app-service/helm-templates/go-test-app-service/templates/ServiceAccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.SAMPLE_SERVICE_ENABLED }}
+# Dedicated ServiceAccount for the sample service. Its projected `dbaas`-audience token identifies
+# the app to the aggregator (sub = system:serviceaccount:<ns>:{{ .Values.SERVICE_NAME }}) in the
+# direct-M2M phase; the aggregator maps that name to the DB_CLIENT role.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ .Values.SERVICE_NAME }}'
+  namespace: '{{ .Values.NAMESPACE }}'
+  labels:
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
+    app.kubernetes.io/component: sample-service
+{{- end }}

--- a/test-apps/go-test-app-service/helm-templates/go-test-app-service/values.yaml
+++ b/test-apps/go-test-app-service/helm-templates/go-test-app-service/values.yaml
@@ -16,6 +16,12 @@ REGION_DBAAS: database
 
 LOG_LEVEL: info
 DBAAS_AGENT: http://dbaas-aggregator.dbaas:8080
+# Direct-M2M phase toggle. When true, the pod mounts a `dbaas`-audience projected token and the
+# base client calls API_DBAAS_ADDRESS directly with a Bearer (no dbaas-agent). Default false keeps
+# the mounted-secret / REST-fallback phases unchanged.
+M2M_ENABLED: false
+# Direct aggregator URL used only when M2M_ENABLED is true (koanf key api.dbaas.address).
+API_DBAAS_ADDRESS: ""
 BASECLIENT_RETRY_MAX_ATTEMPTS: 0
 BASECLIENT_RETRY_DELAY_MS: 10
 

--- a/test-apps/quarkus-test-app-service/README.md
+++ b/test-apps/quarkus-test-app-service/README.md
@@ -33,6 +33,20 @@ the database from `/etc/secrets/dbaas-secrets` **before** the agent provider (RE
 test deploys the service with `API_DBAAS_ADDRESS` pointed at an **unreachable** host, so a successful
 insert/list proves the connection came from the mounted secret, not REST.
 
+## Integration test phases
+
+The `Sample Services Integration Tests` workflow deploys this service three times against the same
+black-box contract, toggling how the DBaaS connection is resolved:
+
+- **Pass A — mounted secret**: secrets mounted, `API_DBAAS_ADDRESS` unreachable → a working round-trip
+  can only come from the mount.
+- **Pass B — REST fallback**: no mount, `API_DBAAS_ADDRESS` at the `dbaas-agent` stub → the client
+  resolves each database over REST through the agent (Basic auth).
+- **Pass C — direct M2M**: no mount, `API_DBAAS_ADDRESS` at the real aggregator, `M2M_ENABLED=true`.
+  A `dbaas`-audience projected token is mounted at `/var/run/secrets/tokens/dbaas/token`; clearing the
+  aggregator basic-auth creds makes `DbaasClientProducer` select the M2M client, which calls the
+  aggregator directly with that token as a Bearer — no dbaas-agent.
+
 The `quarkus_test_app_items` table is created by the dbaas Flyway integration
 (`MigrationService.migrate`) from `classpath:db/migration`, run lazily on the first request.
 `baseline-version=0` lets `V1` apply on top of the (non-empty) dbaas-provisioned schema.
@@ -45,14 +59,16 @@ java -jar target/quarkus-app/quarkus-run.jar
 ```
 
 The build depends on the dbaas Quarkus extension snapshot that carries the mounted-secret feature
-(`com.netcracker.cloud.quarkus:dbaas-datasource-postgresql:10.1.1-SNAPSHOT`), published to GitHub
-Packages.
+(`com.netcracker.cloud.quarkus:dbaas-datasource-postgresql:10.1.3-mounted-secret-SNAPSHOT`), published
+to GitHub Packages.
 
 | Env var | Purpose | Default |
 |---|---|---|
 | `MICROSERVICE_NAME` | dbaas classifier `microserviceName` | `quarkus-test-app-service` |
 | `MICROSERVICE_NAMESPACE` | dbaas classifier `namespace` | `default` |
-| `API_DBAAS_ADDRESS` | REST fallback target (used only on a mounted-secret miss) | `http://dbaas-aggregator:8080` |
+| `API_DBAAS_ADDRESS` | REST target: dbaas-agent (Pass B) or the aggregator directly (Pass C) | `http://dbaas-aggregator:8080` |
+| `KUBERNETES_M2M_ENABLED` | Pass C: call the aggregator directly with a `dbaas`-audience projected token | `false` |
+| `QUARKUS_DBAAS_API_AGGREGATOR_USERNAME` / `_PASSWORD` | cleared in Pass C so the M2M client is selected | `dbaas` / `dbaas` |
 | `LOG_LEVEL` | log level | `INFO` |
 
 Runs on the same digest-pinned Java base image as dbaas-aggregator

--- a/test-apps/quarkus-test-app-service/helm-templates/quarkus-test-app-service/templates/Deployment.yaml
+++ b/test-apps/quarkus-test-app-service/helm-templates/quarkus-test-app-service/templates/Deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
         app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
     spec:
+      # Dedicated ServiceAccount so its projected token identifies this app to the aggregator
+      # (sub = system:serviceaccount:<ns>:quarkus-test-app-service) in the direct-M2M phase.
+      serviceAccountName: '{{ .Values.SERVICE_NAME }}'
       nodeSelector:
         {{ .Values.NODE_SELECTOR_DBAAS_KEY }}: '{{ .Values.REGION_DBAAS }}'
       securityContext:
@@ -36,6 +39,18 @@ spec:
           secret:
             secretName: '{{ .secretName }}'
         {{- end }}
+        {{- end }}
+        # Direct-M2M phase: a Kubernetes projected service-account token scoped to the `dbaas`
+        # audience. M2MClientFactory.getDbaasOkHttpClient reads it from /var/run/secrets/tokens/dbaas
+        # and sends it as a Bearer straight to the aggregator (no dbaas-agent).
+        {{- if .Values.M2M_ENABLED }}
+        - name: dbaas-m2m-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: dbaas
+                  expirationSeconds: 3600
+                  path: token
         {{- end }}
         # Writable temp dir so the JVM can run with a read-only root filesystem.
         - name: tmp
@@ -55,6 +70,17 @@ spec:
               value: '{{ .Values.LOG_LEVEL }}'
             - name: API_DBAAS_ADDRESS
               value: '{{ .Values.API_DBAAS_ADDRESS }}'
+            - name: KUBERNETES_M2M_ENABLED
+              value: '{{ .Values.M2M_ENABLED | default false }}'
+            # In the M2M phase, clear the aggregator basic-auth creds so DbaasClientProducer picks the
+            # M2M client (m2mDbaaSClient) over BasicDbaaSClient. Empty env overrides the username /
+            # password baked into application.properties (SmallRye maps empty -> Optional.empty()).
+            {{- if .Values.M2M_ENABLED }}
+            - name: QUARKUS_DBAAS_API_AGGREGATOR_USERNAME
+              value: ""
+            - name: QUARKUS_DBAAS_API_AGGREGATOR_PASSWORD
+              value: ""
+            {{- end }}
             - name: JAVA_TOOL_OPTIONS
               value: '{{ .Values.JAVA_TOOL_OPTIONS }}'
           ports:
@@ -68,6 +94,11 @@ spec:
               mountPath: /etc/secrets/dbaas-secrets/{{ .secretName }}
               readOnly: true
             {{- end }}
+            {{- end }}
+            {{- if .Values.M2M_ENABLED }}
+            - name: dbaas-m2m-token
+              mountPath: /var/run/secrets/tokens/dbaas
+              readOnly: true
             {{- end }}
             - name: tmp
               mountPath: /tmp

--- a/test-apps/quarkus-test-app-service/helm-templates/quarkus-test-app-service/templates/ServiceAccount.yaml
+++ b/test-apps/quarkus-test-app-service/helm-templates/quarkus-test-app-service/templates/ServiceAccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.SAMPLE_SERVICE_ENABLED }}
+# Dedicated ServiceAccount for the sample service. Its projected `dbaas`-audience token identifies
+# the app to the aggregator (sub = system:serviceaccount:<ns>:{{ .Values.SERVICE_NAME }}) in the
+# direct-M2M phase; the aggregator maps that name to the DB_CLIENT role.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ .Values.SERVICE_NAME }}'
+  namespace: '{{ .Values.NAMESPACE }}'
+  labels:
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
+    app.kubernetes.io/component: sample-service
+{{- end }}

--- a/test-apps/quarkus-test-app-service/helm-templates/quarkus-test-app-service/values.yaml
+++ b/test-apps/quarkus-test-app-service/helm-templates/quarkus-test-app-service/values.yaml
@@ -18,6 +18,10 @@ LOG_LEVEL: info
 # REST fallback target. The mounted secret is consulted first; the integration test sets this to a
 # bogus host to prove every datasource keeps working without dbaas-aggregator.
 API_DBAAS_ADDRESS: http://dbaas-aggregator.dbaas:8080
+# Direct-M2M phase toggle. When true, the pod mounts a `dbaas`-audience projected token, the
+# aggregator basic-auth creds are cleared (so the M2M client is chosen), and the client calls
+# API_DBAAS_ADDRESS directly with a Bearer. Default false keeps the other phases unchanged.
+M2M_ENABLED: false
 # Caps the JVM heap to a fraction of the container memory limit.
 JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=70.0"
 

--- a/test-apps/spring-test-app-service/README.md
+++ b/test-apps/spring-test-app-service/README.md
@@ -35,6 +35,20 @@ are provisioned by the operator (via the real aggregator), but the service can o
 database through the mounted secret — so a successful insert/list proves the connection did not come
 from REST (a REST call to a dead host cannot return one).
 
+## Integration test phases
+
+The `Sample Services Integration Tests` workflow deploys this service three times against the same
+black-box contract, toggling only how the DBaaS connection is resolved:
+
+- **Pass A — mounted secret**: secrets mounted, `API_DBAAS_ADDRESS` at an unreachable host. A working
+  round-trip proves the connection came from the mount, not REST.
+- **Pass B — REST fallback**: no mount, `API_DBAAS_ADDRESS` at the `dbaas-agent` stub. The client
+  misses the mount and resolves each database over REST through the agent (Basic auth).
+- **Pass C — direct M2M**: no mount, `API_DBAAS_ADDRESS` at the real aggregator, `M2M_ENABLED=true`.
+  A `dbaas`-audience projected token is mounted at `/var/run/secrets/tokens/dbaas/token`; the client
+  switches to the M2M OkHttp flavor (`getDbaasOkHttpClient`, `basic-auth` off) and calls the
+  aggregator directly with that token as a Bearer — no dbaas-agent.
+
 ## Build & run
 
 ```bash
@@ -43,13 +57,15 @@ java -jar target/spring-test-app-service.jar
 ```
 
 The jar depends on the dbaas client snapshot that carries the mounted-secret feature
-(`9.1.3-mounted-secret-SNAPSHOT`, pinned in `pom.xml`), published to GitHub Packages.
+(`9.1.5-mounted-secret-SNAPSHOT`, pinned in `pom.xml`), published to GitHub Packages.
 
 | Env var | Purpose | Default |
 |---|---|---|
 | `MICROSERVICE_NAME` | dbaas classifier `microserviceName` | `spring-test-app-service` |
 | `MICROSERVICE_NAMESPACE` | dbaas classifier `namespace` | `default` |
-| `API_DBAAS_ADDRESS` | REST fallback target (used only on a mounted-secret miss) | `http://dbaas-aggregator:8080` |
+| `API_DBAAS_ADDRESS` | REST target: dbaas-agent (Pass B) or the aggregator directly (Pass C) | `http://dbaas-aggregator:8080` |
+| `KUBERNETES_M2M_ENABLED` | Pass C: call the aggregator directly with a `dbaas`-audience projected token | `false` |
+| `DBAAS_RESTCLIENT_RESTTEMPLATE_BASIC_AUTH` | `false` in Pass C to select the M2M OkHttp client | `true` |
 | `LOG_LEVEL` | root + dbaas log level | `INFO` |
 | `JAVA_TOOL_OPTIONS` | JVM options (heap sizing) | — |
 
@@ -60,8 +76,10 @@ The jar depends on the dbaas client snapshot that carries the mounted-secret fea
 - Excludes the JPA/Hibernate the starter declares at compile scope (this service uses only
   `JdbcTemplate`); leaving them on the classpath would let Spring Boot auto-configure JPA and
   eagerly touch the datasource at startup, breaking boot-without-aggregator.
-- Enables the basic-auth RestTemplate flavor (`dbaas.restclient.resttemplate.basic-auth=true`) — a
-  plain `RestTemplate` with no platform gateway/M2M dependency — so the service boots standalone.
+- Defaults to the basic-auth RestTemplate flavor (`dbaas.restclient.resttemplate.basic-auth=true`) —
+  a plain `RestTemplate` with no platform gateway/M2M dependency — so the service boots standalone.
+  Pass C flips it to `false` (via `DBAAS_RESTCLIENT_RESTTEMPLATE_BASIC_AUTH`) so the client uses the
+  M2M OkHttp flavor and authenticates the aggregator with a projected `dbaas`-audience token.
 - Runs on the same digest-pinned Java base image as dbaas-aggregator (`dbaas/Dockerfile` →
   `ghcr.io/netcracker/qubership-java-base-prof:25-alpine-2.3.3`); the static-binary
   `qubership-core-base` ships no JRE.

--- a/test-apps/spring-test-app-service/helm-templates/spring-test-app-service/templates/Deployment.yaml
+++ b/test-apps/spring-test-app-service/helm-templates/spring-test-app-service/templates/Deployment.yaml
@@ -22,6 +22,9 @@ spec:
         app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
         app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
     spec:
+      # Dedicated ServiceAccount so its projected token identifies this app to the aggregator
+      # (sub = system:serviceaccount:<ns>:spring-test-app-service) in the direct-M2M phase.
+      serviceAccountName: '{{ .Values.SERVICE_NAME }}'
       nodeSelector:
         {{ .Values.NODE_SELECTOR_DBAAS_KEY }}: '{{ .Values.REGION_DBAAS }}'
       securityContext:
@@ -36,6 +39,18 @@ spec:
           secret:
             secretName: '{{ .secretName }}'
         {{- end }}
+        {{- end }}
+        # Direct-M2M phase: a Kubernetes projected service-account token scoped to the `dbaas`
+        # audience. M2MClientFactory.getDbaasOkHttpClient reads it from /var/run/secrets/tokens/dbaas
+        # and sends it as a Bearer straight to the aggregator (no dbaas-agent).
+        {{- if .Values.M2M_ENABLED }}
+        - name: dbaas-m2m-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: dbaas
+                  expirationSeconds: 3600
+                  path: token
         {{- end }}
         # Writable temp dir so the JVM/Tomcat can run with a read-only root filesystem.
         - name: tmp
@@ -55,6 +70,12 @@ spec:
               value: '{{ .Values.LOG_LEVEL }}'
             - name: API_DBAAS_ADDRESS
               value: '{{ .Values.API_DBAAS_ADDRESS }}'
+            - name: KUBERNETES_M2M_ENABLED
+              value: '{{ .Values.M2M_ENABLED | default false }}'
+            # In the M2M phase, switch the dbaas Spring client from the Basic RestTemplate flavor to
+            # the M2M OkHttp client (getDbaasOkHttpClient). This env overrides application.yaml.
+            - name: DBAAS_RESTCLIENT_RESTTEMPLATE_BASIC_AUTH
+              value: '{{ not .Values.M2M_ENABLED }}'
             - name: JAVA_TOOL_OPTIONS
               value: '{{ .Values.JAVA_TOOL_OPTIONS }}'
           ports:
@@ -68,6 +89,11 @@ spec:
               mountPath: /etc/secrets/dbaas-secrets/{{ .secretName }}
               readOnly: true
             {{- end }}
+            {{- end }}
+            {{- if .Values.M2M_ENABLED }}
+            - name: dbaas-m2m-token
+              mountPath: /var/run/secrets/tokens/dbaas
+              readOnly: true
             {{- end }}
             - name: tmp
               mountPath: /tmp

--- a/test-apps/spring-test-app-service/helm-templates/spring-test-app-service/templates/ServiceAccount.yaml
+++ b/test-apps/spring-test-app-service/helm-templates/spring-test-app-service/templates/ServiceAccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.SAMPLE_SERVICE_ENABLED }}
+# Dedicated ServiceAccount for the sample service. Its projected `dbaas`-audience token identifies
+# the app to the aggregator (sub = system:serviceaccount:<ns>:{{ .Values.SERVICE_NAME }}) in the
+# direct-M2M phase; the aggregator maps that name to the DB_CLIENT role.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: '{{ .Values.SERVICE_NAME }}'
+  namespace: '{{ .Values.NAMESPACE }}'
+  labels:
+    app.kubernetes.io/name: '{{ .Values.SERVICE_NAME }}'
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/managed-by: '{{ .Values.MANAGED_BY }}'
+    app.kubernetes.io/component: sample-service
+{{- end }}

--- a/test-apps/spring-test-app-service/helm-templates/spring-test-app-service/values.yaml
+++ b/test-apps/spring-test-app-service/helm-templates/spring-test-app-service/values.yaml
@@ -18,6 +18,10 @@ LOG_LEVEL: info
 # REST fallback target. The mounted secret is consulted first; the integration test sets this
 # to a bogus host to prove the service keeps working without dbaas-aggregator.
 API_DBAAS_ADDRESS: http://dbaas-aggregator.dbaas:8080
+# Direct-M2M phase toggle. When true, the pod mounts a `dbaas`-audience projected token, the client
+# switches to the M2M OkHttp flavor (basic-auth off), and calls API_DBAAS_ADDRESS directly with a
+# Bearer. Default false keeps the mounted-secret / REST-fallback phases unchanged.
+M2M_ENABLED: false
 # Caps the JVM heap to a fraction of the container memory limit.
 JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=70.0"
 

--- a/test-apps/spring-test-app-service/src/main/java/com/netcracker/cloud/dbaas/testapp/config/DbaasM2MTenantHeaderConfig.java
+++ b/test-apps/spring-test-app-service/src/main/java/com/netcracker/cloud/dbaas/testapp/config/DbaasM2MTenantHeaderConfig.java
@@ -1,0 +1,102 @@
+package com.netcracker.cloud.dbaas.testapp.config;
+
+import com.netcracker.cloud.context.propagation.core.ContextManager;
+import com.netcracker.cloud.framework.contexts.tenant.BaseTenantProvider;
+import com.netcracker.cloud.framework.contexts.tenant.TenantContextObject;
+import com.netcracker.cloud.restclient.HttpMethod;
+import com.netcracker.cloud.restclient.MicroserviceRestClient;
+import com.netcracker.cloud.restclient.entity.RestClientResponseEntity;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TEMPORARY workaround for the direct-M2M phase (Pass C).
+ *
+ * <p>The dbaas Spring client's M2M flavor is an {@code OkHttp} client built by
+ * {@code M2MClientFactory.getDbaasOkHttpClient}. Unlike the RestTemplate transport
+ * ({@code SpringRestTemplateInterceptor}) and the Quarkus transport
+ * ({@code QuarkusRestClientInterceptor}), the OkHttp transport has no context-propagation
+ * interceptor, so the {@code Tenant} header is not forwarded. The aggregator then rejects
+ * tenant-scoped {@code GetOrCreateDatabase} calls with {@code CORE-DBAAS-4054}
+ * ("tenantId from classifier 'acme' and tenantId from request '' don't match"), because it reads
+ * the request tenant from its {@code TenantContext} (populated from the {@code Tenant} header) —
+ * and that check runs only for K8s-JWT (M2M) callers.
+ *
+ * <p>This decorator re-adds the {@code Tenant} header from the current {@link TenantContextObject}
+ * (pinned by the controller via {@code ContextManager.set}) to every {@code dbaasRestClient}
+ * request. Remove once OkHttp context propagation lands in the dbaas client library.
+ */
+@Configuration
+public class DbaasM2MTenantHeaderConfig {
+
+    static final String DBAAS_REST_CLIENT_BEAN = "dbaasRestClient";
+
+    @Bean
+    static BeanPostProcessor dbaasRestClientTenantHeaderPostProcessor() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) {
+                if (DBAAS_REST_CLIENT_BEAN.equals(beanName)
+                        && bean instanceof MicroserviceRestClient client
+                        && !(bean instanceof TenantHeaderRestClient)) {
+                    return new TenantHeaderRestClient(client);
+                }
+                return bean;
+            }
+        };
+    }
+
+    /** Delegating {@link MicroserviceRestClient} that injects the current {@code Tenant} header. */
+    static final class TenantHeaderRestClient implements MicroserviceRestClient {
+
+        private final MicroserviceRestClient delegate;
+
+        TenantHeaderRestClient(MicroserviceRestClient delegate) {
+            this.delegate = delegate;
+        }
+
+        private static String currentTenant() {
+            try {
+                TenantContextObject ctx = ContextManager.get(BaseTenantProvider.TENANT_CONTEXT_NAME);
+                return ctx == null ? null : ctx.getTenant();
+            } catch (RuntimeException e) {
+                return null;
+            }
+        }
+
+        private static Map<String, List<String>> withTenant(Map<String, List<String>> headers) {
+            String tenant = currentTenant();
+            if (tenant == null || tenant.isEmpty()) {
+                return headers;
+            }
+            Map<String, List<String>> merged = headers == null ? new HashMap<>() : new HashMap<>(headers);
+            merged.putIfAbsent(TenantContextObject.TENANT_HEADER, new ArrayList<>(List.of(tenant)));
+            return merged;
+        }
+
+        @Override
+        public <T> RestClientResponseEntity<T> doRequest(String url, HttpMethod httpMethod, Map<String, List<String>> headers,
+                                                         Object requestBody, Class<T> responseClass, Map<String, Object> params) {
+            return delegate.doRequest(url, httpMethod, withTenant(headers), requestBody, responseClass, params);
+        }
+
+        @Override
+        public <T> RestClientResponseEntity<T> doRequest(String url, HttpMethod httpMethod, Map<String, List<String>> headers,
+                                                         Object requestBody, Class<T> responseClass) {
+            return delegate.doRequest(url, httpMethod, withTenant(headers), requestBody, responseClass);
+        }
+
+        @Override
+        public <T> RestClientResponseEntity<T> doRequest(URI uri, HttpMethod httpMethod, Map<String, List<String>> headers,
+                                                         Object requestBody, Class<T> responseClass) {
+            return delegate.doRequest(uri, httpMethod, withTenant(headers), requestBody, responseClass);
+        }
+    }
+}

--- a/test-apps/spring-test-app-service/src/main/java/com/netcracker/cloud/dbaas/testapp/config/SecurityConfig.java
+++ b/test-apps/spring-test-app-service/src/main/java/com/netcracker/cloud/dbaas/testapp/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.netcracker.cloud.dbaas.testapp.config;
 
+import com.netcracker.cloud.security.core.auth.DummyM2MManager;
+import com.netcracker.cloud.security.core.auth.M2MManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,5 +25,19 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable);
         return http.build();
+    }
+
+    /**
+     * The dbaas REST client's M2M OkHttp flavor (selected in the direct-M2M phase via
+     * {@code dbaas.restclient.resttemplate.basic-auth=false}) autowires an {@link M2MManager}. This
+     * app has no platform gateway/Keycloak; for direct dbaas calls the aggregator is authenticated
+     * with the pod's projected {@code dbaas}-audience token (not this manager's token), so a dummy
+     * manager satisfies the dependency. Guarded by {@link ConditionalOnMissingBean} so a real
+     * manager wins if one is ever present, and harmless in the basic-auth phases (the bean is unused).
+     */
+    @Bean
+    @ConditionalOnMissingBean(M2MManager.class)
+    public M2MManager m2mManager() {
+        return new DummyM2MManager();
     }
 }


### PR DESCRIPTION
## What

Adds a third integration pass (**Phase C**) to *Sample Services Integration Tests* where all three
sample clients (go / spring / quarkus) call the DBaaS aggregator **directly over REST**, authenticated
with a Kubernetes **projected service-account token** (audience `dbaas`) — M2M — instead of via the
`dbaas-agent` sidecar. Complements the existing Pass A (mounted secret) and Pass B (REST fallback).

## How

- **Sample-app helm (3 charts):** dedicated `ServiceAccount` per app; a `dbaas`-audience projected
  token at `/var/run/secrets/tokens/dbaas/token` + `KUBERNETES_M2M_ENABLED`, gated on a new
  `M2M_ENABLED` value (default `false` → **Pass A/B unchanged**). M2M is activated **without touching
  app sources**, via helm env overrides:
  - Spring → `DBAAS_RESTCLIENT_RESTTEMPLATE_BASIC_AUTH=false` (selects the M2M OkHttp client)
  - Quarkus → clears aggregator basic-auth creds (`DbaasClientProducer` picks the M2M client)
  - Go → adds `API_DBAAS_ADDRESS` (koanf `api.dbaas.address`); `NewDbaasRestClient` is M2M-with-fallback
- **Aggregator:** map the three sample-app SAs to `DB_CLIENT` in `service-account-roles.yaml`.
- **deploy-sample-services.sh:** optional 3rd arg `M2M_ENABLED`, threaded to all charts.
- **Workflow:** grant the aggregator SA `system:service-account-issuer-discovery` (OIDC token
  verification) + restart; add the Phase C deploy/wait/test block after Pass B. The phase-agnostic IT
  suite is reused unchanged.
- **Docs:** Pass A/B/C + M2M env documented in the three sample READMEs.

## Server side — already present (no product code changes)

`dbaas.security.k8s.m2m.enabled/.audience=dbaas`, `BasicAndKubernetesAuthMechanism`,
`KubernetesJWTCallerPrincipalFactory` + `KubernetesTokenVerifier` (OIDC), `NamespaceValidator`,
`ServiceAccountRolesAugmentor` (defaults unknown SAs to `DB_CLIENT`). The aggregator is already
deployed in CI with `KUBERNETES_M2M_ENABLED=true`.

## Verification

- Local: `helm template` of all three charts (M2M on/off) renders the SA, projected token (audience
  `dbaas`), and env toggles correctly; with `M2M_ENABLED=false` nothing changes. Workflow YAML parses;
  `bash -n` on the deploy script passes.
- E2E (this PR's CI): the new **Phase C** step must go green — all three apps complete the 4-quadrant
  CRUD via direct M2M REST; **Pass A/B must remain green**.

## Risk

First CI exercise of the aggregator's **inbound K8s-JWT verification** (Pass A/B use mount / Basic).
The issuer-discovery RBAC + restart step covers OIDC discovery in kind; if verification still fails,
the aggregator logs will show it (may then need kube-apiserver `--service-account-issuer` /
`--api-audiences` in the kind config).