### PR TITLE
fix(aggregator): stop holding the repository mutex across Postgres writes

### DIFF
--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/dao/jpa/DatabaseDbaasRepositoryImpl.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/dao/jpa/DatabaseDbaasRepositoryImpl.java
@@ -125,8 +125,10 @@ public class DatabaseDbaasRepositoryImpl implements DatabaseDbaasRepository {
 
     public void deleteById(UUID databaseId) {
         log.debug("delete database by id = {}", databaseId);
+        // Delete from Postgres outside the monitor; hold the monitor only for the H2 mirror, matching
+        // deleteAll() below. DBAAS_REPOSITORIES_MUTEX guards the H2 cache and must never wrap a Postgres write.
+        databasesRepository.deleteById(databaseId);
         synchronized (getMutex()) {
-            databasesRepository.deleteById(databaseId);
             h2DatabaseRepository.deleteById(databaseId);
             h2DatabaseRepository.flush();
         }

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/dao/jpa/DatabaseRegistryDbaasRepositoryImpl.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/dao/jpa/DatabaseRegistryDbaasRepositoryImpl.java
@@ -159,8 +159,10 @@ public class DatabaseRegistryDbaasRepositoryImpl implements DatabaseRegistryDbaa
     public void delete(DatabaseRegistry databaseRegistry) {
         UUID databaseRegistryId = databaseRegistry.getId();
         log.debug("Delete database registry with id={}", databaseRegistryId);
+        // Delete from Postgres outside the monitor; hold DBAAS_REPOSITORIES_MUTEX only for the H2 mirror.
+        // The monitor must never wrap a Postgres write — see save() for the cross-layer deadlock it caused.
+        deleteDatabase(databaseRegistryId);
         synchronized (getMutex()) {
-            deleteDatabase(databaseRegistryId);
             Failsafe.with(H2_DELETE_RETRY_POLICY).run(() -> safeDeleteAndFlushDatabaseRegistry(databaseRegistryId));
         }
     }
@@ -311,20 +313,23 @@ public class DatabaseRegistryDbaasRepositoryImpl implements DatabaseRegistryDbaa
             databaseRegistry.getConnectionProperties().stream().filter(cp -> cp.containsKey(ROLE)).forEach(cp -> cp.put(ROLE, ((String) cp.get(ROLE)).toLowerCase()));
         }
         log.debug("save classifier = {}", databaseRegistry);
-        synchronized (getMutex()) {
-            Database savedDatabase = databaseRegistry.getDatabase();
-            if (databaseRegistry.getId() == null) {
-                databasesRepository.persistAndFlush(savedDatabase);
-            } else {
-                EntityManager entityManager = databasesRepository.getEntityManager();
-                savedDatabase = entityManager.merge(savedDatabase);
-                entityManager.flush();
-            }
-            Optional<DatabaseRegistry> savedDatabaseRegistry = savedDatabase.getDatabaseRegistry().stream()
-                    .filter(v -> v.getClassifier().equals(databaseRegistry.getClassifier())).findFirst();
-            log.debug("saved classifier = {}", savedDatabaseRegistry);
-            return savedDatabaseRegistry.orElseThrow();
+        // No getMutex() here: DBAAS_REPOSITORIES_MUTEX guards the in-memory H2 cache, and this method only
+        // writes Postgres. Holding the monitor across the Hibernate flush let one caller wait on the monitor
+        // while another thread's open transaction held a conflicting row lock — a deadlock spanning the JVM
+        // monitor and a Postgres row lock that neither side could detect. Postgres serializes the write itself;
+        // the H2 mirror is refreshed asynchronously by the classifier table listener.
+        Database savedDatabase = databaseRegistry.getDatabase();
+        if (databaseRegistry.getId() == null) {
+            databasesRepository.persistAndFlush(savedDatabase);
+        } else {
+            EntityManager entityManager = databasesRepository.getEntityManager();
+            savedDatabase = entityManager.merge(savedDatabase);
+            entityManager.flush();
         }
+        Optional<DatabaseRegistry> savedDatabaseRegistry = savedDatabase.getDatabaseRegistry().stream()
+                .filter(v -> v.getClassifier().equals(databaseRegistry.getClassifier())).findFirst();
+        log.debug("saved classifier = {}", savedDatabaseRegistry);
+        return savedDatabaseRegistry.orElseThrow();
     }
 
     private <T> T doGet(Callable<T> action, Function<Exception, T> rollback) {


### PR DESCRIPTION
## Why

The aggregator freezes intermittently under concurrent load. Every path guarded by `DBAAS_REPOSITORIES_MUTEX` —
logical-database persistence, H2 cache reload, the Postgres table listeners — stops and never recovers until the pod
restarts. This surfaces as flaky `OperatorIT` and `BlueGreenV1IT` timeouts, because the operator's aggregator client
gives up after 30 s and retries.

Root cause is a deadlock across two layers, captured with thread dumps and `pg_stat_activity` in
[run 29868895200](https://github.com/Netcracker/qubership-dbaas/actions/runs/29868895200) (see #595 for the full
investigation). `DBAAS_REPOSITORIES_MUTEX` is one static JVM monitor that guards the in-memory H2 cache. Three write
paths held it across a Postgres operation:

| Path | Held across |
| --- | --- |
| `DatabaseRegistryDbaasRepositoryImpl.save` | a Hibernate `flush()` (an `UPDATE`) |
| `DatabaseRegistryDbaasRepositoryImpl.delete` | a Postgres delete |
| `DatabaseDbaasRepositoryImpl.deleteById` | a Postgres delete |

The cycle:

```text
thread owning the row lock ──wants──▶ DBAAS_REPOSITORIES_MUTEX ──held by──▶ save()'s thread
        ▲                                                                        │
        └──────────────── PG row lock on database / database_state_info ◀────wants┘
```

One thread updates a row (takes its row lock), then blocks entering the monitor. The monitor holder, inside its own
transaction, flushes an `UPDATE` that needs the same row and waits on the row lock. Postgres cannot detect it — the
blocked thread's transaction is `idle in transaction`, not waiting inside Postgres. The JVM cannot detect it either —
the monitor holder is `RUNNABLE` in a native socket read. It holds until the pod restarts.

## What

Never hold the monitor across a Postgres operation. Do the Postgres write first, then take the monitor only for the H2
mirror. Two paths in the same layer already follow this pattern —
[`PhysicalDatabaseDbaasRepositoryImpl.delete`](https://github.com/Netcracker/qubership-dbaas/blob/feat/operator-dev/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/dao/jpa/PhysicalDatabaseDbaasRepositoryImpl.java#L102)
and
[`DatabaseDbaasRepositoryImpl.deleteAll`](https://github.com/Netcracker/qubership-dbaas/blob/feat/operator-dev/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/dao/jpa/DatabaseDbaasRepositoryImpl.java#L162) —
so this makes the three outliers consistent.

- `save()` takes no monitor at all: its block is Postgres-only, so there is nothing for the monitor to guard. This
  mirrors `PhysicalDatabaseDbaasRepositoryImpl.save`, which already writes Postgres without the monitor.
- `delete()` and `deleteById()` keep the monitor around the H2 mirror only.

The H2 cache stays correct: it is refreshed asynchronously from Postgres by the classifier / database table listeners,
which still take the monitor for their H2 writes. The reload paths hold the monitor across a Postgres *read*; a plain
`SELECT` takes no row locks and cannot be the parked holder, so they are left unchanged.

No behavior change for callers. Three files, mutex scope only.

## How to verify

- `mvn -pl dbaas/dbaas-aggregator test` — repository and listener unit tests pass, including `PgTableListenersTest`,
  which exercises the mutex and the reload path.
- The `DBaaS Integration Tests` workflow reproduces the freeze under load (~2 of 8 runs before this change). Several
  runs on this branch should stay green, with no `OperatorIT` / `BlueGreenV1IT` timeout cluster and no 20-minute gap in
  the aggregator's `External logical database was saved` log line.

## Follow-up

Optional defense-in-depth, not in this PR: replace `synchronized` with `ReentrantLock.tryLock(timeout)` and add a
Postgres `statement_timeout` / `lock_timeout`, so any future contention surfaces as a bounded, logged error rather than
a hang. Separately, `safeDeleteAndFlushDatabaseRegistry` is annotated `@Transactional(REQUIRES_NEW)` but self-invoked,
so the annotation has no effect — worth a look when the transaction boundaries are revisited.
