### PR TITLE
build(test-apps): consume the Go dbaas client from main

### DIFF
--- a/test-apps/go-test-app-service/go.mod
+++ b/test-apps/go-test-app-service/go.mod
@@ -1,12 +1,12 @@
 module github.com/netcracker/qubership-dbaas/test-apps/go-test-app-service
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3 v3.5.4-0.20260701125619-f0a56365482c
+	github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3 v3.5.6-0.20260723073104-deedb69e4d2d
 	github.com/netcracker/qubership-core-lib-go-dbaas-postgres-client/v4 v4.4.3
-	github.com/netcracker/qubership-core-lib-go/v3 v3.12.0
+	github.com/netcracker/qubership-core-lib-go/v3 v3.13.1
 	github.com/uptrace/bun v1.2.18
 )
 

--- a/test-apps/go-test-app-service/go.sum
+++ b/test-apps/go-test-app-service/go.sum
@@ -117,12 +117,12 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3 v3.5.4-0.20260701125619-f0a56365482c h1:+rpnJlcW/j/KO2Be8AhSElwjCIRWtwstsKH0ls5k2rM=
-github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3 v3.5.4-0.20260701125619-f0a56365482c/go.mod h1:bXE50/NZT9gBdA2w7W3UkKVBvVPDBF8AwFQDZdHJMiE=
+github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3 v3.5.6-0.20260723073104-deedb69e4d2d h1:VAlXLZ+eF9Iu483d2MFNtWYn1otMRVis8o5I9RRguG4=
+github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3 v3.5.6-0.20260723073104-deedb69e4d2d/go.mod h1:nqpxyV/kRShKvXsHbTbpXIVo4DSKpRZPMsMR3pSIDto=
 github.com/netcracker/qubership-core-lib-go-dbaas-postgres-client/v4 v4.4.3 h1:liO3z/pclqtDHV8IliaLRwjIHxwUgjmwMwLGWJvu41Q=
 github.com/netcracker/qubership-core-lib-go-dbaas-postgres-client/v4 v4.4.3/go.mod h1:2BtPJVZ0Noe0tLc64qeRwxbBwBFmqNAJdLjwRyr8NhI=
-github.com/netcracker/qubership-core-lib-go/v3 v3.12.0 h1:EBdb4Vc33dXSpnXDYijcs14h2M8olh6TJaWIo48GUlU=
-github.com/netcracker/qubership-core-lib-go/v3 v3.12.0/go.mod h1:DJg7ebBI1IZqlc1PbqaCB1OFtX3+zULmtpHmDMCmeZw=
+github.com/netcracker/qubership-core-lib-go/v3 v3.13.1 h1:dq8ZT1mtvf9YLYjEupq9djxUu9vgVGNiZoWQnnsUMWc=
+github.com/netcracker/qubership-core-lib-go/v3 v3.13.1/go.mod h1:DJg7ebBI1IZqlc1PbqaCB1OFtX3+zULmtpHmDMCmeZw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=


### PR DESCRIPTION
## Why

The Go sample app pinned a throwaway feature-branch build of `qubership-core-lib-go-dbaas-base-client`. The mounted-secret support merged to main in Netcracker/qubership-core-lib-go-dbaas-base-client#70, so the integration tests should exercise what users will actually consume.

## What

- `go.mod`/`go.sum`: `v3.5.4-0.20260701125619-f0a56365482c` (feature branch) → `v3.5.6-0.20260723073104-deedb69e4d2d` (main tip; no release tag covers the merge yet — worth cutting one later and re-pinning).
- Transitive: `qubership-core-lib-go` 3.12.0 → 3.13.1.

## How to verify

- Local: `go build ./...` + `go test ./...` in `test-apps/go-test-app-service` — 23 tests green.
- CI: Sample Services Integration Tests on this branch (all three passes; the workflow builds the Go app image in-job from this code).