### PR TITLE
fix(tests): read adapter credentials from the mounted secret

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,7 +139,16 @@ jobs:
             securityContext:
               runAsUser: 101
               fsGroup: 101
-      
+            s3Aliases:
+              - name: default
+                spec:
+                  storageServerUrl: http://minio.minio.svc.cluster.local
+                  storageBucket: dbaas-backup-restore-test
+                  storageUsername: minio
+                  storageRegion: region123
+                secretContent:
+                  storagePassword: minio123
+
           dbaas:
             install: true
             aggregator:

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/MigrationHelper.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/MigrationHelper.java
@@ -7,7 +7,11 @@ import com.mongodb.client.MongoDatabase;
 import com.netcracker.it.dbaas.entity.*;
 import com.netcracker.it.dbaas.entity.response.MigrationResult;
 import com.netcracker.it.dbaas.exceptions.CannotConnect;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +19,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -45,7 +50,8 @@ public class MigrationHelper {
             .build();
 
     private static final String DBAAS_METADATA = "_dbaas_metadata";
-    private static final String ADAPTER_CREDS_SECRET_NAME = "dbaas-aggregator-credentials.v1";
+    private static final String AGGREGATOR_CREDS_SECRET_NAME = "dbaas-aggregator-credentials.v1";
+    private static final String ADAPTER_CREDS_MOUNT_DIR = "dbaas-adapter-credentials";
     public static final String CONNECTION_PROPERTIES = "connectionProperties";
 
     public static final String BASE_MIGRATE_API = "api/v3/dbaas/migration/databases";
@@ -130,19 +136,29 @@ public class MigrationHelper {
                         "Could not find adapter pod for service " + adapterServiceName
                                 + " in namespace: " + adapterNamespace));
 
-        String username = readFirstAvailableSecretFromEnv(
-                adapterPod,
-                adapterNamespace,
-                List.of("DBAAS_ADAPTER_API_USER", "DBAAS_AGGREGATOR_USERNAME")
-        ).orElseGet(() -> readFromAggregatorCredentialsSecret(adapterNamespace, "username"));
+        String username = readAdapterCredential(adapterPod, adapterNamespace, "username",
+                List.of("DBAAS_ADAPTER_API_USER", "DBAAS_AGGREGATOR_USERNAME"));
 
-        String password = readFirstAvailableSecretFromEnv(
-                adapterPod,
-                adapterNamespace,
-                List.of("DBAAS_ADAPTER_API_PASSWORD", "DBAAS_AGGREGATOR_PASSWORD")
-        ).orElseGet(() -> readFromAggregatorCredentialsSecret(adapterNamespace, "password"));
+        String password = readAdapterCredential(adapterPod, adapterNamespace, "password",
+                List.of("DBAAS_ADAPTER_API_PASSWORD", "DBAAS_AGGREGATOR_PASSWORD"));
 
         return username + ":" + password;
