### PR TITLE
chore(ci): align log artifact names, add sample-service diagnostics

### DIFF
--- a/.github/workflows/integration-tests-sample-service.yml
+++ b/.github/workflows/integration-tests-sample-service.yml
@@ -308,24 +308,27 @@ jobs:
           path: test-apps/test-apps-integration-tests/target/surefire-reports/**
           if-no-files-found: warn
 
-      - name: Collect Fluent Bit logs
+      - name: Collect pod stdout (Fluent Bit)
         id: collect_fluentbit_logs
         if: always()
         run: |
           chmod +x .github/scripts/collect-fluentbit-logs.sh
           .github/scripts/collect-fluentbit-logs.sh
 
-      - name: Upload Fluent Bit logs
+      - name: Upload pod stdout (Fluent Bit)
         if: always() && steps.collect_fluentbit_logs.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          name: sample-services-pod-logs
+          name: sample-services-pod-stdout
           path: fluentbit-logs/**
           if-no-files-found: warn
 
-      - name: Dump diagnostics on failure
-        # always() so this also runs when the deploy/rollout fails (which skips the tests step);
-        # the body stays quiet on a fully green run.
+      - name: Collect K8s diagnostics (kubectl)
+        id: collect_diagnostics
+        # always() so this also runs when the deploy/rollout fails (which skips the tests step).
+        # Each section is written to a file (for the downloadable artifact) AND echoed to the job
+        # log with ::group:: folding — one kubectl call per section, so file and console show the
+        # same snapshot. A fully green run writes no files, so no diagnostics artifact is produced.
         if: always()
         run: |
           set +e
@@ -335,38 +338,58 @@ jobs:
             echo "All sample-service tests passed; skipping diagnostics."
             exit 0
           fi
-          echo "::group::All pods"
-          kubectl get pods -A -o wide
-          echo "::endgroup::"
-          echo "::group::Sample-service pods describe (scheduling / FailedMount events)"
+
+          DIAG=diagnostics
+          mkdir -p "$DIAG"
+          dump() { echo "::group::$1"; cat "$DIAG/$2"; echo "::endgroup::"; }
+
+          kubectl get pods -A -o wide > "$DIAG/all-pods.txt" 2>&1
+          dump "All pods" all-pods.txt
+
           for svc in "$GO_SERVICE_NAME" "$SPRING_SERVICE_NAME" "$QUARKUS_SERVICE_NAME"; do
-            kubectl -n "$TEST_NAMESPACE" describe pod -l app.kubernetes.io/name="$svc"
+            kubectl -n "$TEST_NAMESPACE" describe pod -l app.kubernetes.io/name="$svc" >> "$DIAG/sample-pods-describe.txt" 2>&1
           done
-          echo "::endgroup::"
-          echo "::group::All InternalDatabase + DatabaseSecretClaim ($TEST_NAMESPACE)"
-          kubectl -n "$TEST_NAMESPACE" get internaldatabase,databasesecretclaim -o wide
-          kubectl -n "$TEST_NAMESPACE" get internaldatabase,databasesecretclaim -o yaml
-          echo "::endgroup::"
-          echo "::group::Secrets ($TEST_NAMESPACE)"
-          kubectl -n "$TEST_NAMESPACE" get secret -o name
-          echo "::endgroup::"
-          echo "::group::Physical databases on Patroni + dbaas classifier registry (who created what)"
+          dump "Sample-service pods describe (scheduling / FailedMount events)" sample-pods-describe.txt
+
+          {
+            kubectl -n "$TEST_NAMESPACE" get internaldatabase,databasesecretclaim -o wide
+            echo
+            kubectl -n "$TEST_NAMESPACE" get internaldatabase,databasesecretclaim -o yaml
+          } > "$DIAG/internaldatabase-databasesecretclaim.txt" 2>&1
+          dump "All InternalDatabase + DatabaseSecretClaim ($TEST_NAMESPACE)" internaldatabase-databasesecretclaim.txt
+
+          kubectl -n "$TEST_NAMESPACE" get secret -o name > "$DIAG/secrets.txt" 2>&1
+          dump "Secrets ($TEST_NAMESPACE)" secrets.txt
+
           PG_POD="$(kubectl -n postgres get pods -o name | grep '^pod/pg-patroni-' | head -1 | cut -d/ -f2)"
-          echo "patroni pod: $PG_POD"
-          kubectl -n postgres exec "$PG_POD" -- bash -lc "psql -U postgres -P pager=off -c '\l'" 2>&1
-          echo "--- every dbaas-managed classifier (microserviceName/namespace/scope/tenantId) by creation time ---"
-          kubectl -n postgres exec "$PG_POD" -- bash -lc "psql -U postgres -d dbaas -P pager=off -c \"select time_db_creation, type, namespace, classifier from classifier order by time_db_creation;\"" 2>&1
-          echo "::endgroup::"
+          {
+            echo "patroni pod: $PG_POD"
+            kubectl -n postgres exec "$PG_POD" -- bash -lc "psql -U postgres -P pager=off -c '\l'"
+            echo "--- every dbaas-managed classifier (microserviceName/namespace/scope/tenantId) by creation time ---"
+            kubectl -n postgres exec "$PG_POD" -- bash -lc "psql -U postgres -d dbaas -P pager=off -c \"select time_db_creation, type, namespace, classifier from classifier order by time_db_creation;\""
+          } > "$DIAG/physical-databases-and-classifiers.txt" 2>&1
+          dump "Physical databases on Patroni + dbaas classifier registry (who created what)" physical-databases-and-classifiers.txt
+
           for pair in "dbaas-operator:$TEST_NAMESPACE" "dbaas-aggregator:$TEST_NAMESPACE" "dbaas-postgres-adapter:postgres"; do
             d="${pair%%:*}"; ns="${pair##*:}"
-            echo "::group::logs $d ($ns)"
-            kubectl -n "$ns" logs deploy/"$d" --all-containers=true --tail=2000 2>&1
-            echo "::endgroup::"
+            kubectl -n "$ns" logs deploy/"$d" --all-containers=true --tail=2000 > "$DIAG/logs-$d.txt" 2>&1
+            dump "logs $d ($ns)" "logs-$d.txt"
           done
-          echo "::group::Recent events ($TEST_NAMESPACE + postgres)"
-          kubectl -n "$TEST_NAMESPACE" get events --sort-by=.lastTimestamp | tail -150
-          kubectl -n postgres get events --sort-by=.lastTimestamp | tail -100
-          echo "::endgroup::"
+
+          {
+            kubectl -n "$TEST_NAMESPACE" get events --sort-by=.lastTimestamp | tail -150
+            echo "--- postgres ---"
+            kubectl -n postgres get events --sort-by=.lastTimestamp | tail -100
+          } > "$DIAG/events.txt" 2>&1
+          dump "Recent events ($TEST_NAMESPACE + postgres)" events.txt
+
+      - name: Upload K8s diagnostics (kubectl)
+        if: always() && steps.collect_diagnostics.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sample-services-k8s-diagnostics
+          path: diagnostics/**
+          if-no-files-found: ignore
 
       - name: Fail job if sample service tests failed
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -227,33 +227,33 @@ jobs:
           name: surefire-reports
           path: artifacts/*
 
-      - name: Collect Fluent Bit logs
+      - name: Collect pod stdout (Fluent Bit)
         id: collect_fluentbit_logs
         if: always()
         run: |
           chmod +x .github/scripts/collect-fluentbit-logs.sh && \
           .github/scripts/collect-fluentbit-logs.sh
 
-      - name: Upload Fluent Bit logs
+      - name: Upload pod stdout (Fluent Bit)
         if: always() && steps.collect_fluentbit_logs.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          name: dbaas-pod-logs
+          name: dbaas-pod-stdout
           path: fluentbit-logs/**
           if-no-files-found: warn
 
-      - name: Collect DBaaS logs
+      - name: Collect K8s diagnostics (kubectl)
         id: collect_logs
         if: always()
         run: |
           chmod +x .github/scripts/get-dbaas-logs.sh && \
           .github/scripts/get-dbaas-logs.sh
 
-      - name: Upload DBaaS logs
+      - name: Upload K8s diagnostics (kubectl)
         if: always() && steps.collect_logs.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
-          name: dbaas-logs
+          name: dbaas-k8s-diagnostics
           path: logs/*
 
       - name: Build test report


### PR DESCRIPTION
## Why

The CI log artifacts read ambiguously — `dbaas-logs` and `dbaas-pod-logs` both
just say "logs", so it is not obvious which one to download. And the
sample-service workflow only exposed Fluent Bit stdout as an artifact; its
richer kubectl diagnostics (describe / events / CR YAML / Patroni / classifier
registry) were dumped to the job log only, so they could not be downloaded —
exactly the info you need when a pod never starts (ImagePull / CrashLoop /
OOMKilled), where the stdout artifact is empty.

## What

Naming (both `integration-tests.yml` and `integration-tests-sample-service.yml`):

| Before | After |
| --- | --- |
| `dbaas-pod-logs` | `dbaas-pod-stdout` |
| `dbaas-logs` | `dbaas-k8s-diagnostics` |
| `sample-services-pod-logs` | `sample-services-pod-stdout` |

Step names aligned to `Collect/Upload ... (tool)` in both workflows.

Sample-service diagnostics promoted to an artifact:

- The `Dump diagnostics on failure` console step is split into
  `Collect K8s diagnostics (kubectl)` + `Upload K8s diagnostics (kubectl)`,
  producing a new `sample-services-k8s-diagnostics` artifact.
- Each section is written to a file **and** echoed to the job log with
  `::group::` folding — one `kubectl` call per section, so file and console
  show the same snapshot. Nothing from the previous console dump is lost.
- Collected only on failure (the existing green-run early-exit is kept); the
  upload uses `if-no-files-found: ignore`, so a green run produces no artifact.

No product code touched — CI workflow metadata only.

## How to verify

- Run **Sample Services Integration Tests** and **DBaaS Integration Tests**;
  on green, artifacts are `*-pod-stdout` (+ surefire); no diagnostics artifact.
- Force a failure (e.g. break a rollout) and confirm a `*-k8s-diagnostics`
  artifact appears with the describe / events / logs sections, and the job log
  still shows the same folded `::group::` output.
