### PR TITLE
fix(ci): keep per-pass Surefire reports in sample-service tests

### DIFF
--- a/.github/workflows/integration-tests-sample-service.yml
+++ b/.github/workflows/integration-tests-sample-service.yml
@@ -248,11 +248,15 @@ jobs:
       - name: "Pass A — run integration tests (mount proof)"
         id: tests_a
         working-directory: test-apps/test-apps-integration-tests
+        # Each pass writes its own reports directory. All passes run `mvn test` in the same module,
+        # so a shared directory would let a later pass overwrite an earlier pass's results and hide
+        # its failures from the gate.
         run: >
           mvn --batch-mode
           -DskipIT=false
           -Dclouds.cloud.name=kind
           -Dclouds.cloud.namespaces.namespace=$TEST_NAMESPACE
+          -Dsurefire.reportsDirectory=target/surefire-reports/pass-a
           test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -279,6 +283,7 @@ jobs:
           -DskipIT=false
           -Dclouds.cloud.name=kind
           -Dclouds.cloud.namespaces.namespace=$TEST_NAMESPACE
+          -Dsurefire.reportsDirectory=target/surefire-reports/pass-b
           test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -306,6 +311,7 @@ jobs:
           -DskipIT=false
           -Dclouds.cloud.name=kind
           -Dclouds.cloud.namespaces.namespace=$TEST_NAMESPACE
+          -Dsurefire.reportsDirectory=target/surefire-reports/phase-c
           test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -343,7 +349,7 @@ jobs:
         run: |
           set +e
           shopt -s nullglob
-          reports=(test-apps/test-apps-integration-tests/target/surefire-reports/TEST-*.xml)
+          reports=(test-apps/test-apps-integration-tests/target/surefire-reports/*/TEST-*.xml)
           if [ "${#reports[@]}" -gt 0 ] && ! grep -E 'failures="[1-9]|errors="[1-9]' "${reports[@]}" >/dev/null 2>&1; then
             echo "All sample-service tests passed; skipping diagnostics."
             exit 0
@@ -405,12 +411,19 @@ jobs:
         if: always()
         run: |
           shopt -s nullglob
-          reports=(test-apps/test-apps-integration-tests/target/surefire-reports/TEST-*.xml)
-          if [ "${#reports[@]}" -eq 0 ]; then
-            echo "::error::No Surefire XML reports were generated for sample service integration tests"
-            exit 1
-          fi
-          if grep -E 'failures="[1-9]|errors="[1-9]' "${reports[@]}" >/dev/null 2>&1; then
-            echo "::error::Sample service integration test failed"
-            exit 1
-          fi
+          # Check every pass separately, and require reports from each one. A missing set means the
+          # pass never ran or wrote elsewhere — treat both as failures, or a broken pass stays green.
+          rc=0
+          for pass in pass-a pass-b phase-c; do
+            reports=(test-apps/test-apps-integration-tests/target/surefire-reports/"$pass"/TEST-*.xml)
+            if [ "${#reports[@]}" -eq 0 ]; then
+              echo "::error::No Surefire XML reports were generated for $pass"
+              rc=1
+              continue
+            fi
+            if grep -E 'failures="[1-9]|errors="[1-9]' "${reports[@]}" >/dev/null 2>&1; then
+              echo "::error::Sample service integration tests failed in $pass"
+              rc=1
+            fi
+          done
+          exit $rc

--- a/test-apps/test-apps-integration-tests/pom.xml
+++ b/test-apps/test-apps-integration-tests/pom.xml
@@ -18,6 +18,10 @@
         <fabric8.version>7.5.2</fabric8.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven.test.failure.ignore>true</maven.test.failure.ignore>
+        <!-- Surefire 3.x has no user property for reportsDirectory, so route it through a Maven
+             property. The CI workflow overrides it per pass to keep one pass's reports from
+             overwriting another's. -->
+        <surefire.reportsDirectory>${project.build.directory}/surefire-reports</surefire.reportsDirectory>
     </properties>
 
     <dependencies>
@@ -61,6 +65,7 @@
                     <skipTests>${skipIT}</skipTests>
                     <trimStackTrace>false</trimStackTrace>
                     <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
+                    <reportsDirectory>${surefire.reportsDirectory}</reportsDirectory>
                     <argLine>
                         --add-opens=java.base/java.lang=ALL-UNNAMED
                         --add-opens=java.base/java.lang.reflect=ALL-UNNAMED


### PR DESCRIPTION
## Why

The sample-service workflow runs `mvn test` three times in the same module — pass A (mount proof), pass B (REST
fallback), phase C (direct M2M) — and every run wrote to the same `target/surefire-reports`. Each pass overwrote the
previous one, so the `Fail job if sample service tests failed` gate, the diagnostics trigger, and the uploaded artifact
only ever saw the **last** pass.

The cost of that is not hypothetical. Every nightly run on `main` from July 10 through July 23 (14 runs) reported
`success` while pass A was failing **12 of 12 tests** each night (`Tests run: 12, Failures: 8, Errors: 4` in the job
log, e.g. [run 29976020133](https://github.com/Netcracker/qubership-dbaas/actions/runs/29976020133)). Pass B then
overwrote the reports with 12 green results and the gate passed. The individual mvn steps stay green by design —
`maven.test.failure.ignore=true` delegates the verdict to the gate — which makes the gate the single point of truth,
and it was reading the wrong files.

## What

- Each pass writes its own reports directory: `target/surefire-reports/{pass-a,pass-b,phase-c}`.
- Surefire 3.x has no user property for `reportsDirectory` (checked the 3.5.6 plugin descriptor — the parameter has no
  expression binding), so the value is routed through a Maven property in the test module's POM, the same pattern
  already used for `testFailureIgnore`. Verified with `help:effective-pom` that the per-pass override reaches the
  plugin configuration.
- The gate loops over the three report sets, fails on any `failures=`/`errors=`, and treats a **missing** set as a
  failure — a pass that never wrote reports cannot pass silently (this also guards against the property ever being
  dropped).
- The diagnostics-collection trigger reads the per-pass directories.
- The artifact path (`target/surefire-reports/**`) already covers subdirectories, so the artifact now contains all
  three sets instead of the last one.

## How to verify

Run the `Sample Services Integration Tests` workflow on this branch: the artifact should contain three subdirectories
with 12 tests each, and the job should stay green only if all three passes are green.

Note for reviewers: once this reaches `main`, the nightly job will start failing **honestly** — pass A genuinely fails
there (the mount-proof scenario; all suites return 500 on CRUD). That is the point of the fix; the pass A breakage on
`main` needs its own follow-up.
