### PR TITLE
chore(ci): skip operator build for docs/dev-only commits

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -9,8 +9,17 @@ on:
   push:
     branches:
       - main
+    # Skip the operator build for commits that touch only operator docs/dev helpers.
+    # paths-ignore skips the run only when EVERY changed file matches; a mixed
+    # docs-plus-code commit still builds.
+    paths-ignore:
+      - 'dbaas-operator/docs/**'
+      - 'dbaas-operator/dev/**'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'dbaas-operator/docs/**'
+      - 'dbaas-operator/dev/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why

The Go operator build (`go-build.yml`) runs on every push to `main` and every
PR, with no path filter. Commits that touch only `dbaas-operator/docs` or
`dbaas-operator/dev` therefore trigger a full operator build + test, even
though neither folder affects the built binary.

## What

Add `paths-ignore` to both the `push` and `pull_request` triggers:

```yaml
paths-ignore:
  - 'dbaas-operator/docs/**'
  - 'dbaas-operator/dev/**'
```

`paths-ignore` skips a run only when **every** changed file matches, so a mixed
docs-plus-code commit still builds. `workflow_dispatch` is kept for manual runs.

## How to verify

- A commit that changes only files under `dbaas-operator/docs/**` or
  `dbaas-operator/dev/**` → **Go Build** does not run.
- A commit that also changes any other file → **Go Build** runs as before.

Safe to skip: `Go Build` is not a required status check on `main` (the
`main-protection` ruleset requires a PR + 1 review only, no status checks) or on
`feat/operator-dev` (no rules), so a docs-only PR is not blocked by a skipped run.
