### PR TITLE
fix(aggregator): tolerate concurrently deleted registries in restore sweeps

### DIFF
--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/DBBackupsService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/DBBackupsService.java
@@ -600,8 +600,7 @@ public class DBBackupsService {
                 deltaDatabases.size(), backup.getId(), backup.getNamespace()
         );
 
-        deltaDatabases = deletionService.markRegistriesForDrop(backup.getNamespace(), deltaDatabases);
-        deletionService.dropRegistriesSafe(backup.getNamespace(), deltaDatabases);
+        deletionService.markAndDropRegistriesSafe(backup.getNamespace(), deltaDatabases);
 
         log.info("Delta cleaned during restoration of backup {} in namespace {}", backup.getId(), backup.getNamespace());
 
@@ -664,8 +663,7 @@ public class DBBackupsService {
             log.info("Clean {} databases in target namespace {} during restoration of backup {}",
                     targetDatabasesToDrop.size(), targetNamespace, backup.getId());
             log.debug("databases to drop = {}", targetDatabasesToDrop);
-            targetDatabasesToDrop = deletionService.markRegistriesForDrop(targetNamespace, targetDatabasesToDrop);
-            deletionService.dropRegistriesSafe(targetNamespace, targetDatabasesToDrop);
+            deletionService.markAndDropRegistriesSafe(targetNamespace, targetDatabasesToDrop);
             saveRestoreDbWithAnotherName(targetNamespace, result, notMarkedForDropInBackup);
         }
         log.info("Saving databases in database collection");

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/DeletionService.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/DeletionService.java
@@ -7,14 +7,17 @@ import com.netcracker.cloud.dbaas.repositories.dbaas.LogicalDbDbaasRepository;
 import com.netcracker.cloud.dbaas.repositories.pg.jpa.DatabaseDeclarativeConfigRepository;
 import com.netcracker.cloud.dbaas.repositories.pg.jpa.LogicalDbOperationErrorRepository;
 import com.netcracker.cloud.dbaas.service.composite.CompositeNamespaceService;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.persistence.OptimisticLockException;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.ws.rs.WebApplicationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.hibernate.StaleStateException;
 
 import java.util.*;
 import java.util.function.Predicate;
