### PR TITLE
build: add required property to backupDaemon (port of #591)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,7 +139,8 @@ jobs:
             securityContext:
               runAsUser: 101
               fsGroup: 101
-      
+            s3Aliases: []
+
           dbaas:
             install: true
             aggregator:


### PR DESCRIPTION
## Why

Ports #591 to `feat/operator-dev`. That PR targets `main`, so the change would not reach this branch
until `main` is merged back in; the integration tests run from `feat/operator-dev` today and need the
property now.

The patroni-services chart requires `backupDaemon.s3Aliases`. Without it the backup daemon fails to
render, so `Deploy DBaaS` in the integration-tests workflow cannot come up.

## What

Cherry-picked `adaf121e` from #591 (authorship preserved: Alisher Askar). One line:

```yaml
            securityContext:
              runAsUser: 101
              fsGroup: 101
+           s3Aliases: []
```

The cherry-pick conflicted on context, not content: the blank line after `fsGroup: 101` carries
trailing whitespace on this branch but not on `main`. Resolved by keeping the added property and
dropping the trailing whitespace, which also aligns this spot with `main` and avoids the same
conflict next time. Hence `+2/-1` rather than `+1`.

`integration-tests-sample-service.yml` deliberately does **not** get the property: it sets
`backupDaemon.install: false`, so the daemon is never rendered there.

## How to verify

The workflow file parses, and the values document embedded in the heredoc parses with
`backupDaemon.s3Aliases == []`. The real check is the **DBaaS Integration Tests** run on this branch
getting past `Deploy DBaaS`.

## Note

#591 should still merge into `main` on its own — this PR does not replace it, it only stops
`feat/operator-dev` from waiting on the back-merge.
