### PR TITLE
fix(ci): configure default S3 alias for the backup daemon

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,7 +139,16 @@ jobs:
             securityContext:
               runAsUser: 101
               fsGroup: 101
-      
+            s3Aliases:
+              - name: default
+                spec:
+                  storageServerUrl: http://minio.minio.svc.cluster.local
+                  storageBucket: dbaas-backup-restore-test
+                  storageUsername: minio
+                  storageRegion: region123
+                secretContent:
+                  storagePassword: minio123
+
           dbaas:
             install: true
             aggregator:


### PR DESCRIPTION
## Why

Every backup test in `BackupV3IT$Database$Postgresql` fails in the integration-tests workflow, and the job then hangs
well past its usual runtime while the test polls a backup that can never succeed (the last run produced a job log over
500 MB).

The tests send `storageName: "default"` in every backup and restore request. The postgres backup daemon resolves a
storage name only when S3 aliases are enabled, and rejects the request otherwise
([`storage_s3.py:60-64`](https://github.com/Netcracker/pgskipper-operator/blob/main/services/backup-daemon/docker/granular/storage_s3.py#L60-L64)):

```text
storageName was provided but S3 aliases are not enabled
```

`dbaas-postgres-adapter` turns that response into `PanicError` and returns HTTP 500, so the aggregator fails the logical
backup with `[CORE-DBAAS-4018] Backup execution failed` and marks it `RETRYABLE_FAIL`.

The workflow never configured aliases. The `patroni-services` chart sets `s3AliasesUsed: true` in the CR only when
`backupDaemon.s3Aliases` is a non-empty list, and the operator passes `S3_ALIASES_USED=true` to the daemon only when
that field is set — so an empty or absent list leaves the daemon with aliases disabled.

## What

Declare one alias named `default` under `backupDaemon.s3Aliases` in `patroni-services-values.yaml`, pointing at the same
MinIO tenant already configured under `s3Storage`. Field names follow the chart's
[`s3-aliases-secret.yaml`](https://github.com/Netcracker/pgskipper-operator/blob/main/operator/charts/patroni-services/templates/secrets/s3-aliases-secret.yaml)
mapping: `storageServerUrl` → `s3Url`, `storageBucket` → `bucketName`, `storageUsername` → `accessKeyId`,
`storagePassword` → `accessKeySecret`.

## How to verify

Run the `DBaaS Integration Tests` workflow on this branch and check that the `BackupV3IT$Database$Postgresql` backup
tests pass:

- `testBackupRestoreV1_backupRestore`
- `testBackupRestoreV1_testParallelBackupRestore`
- `testBackupRestoreV1_restoreDeletedBackup`
- `testBackupRestoreV1_testEnrichingBackupRestore`
- `testBackupRestoreV1_importAndExportBackupMetadata`

The `postgres-backup-daemon` deployment should carry `S3_ALIASES_USED=true` and mount the `s3-aliases` secret.

## Follow-up

Two unrelated failure groups in the same run are out of scope here:

- `DatabaseMigrationIT` and `testMigratedExternalToInternalDatabasesBackupRestore` fail with
  `Key 'username' not found in secret 'dbaas-aggregator-credentials.v1' in namespace postgres`.
- `OperatorIT` and `BlueGreenV1IT` hit `SocketTimeoutException`, most likely secondary to the stalled backup tests.