+    }
+
+    /**
+     * Reads one basic-auth credential of the adapter API. Adapters expose these credentials in one of three ways,
+     * depending on their version: through secret-backed environment variables, through a mounted credentials secret,
+     * or through the shared aggregator credentials secret.
+     */
+    private String readAdapterCredential(Pod pod, String namespace, String key, List<String> envNames) {
+        return readFirstAvailableSecretFromEnv(pod, namespace, envNames)
+                .or(() -> readFromMountedCredentialsSecret(pod, namespace, key))
+                .or(() -> readSecretKey(namespace, AGGREGATOR_CREDS_SECRET_NAME, key))
+                .orElseThrow(() -> new RuntimeException(
+                        "Could not read adapter credential '" + key + "' in namespace " + namespace
+                                + ": none of the environment variables " + envNames + " is backed by a secret,"
+                                + " the pod has no '" + ADAPTER_CREDS_MOUNT_DIR + "' volume mount,"
+                                + " and secret '" + AGGREGATOR_CREDS_SECRET_NAME + "' holds no such key"));
     }
 
     private Optional<String> readFirstAvailableSecretFromEnv(Pod pod, String namespace, List<String> envNames) {
@@ -155,13 +171,30 @@ public class MigrationHelper {
         return Optional.empty();
     }
 
-    private String readFromAggregatorCredentialsSecret(String namespace, String key) {
-        var secret = helperV3.getKubernetesClientSecret(namespace, ADAPTER_CREDS_SECRET_NAME);
+    /**
+     * Resolves the secret behind the adapter credentials volume mount and reads a key from it. The secret name is
+     * taken from the pod spec rather than hard-coded, because it differs between adapters.
+     */
+    private Optional<String> readFromMountedCredentialsSecret(Pod pod, String namespace, String key) {
+        Container container = pod.getSpec().getContainers().getFirst();
+        return container.getVolumeMounts().stream()
+                .filter(mount -> StringUtils.removeEnd(mount.getMountPath(), "/").endsWith(ADAPTER_CREDS_MOUNT_DIR))
+                .map(VolumeMount::getName)
+                .findFirst()
+                .flatMap(volumeName -> pod.getSpec().getVolumes().stream()
+                        .filter(volume -> volumeName.equals(volume.getName()))
+                        .findFirst())
+                .map(Volume::getSecret)
+                .map(SecretVolumeSource::getSecretName)
+                .flatMap(secretName -> readSecretKey(namespace, secretName, key));
+    }
+
+    private Optional<String> readSecretKey(String namespace, String secretName, String key) {
+        var secret = helperV3.getKubernetesClientSecret(namespace, secretName);
         if (secret == null || secret.getData() == null || !secret.getData().containsKey(key)) {
-            throw new RuntimeException("Key '" + key + "' not found in secret '" + ADAPTER_CREDS_SECRET_NAME + "'"
-                    + " in namespace " + namespace);
+            return Optional.empty();
         }
-        return new String(Base64.getDecoder().decode(secret.getData().get(key)));
+        return Optional.of(new String(Base64.getDecoder().decode(secret.getData().get(key))));
     }
 
     public DatabaseResponse prepareMigratedExternalToInternalPostgresDatabase(String sourceNamespace,


### PR DESCRIPTION
> Stacked on #593. Review that one first; this PR's diff contains its commit until it merges.

## Why

Six integration tests fail in every run with the same error:

```text
Key 'username' not found in secret 'dbaas-aggregator-credentials.v1' in namespace postgres
```

- `DatabaseMigrationIT` — `migrateDatabaseSuccessfullyMigratedPostgreSql`, `migrateWithUserCreation_SuccessfullyMigratedPostgresql`, `migrateWithUserCreation_SuccessfullyMigratedPostgresql_SetOnlyHostDb`, `migrateDatabaseSuccessfullyMigratedPostgresql_SetOnlyHostDb`, `migrateWithUserCreation_MigrateExternalAsInternal`
- `BackupV3IT$Database$Postgresql#testMigratedExternalToInternalDatabasesBackupRestore`

`MigrationHelper.readAdapterCredentials` needs the adapter's basic-auth credentials to create a database through the
adapter API. It read them from the `DBAAS_ADAPTER_API_USER` / `DBAAS_ADAPTER_API_PASSWORD` environment variables, and
fell back to the `dbaas-aggregator-credentials.v1` secret.

Both paths are now dead ends for the postgres adapter. pgskipper-operator moved the adapter to mounted secrets: the
deployment mounts `dbaas-adapter-credentials` at `/var/run/secrets/postgresql/dbaas-adapter-credentials` and the adapter
reads `serve_user` and `serve_pass` from that directory
([`main.go:77-87`](https://github.com/Netcracker/pgskipper-operator/blob/main/services/dbaas-adapter/adapter/main.go#L77-L87)).
No credential environment variables remain. And `dbaas-aggregator-credentials.v1` is the *mongo* adapter's secret name
([`const.go:102`](https://github.com/Netcracker/qubership-mongodb-operator/blob/main/operator/pkg/utils/const.go#L102)) —
it never existed in the `postgres` namespace.

## What

Add a mounted-secret step to the lookup chain in `MigrationHelper`. The secret name comes from the pod spec — find the
volume mount whose path ends with `dbaas-adapter-credentials`, resolve it to the backing secret, read the key — rather
than being hard-coded, so the helper keeps working as adapters diverge.

The order is now: secret-backed environment variable, mounted credentials secret, aggregator credentials secret. The
first and last steps are unchanged, so adapters on older versions keep working. The final error message now names every
source that was tried instead of only the last one.

## How to verify

Run the `DBaaS Integration Tests` workflow on this branch. All six tests listed above should pass, and the run should
have no failures at all once #593 is included.

`mvn -o test-compile -pl dbaas/dbaas-integration-tests` compiles clean.
