### PR TITLE
chore(ci): snapshot aggregator threads and PG locks during tests

### DIFF
--- a/.github/scripts/watch-aggregator-stalls.sh
+++ b/.github/scripts/watch-aggregator-stalls.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Periodic snapshots of what the aggregator and its PostgreSQL are blocked on.
+#
+# Aimed at the stall where every code path guarded by DBAAS_REPOSITORIES_MUTEX
+# freezes: logical database writes and H2 cache reloads stop, external database
+# registrations pile up unanswered, and the aggregator only recovers when the pod
+# is replaced. Log lines alone cannot name the blocked frame, so each round takes
+# a JVM thread dump and a PostgreSQL lock snapshot at the same moment.
+#
+# Runs in the background for the whole test step, so it must NEVER fail the job:
+# no `set -e`, every kubectl call guarded, unavailable pods skipped.
+set -uo pipefail
+
+OUT_DIR="${OUT_DIR:-./thread-dumps}"
+INTERVAL="${INTERVAL:-60}"
+AGG_NS="${AGG_NS:-dbaas}"
+AGG_DEPLOY="${AGG_DEPLOY:-dbaas-aggregator}"
+PG_NS="${PG_NS:-postgres}"
+PG_POD="${PG_POD:-pg-patroni-node1-0}"
+
+mkdir -p "$OUT_DIR"
+
+# SIGQUIT prints the dump to the JVM's stdout, which Fluent Bit already collects.
+# jcmd returns it on our own stdout instead, which keeps the dumps timestamped and
+# separate from a multi-megabyte pod log, so try jcmd first.
+dump_threads() {
+  local pod=$1 stamp=$2
+  local out="$OUT_DIR/${pod}-${stamp}.threads.txt"
+
+  # shellcheck disable=SC2016  # the body runs in the pod's shell, not this one
+  kubectl -n "$AGG_NS" exec "$pod" -c "$AGG_DEPLOY" -- sh -c '
+    pid=""
+    for proc in /proc/[0-9]*; do
+      [ -r "$proc/cmdline" ] || continue
+      case "$(tr "\0" " " < "$proc/cmdline")" in
+        *java*) pid="${proc#/proc/}"; break ;;
+      esac
+    done
+    [ -n "$pid" ] || { echo "no java process found"; exit 1; }
+
+    if command -v jcmd >/dev/null 2>&1; then
+      jcmd "$pid" Thread.print -l
+    else
+      echo "jcmd unavailable, sent SIGQUIT to pid $pid — dump is in the pod stdout"
+      kill -3 "$pid"
+    fi
+  ' > "$out" 2>&1
+
+  if [ ! -s "$out" ]; then
+    rm -f "$out"
+  fi
+}
+
+# A thread parked on a PostgreSQL row lock looks like an ordinary socket read in the
+# thread dump. pg_stat_activity names the blocker, so capture both sides.
+dump_pg_locks() {
+  local stamp=$1
+  kubectl -n "$PG_NS" exec "$PG_POD" -- psql -U postgres -d postgres -X -P pager=off -c "
+    SELECT now() AS captured_at, a.pid, a.state, a.wait_event_type, a.wait_event,
+           age(clock_timestamp(), a.xact_start) AS xact_age,
+           age(clock_timestamp(), a.query_start) AS query_age,
+           cardinality(pg_blocking_pids(a.pid)) AS blockers,
+           pg_blocking_pids(a.pid) AS blocked_by,
+           left(a.query, 200) AS query
+      FROM pg_stat_activity a
+     WHERE a.backend_type = 'client backend'
+       AND a.state <> 'idle'
+     ORDER BY xact_age DESC NULLS LAST;
+  " > "$OUT_DIR/pg-activity-${stamp}.txt" 2>&1
+
+  if [ ! -s "$OUT_DIR/pg-activity-${stamp}.txt" ]; then
+    rm -f "$OUT_DIR/pg-activity-${stamp}.txt"
+  fi
+}
+
+echo "Watching $AGG_DEPLOY in $AGG_NS every ${INTERVAL}s, writing to $OUT_DIR"
+
+while :; do
+  stamp=$(date -u +%Y%m%dT%H%M%SZ)
+
+  pods=$(kubectl -n "$AGG_NS" get pods -l "name=$AGG_DEPLOY" \
+           --field-selector=status.phase=Running -o name 2>/dev/null)
+  for pod in $pods; do
+    dump_threads "${pod#pod/}" "$stamp"
+  done
+
+  dump_pg_locks "$stamp"
+  sleep "$INTERVAL"
+done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,7 +139,16 @@ jobs:
             securityContext:
               runAsUser: 101
               fsGroup: 101