@@ -82,6 +85,65 @@ public class DeletionService {
         log.info("Mark {} registries for drop in '{}' namespace", registries.size(), namespace);
         registries.forEach(this::markRegistryForDropWithoutTransaction);
         return logicalDbDbaasRepository.getDatabaseRegistryDbaasRepository().saveAll(registries);
+    }
+
+    /**
+     * Marks the given registries for drop and drops them, each in its own new
+     * transaction with a fresh read by id.
+     *
+     * <p>Restore sweeps pass a list that may be stale: in a busy namespace a
+     * concurrent request can legitimately delete a database between the caller's
+     * read and this sweep. Flushing an update for a vanished row inside the
+     * caller's long transaction aborts the whole restore with a stale-state
+     * conflict, so each registry is re-read and processed in isolation instead,
+     * and a registry that no longer exists is treated as already dropped.
+     *
+     * @return the number of registries actually dropped
+     */
+    public long markAndDropRegistriesSafe(String namespace, List<DatabaseRegistry> registries) {
+        List<UUID> ids = registries.stream().map(DatabaseRegistry::getId).filter(Objects::nonNull).toList();
+        log.info("Mark {} registries for drop in '{}' namespace and drop them one by one", ids.size(), namespace);
+        long dropped = 0;
+        for (UUID id : ids) {
+            try {
+                if (Boolean.TRUE.equals(QuarkusTransaction.requiringNew().call(() -> markAndDropRegistry(id)))) {
+                    dropped++;
+                }
+            } catch (RuntimeException e) {
+                if (!isStaleStateConflict(e) || registryStillExists(id)) {
+                    throw e;
+                }
+                log.info("Registry {} was deleted concurrently during the sweep in '{}' namespace, treating as already dropped", id, namespace);
+            }
+        }
+        log.info("Successfully dropped {} of {} databases in {}", dropped, ids.size(), namespace);
+        return dropped;
+    }
+
+    private boolean markAndDropRegistry(UUID registryId) {
+        Optional<DatabaseRegistry> fresh = logicalDbDbaasRepository.getDatabaseRegistryDbaasRepository().findDatabaseRegistryById(registryId);
+        if (fresh.isEmpty()) {
+            log.info("Registry {} is already deleted, skipping the drop", registryId);
+            return false;
+        }
+        DatabaseRegistry registry = fresh.get();
+        markRegistryForDropWithoutTransaction(registry);
+        logicalDbDbaasRepository.getDatabaseRegistryDbaasRepository().saveAnyTypeLogDb(registry);
+        return dropRegistrySafe(registry, false);
+    }
+
+    private boolean registryStillExists(UUID registryId) {
+        return QuarkusTransaction.requiringNew().call(() ->
+                logicalDbDbaasRepository.getDatabaseRegistryDbaasRepository().findDatabaseRegistryById(registryId).isPresent());
+    }
+
+    private static boolean isStaleStateConflict(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof StaleStateException || t instanceof OptimisticLockException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Transactional

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/integration/DeletionServiceTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/integration/DeletionServiceTest.java
@@ -381,6 +381,89 @@ class DeletionServiceTest {
     }
 
     @Test
+    void testMarkAndDropRegistriesSafe_dropsAllRegistries() {
+        Database database1 = new DatabaseBuilder()
+                .registry()
+                .build();
+        Database database2 = new DatabaseBuilder()
+                .classifier(MICROSERVICE_NAME, "another")
+                .registry()
+                .build();
+        databaseRegistryDbaasRepository.saveAnyTypeLogDb(database1.getDatabaseRegistry().getFirst());
+        databaseRegistryDbaasRepository.saveAnyTypeLogDb(database2.getDatabaseRegistry().getFirst());
+        assertEquals(2, databaseRegistryDbaasRepository.findAnyLogDbRegistryTypeByNamespace(TEST_NS).size());
+
+        long dropped = deletionService.markAndDropRegistriesSafe(TEST_NS,
+                List.of(database1.getDatabaseRegistry().getFirst(), database2.getDatabaseRegistry().getFirst()));
+
+        assertEquals(2, dropped);
+        assertEquals(0, databaseRegistryDbaasRepository.findAnyLogDbRegistryTypeByNamespace(TEST_NS).size());
+        // The sweep drops a freshly re-read copy whose classifier already carries
+        // MARKED_FOR_DROP, so match by registry id rather than by equals.
+        verify(dbaasAdapterRESTClient).dropDatabase(argThat(r -> r.getId().equals(database1.getDatabaseRegistry().getFirst().getId())));
+        verify(dbaasAdapterRESTClient).dropDatabase(argThat(r -> r.getId().equals(database2.getDatabaseRegistry().getFirst().getId())));
+    }
+
+    @Test
+    void testMarkAndDropRegistriesSafe_skipsConcurrentlyDeletedRegistry() {
+        Database survivor = new DatabaseBuilder()
+                .registry()
+                .build();
+        Database deleted = new DatabaseBuilder()
+                .classifier(MICROSERVICE_NAME, "another")
+                .registry()
+                .build();
+        databaseRegistryDbaasRepository.saveAnyTypeLogDb(survivor.getDatabaseRegistry().getFirst());
+        databaseRegistryDbaasRepository.saveAnyTypeLogDb(deleted.getDatabaseRegistry().getFirst());
+        // The sweep list is collected first; a concurrent request then deletes one
+        // of the databases before the sweep reaches it.
+        List<DatabaseRegistry> staleSweepList =
+                List.of(survivor.getDatabaseRegistry().getFirst(), deleted.getDatabaseRegistry().getFirst());
+        databaseRegistryDbaasRepository.delete(deleted.getDatabaseRegistry().getFirst());
+        assertEquals(1, databaseRegistryDbaasRepository.findAnyLogDbRegistryTypeByNamespace(TEST_NS).size());
+
+        long dropped = deletionService.markAndDropRegistriesSafe(TEST_NS, staleSweepList);
+
+        assertEquals(1, dropped, "only the surviving registry is dropped");
+        assertEquals(0, databaseRegistryDbaasRepository.findAnyLogDbRegistryTypeByNamespace(TEST_NS).size());
+        verify(dbaasAdapterRESTClient).dropDatabase(argThat(r -> r.getId().equals(survivor.getDatabaseRegistry().getFirst().getId())));
+        verify(dbaasAdapterRESTClient, never()).dropDatabase(argThat(r -> r.getId().equals(deleted.getDatabaseRegistry().getFirst().getId())));
+    }
+
+    @Test
+    void testMarkAndDropRegistriesSafe_staleListInsideCallerTransaction() {
+        Database survivor = new DatabaseBuilder()
+                .registry()
+                .build();
+        Database deleted = new DatabaseBuilder()
+                .classifier(MICROSERVICE_NAME, "another")
+                .registry()
+                .build();
+        databaseRegistryDbaasRepository.saveAnyTypeLogDb(survivor.getDatabaseRegistry().getFirst());
+        databaseRegistryDbaasRepository.saveAnyTypeLogDb(deleted.getDatabaseRegistry().getFirst());
+        databaseRegistryDbaasRepository.delete(deleted.getDatabaseRegistry().getFirst());
+
+        // The restore flow runs the sweep inside a long transaction; the sweep must
+        // neither abort it nor poison its persistence context, and work committed
+        // after the sweep must survive.
+        QuarkusTransaction.requiringNew().run(() -> {
+            long dropped = deletionService.markAndDropRegistriesSafe(TEST_NS,
+                    List.of(survivor.getDatabaseRegistry().getFirst(), deleted.getDatabaseRegistry().getFirst()));
+            assertEquals(1, dropped);
+
+            Database restored = new DatabaseBuilder()
+                    .classifier(MICROSERVICE_NAME, "restored")
+                    .registry()
+                    .build();
+            databaseRegistryDbaasRepository.saveAll(restored.getDatabaseRegistry());
+        });
+
+        List<DatabaseRegistry> remaining = databaseRegistryDbaasRepository.findAnyLogDbRegistryTypeByNamespace(TEST_NS);
+        assertEquals(1, remaining.size(), "the registry saved after the sweep must be committed");
+        assertEquals("restored", remaining.getFirst().getClassifier().get(MICROSERVICE_NAME));
+    }
+
+    @Test
     void testMarkAsOrphan() {
         Database database = new DatabaseBuilder()
                 .registry()


### PR DESCRIPTION
## Why

Namespace restore fails intermittently with HTTP 500 `CORE-DBAAS-4018` under concurrent load:

```
jakarta.persistence.OptimisticLockException: Unexpected row count (expected row count 1 but was 0)
[update database ... where id=?]
  at DatabaseRegistryDbaasRepositoryImpl.save(DatabaseRegistryDbaasRepositoryImpl.java:327)
  at DeletionService.markRegistriesForDrop(DeletionService.java:84)
  at DBBackupsService.restoreToAnotherNamespace(DBBackupsService.java:667)
```

Seen in [run 30074030720](https://github.com/Netcracker/qubership-dbaas/actions/runs/30074030720) (`OperatorIT.testDatabaseSecretClaimTenantUpdatedAfterBackupRestoreV3`); the same family hit the create path in [run 30034634987](https://github.com/Netcracker/qubership-dbaas/actions/runs/30034634987).

The restore cleanup (mark for drop + drop of the target-namespace or delta registries) runs inside the long restore transaction over a list read at its start. In a busy shared namespace a concurrent request legitimately deletes its own database meanwhile. The sweep's flush then updates a vanished row; the entities carry no `@Version`, so Hibernate treats the 0-row update as a stale flush and aborts the whole restore. The existing re-find inside `dropRegistry` cannot help: within the same transaction the first-level cache keeps returning the stale entity. The cleanup's atomicity was already illusory — adapter-side physical drops are external calls and never roll back.

## What

- `DeletionService.markAndDropRegistriesSafe`: processes each registry in its own new transaction (`QuarkusTransaction.requiringNew`, per-row) with a fresh read by id. A registry that no longer exists is treated as already dropped — the same semantics `dropRegistry` already has for missing rows. A stale-flush conflict inside a row's transaction is swallowed only after re-checking in another fresh transaction that the row is really gone; anything else (adapter failures included) propagates as before.
- Both `DBBackupsService` sweep call sites (`cleanDelta`, `restoreToAnotherNamespace`) switched to it. `markRegistriesForDrop`/`dropRegistriesSafe` are untouched — other callers keep their semantics.

## How to verify

- `DeletionServiceTest`: 3 new cases — full sweep drop, skip of a concurrently deleted registry, and a stale list inside a caller transaction (the sweep must neither abort it nor poison its persistence context; work committed after the sweep survives). 27/27 locally.
- `DBBackupsServiceTest` 18/18, `DbBackupV2ServiceTest` 55/55 locally.
- The remaining exposure window shrinks from the whole restore duration to a single row's mark+drop transaction.