-      
+            s3Aliases:
+              - name: default
+                spec:
+                  storageServerUrl: http://minio.minio.svc.cluster.local
+                  storageBucket: dbaas-backup-restore-test
+                  storageUsername: minio
+                  storageRegion: region123
+                secretContent:
+                  storagePassword: minio123
+
           dbaas:
             install: true
             aggregator:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -208,11 +208,32 @@ jobs:
           kubectl -n postgres get events --sort-by=.lastTimestamp | tail -40
           echo "::endgroup::"
 
+      - name: Start aggregator stall watchdog
+        run: |
+          chmod +x .github/scripts/watch-aggregator-stalls.sh
+          nohup .github/scripts/watch-aggregator-stalls.sh > watchdog.log 2>&1 &
+          echo "WATCHDOG_PID=$!" >> "$GITHUB_ENV"
+
       - name: Run tests
         id: tests
         run: mvn --batch-mode -Dmaven.test.failure.ignore=true -DskipIT="false" -Dclouds.cloud.name="kind-kind" -Dclouds.cloud.namespaces.namespace="dbaas" test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop aggregator stall watchdog
+        if: always()
+        run: |
+          kill "${WATCHDOG_PID:-}" 2>/dev/null || true
+          cp watchdog.log thread-dumps/ 2>/dev/null || true
+          ls -la thread-dumps/ 2>/dev/null || echo "no snapshots collected"
+
+      - name: Upload aggregator stall snapshots
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: aggregator-stall-snapshots
+          path: thread-dumps/**
+          if-no-files-found: warn
 
       - name: Aggregate Surefire reports
         id: collect_reports

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/MigrationHelper.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/helpers/MigrationHelper.java
@@ -7,7 +7,11 @@ import com.mongodb.client.MongoDatabase;
 import com.netcracker.it.dbaas.entity.*;
 import com.netcracker.it.dbaas.entity.response.MigrationResult;
 import com.netcracker.it.dbaas.exceptions.CannotConnect;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.SecretVolumeSource;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +19,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -45,7 +50,8 @@ public class MigrationHelper {
             .build();
 
     private static final String DBAAS_METADATA = "_dbaas_metadata";
-    private static final String ADAPTER_CREDS_SECRET_NAME = "dbaas-aggregator-credentials.v1";
+    private static final String AGGREGATOR_CREDS_SECRET_NAME = "dbaas-aggregator-credentials.v1";
+    private static final String ADAPTER_CREDS_MOUNT_DIR = "dbaas-adapter-credentials";
     public static final String CONNECTION_PROPERTIES = "connectionProperties";
 
     public static final String BASE_MIGRATE_API = "api/v3/dbaas/migration/databases";
@@ -130,19 +136,29 @@ public class MigrationHelper {
                         "Could not find adapter pod for service " + adapterServiceName
                                 + " in namespace: " + adapterNamespace));
 
-        String username = readFirstAvailableSecretFromEnv(
-                adapterPod,
-                adapterNamespace,
-                List.of("DBAAS_ADAPTER_API_USER", "DBAAS_AGGREGATOR_USERNAME")
-        ).orElseGet(() -> readFromAggregatorCredentialsSecret(adapterNamespace, "username"));
+        String username = readAdapterCredential(adapterPod, adapterNamespace, "username",
+                List.of("DBAAS_ADAPTER_API_USER", "DBAAS_AGGREGATOR_USERNAME"));
 
-        String password = readFirstAvailableSecretFromEnv(
-                adapterPod,
-                adapterNamespace,
-                List.of("DBAAS_ADAPTER_API_PASSWORD", "DBAAS_AGGREGATOR_PASSWORD")
-        ).orElseGet(() -> readFromAggregatorCredentialsSecret(adapterNamespace, "password"));
+        String password = readAdapterCredential(adapterPod, adapterNamespace, "password",
+                List.of("DBAAS_ADAPTER_API_PASSWORD", "DBAAS_AGGREGATOR_PASSWORD"));
 
         return username + ":" + password;
+    }
+
+    /**
+     * Reads one basic-auth credential of the adapter API. Adapters expose these credentials in one of three ways,
+     * depending on their version: through secret-backed environment variables, through a mounted credentials secret,
+     * or through the shared aggregator credentials secret.
+     */
+    private String readAdapterCredential(Pod pod, String namespace, String key, List<String> envNames) {
+        return readFirstAvailableSecretFromEnv(pod, namespace, envNames)
+                .or(() -> readFromMountedCredentialsSecret(pod, namespace, key))
+                .or(() -> readSecretKey(namespace, AGGREGATOR_CREDS_SECRET_NAME, key))
+                .orElseThrow(() -> new RuntimeException(
+                        "Could not read adapter credential '" + key + "' in namespace " + namespace
+                                + ": none of the environment variables " + envNames + " is backed by a secret,"
+                                + " the pod has no '" + ADAPTER_CREDS_MOUNT_DIR + "' volume mount,"
+                                + " and secret '" + AGGREGATOR_CREDS_SECRET_NAME + "' holds no such key"));
     }
 
     private Optional<String> readFirstAvailableSecretFromEnv(Pod pod, String namespace, List<String> envNames) {
@@ -155,13 +171,30 @@ public class MigrationHelper {
         return Optional.empty();
     }
 
-    private String readFromAggregatorCredentialsSecret(String namespace, String key) {
-        var secret = helperV3.getKubernetesClientSecret(namespace, ADAPTER_CREDS_SECRET_NAME);
+    /**
+     * Resolves the secret behind the adapter credentials volume mount and reads a key from it. The secret name is
+     * taken from the pod spec rather than hard-coded, because it differs between adapters.
+     */
+    private Optional<String> readFromMountedCredentialsSecret(Pod pod, String namespace, String key) {
+        Container container = pod.getSpec().getContainers().getFirst();
+        return container.getVolumeMounts().stream()
+                .filter(mount -> StringUtils.removeEnd(mount.getMountPath(), "/").endsWith(ADAPTER_CREDS_MOUNT_DIR))
+                .map(VolumeMount::getName)
+                .findFirst()
+                .flatMap(volumeName -> pod.getSpec().getVolumes().stream()
+                        .filter(volume -> volumeName.equals(volume.getName()))
+                        .findFirst())
+                .map(Volume::getSecret)
+                .map(SecretVolumeSource::getSecretName)
+                .flatMap(secretName -> readSecretKey(namespace, secretName, key));
+    }
+
+    private Optional<String> readSecretKey(String namespace, String secretName, String key) {
+        var secret = helperV3.getKubernetesClientSecret(namespace, secretName);
         if (secret == null || secret.getData() == null || !secret.getData().containsKey(key)) {
-            throw new RuntimeException("Key '" + key + "' not found in secret '" + ADAPTER_CREDS_SECRET_NAME + "'"
-                    + " in namespace " + namespace);
+            return Optional.empty();
         }
-        return new String(Base64.getDecoder().decode(secret.getData().get(key)));
+        return Optional.of(new String(Base64.getDecoder().decode(secret.getData().get(key))));
     }
 
     public DatabaseResponse prepareMigratedExternalToInternalPostgresDatabase(String sourceNamespace,


### PR DESCRIPTION
> **Diagnostics — do not merge.** Stacked on #594. Meant to run until the freeze is caught, name the blocked frame, and
> then be replaced by the actual fix.

## Why

Some integration-test runs freeze every code path guarded by `DBAAS_REPOSITORIES_MUTEX`
([ServicesConfig.java:36](https://github.com/Netcracker/qubership-dbaas/blob/feat/operator-dev/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/config/ServicesConfig.java#L36)),
a single static monitor shared by logical-database persistence, the H2 cache reload, and the Postgres table listeners.

In run [29850808300](https://github.com/Netcracker/qubership-dbaas/actions/runs/29850808300) the aggregator logged its
last `External logical database was saved`, `New database was created`, and `finished reload in databaseregistry` at
17:23:44. For the next 26 minutes it accepted 32 registration requests, logged `Skip creation` for each, and answered
none — while unrelated endpoints (Blue/Green, physical database registration) kept serving normally. The last thread to
make progress was `backups-pool-10-thread-9`:

```text
17:23:47.045 [DeletionService] Successfully dropped logical database 'operator-autotests-0ac8149d-…'
                              ← 26 minutes of silence
17:49:37.047 [DeletionService] Error happened during dropping registry 808107b8-… [Error Occurred After Shutdown]
17:49:37.051 [DeletionService] Register deletion error … of database operator-autotests-0ac8149d-…
```

Same thread, same database, and between those two log lines sits exactly one call —
`DatabaseRegistryDbaasRepository.delete`, which holds the mutex across both a Postgres delete and an H2 delete. The
thread came back only when the pod shut down. That is what makes the `OperatorIT` and `BlueGreenV1IT` failures look like
flakes: the operator's aggregator client gives up after 30s and retries, so the freeze surfaces as scattered timeouts.

Pod logs cannot go further: they show which call was entered, not which frame is parked.

## What

A background watchdog that runs for the whole test step and, once a minute:

- takes a JVM thread dump of every running aggregator pod (`jcmd Thread.print -l`, falling back to `SIGQUIT` when
  `jcmd` is missing, which routes the dump to the pod stdout Fluent Bit already collects);
- snapshots `pg_stat_activity` with `pg_blocking_pids`, transaction age, and wait events.

Both sides are needed: a thread parked on a Postgres row lock is an ordinary socket read in a thread dump, so only the
database snapshot distinguishes a JVM monitor from a lock held by another backend. Snapshots upload as the
`aggregator-stall-snapshots` artifact.

The script never fails the job — no `set -e`, every `kubectl` call guarded, missing pods skipped.

## Status

First run, [29861265169](https://github.com/Netcracker/qubership-dbaas/actions/runs/29861265169), was green, so the
freeze did not reproduce. The collector itself works end to end:

- the image ships no `jcmd`, so the fallback ran; PID 1 is the JVM, and 36 thread dumps landed in the pod stdout
  artifact;
- 34 `pg_stat_activity` snapshots landed in `aggregator-stall-snapshots`;
- during the run the aggregator was genuinely idle — every dump shows zero `BLOCKED` threads and no active Postgres
  backends, which is the baseline a frozen run has to be compared against.

Re-run until a red run is captured.

## Follow-up

The fix itself is a separate change. Holding a JVM-wide monitor across JDBC and JTA work has no timeout and no fairness,
so a single blocked holder wedges the aggregator until restart. Related: `safeDeleteAndFlushDatabaseRegistry` is
annotated `@Transactional(REQUIRES_NEW)` but invoked through `this`, so no interceptor applies and it runs in the
caller's transaction.
