### PR TITLE
fix(aggregator): pin process-engine 1.5.5-SNAPSHOT with optimistic-lock race fixes

### DIFF
--- a/dbaas/dbaas-aggregator/pom.xml
+++ b/dbaas/dbaas-aggregator/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>com.netcracker.core</groupId>
             <artifactId>process-engine</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>

--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/processengine/tasks/AbstractDbaaSTask.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/processengine/tasks/AbstractDbaaSTask.java
@@ -44,8 +44,12 @@ public abstract class AbstractDbaaSTask extends AbstractProcessTask implements S
     }
 
     protected static void updateState(DataContext context, String stateDescription, boolean waitingForResources) {
-        context.put("stateDescription", stateDescription);
-        context.put("waitingForResources", Boolean.toString(waitingForResources));
-        context.save();
+        // apply() recovers from a concurrent version conflict by re-applying the
+        // mutation on a fresh copy; a plain save() aborted the whole task when the
+        // POProcess tick or the timeout watchdog wrote the same row first.
+        context.apply(c -> {
+            c.put("stateDescription", stateDescription);
+            c.put("waitingForResources", Boolean.toString(waitingForResources));
+        });
     }
 }


### PR DESCRIPTION
## Why

The aggregator pinned `process-engine` 1.5.3, which loses updates under concurrency: the POProcess tick, the executing task, the failure handler, and the timeout watchdog each hold their own copy of the same row, and a lost optimistic-lock race aborted terminal saves. A backup task stuck in `picked` state then surfaced as hung backups, HTTP 500s, and IT timeouts (the `VersionMismatchException` signature that failed the DBaaS IT concurrent section four runs in a row on feat/namespacebinding-status).

## What

- Pin `process-engine` **1.5.5-SNAPSHOT** — the first build with [qubership-core-java-libs#151](https://github.com/Netcracker/qubership-core-java-libs/pull/151) (merged to main, published as `1.5.5-20260724.091358-10`): atomic `UPDATE ... WHERE version=?` guards on task/process/context rows, conflict-recovering terminal saves (`saveResolvingConflict`, `DataContext.apply`), exactly-one completion callback per task, and a watchdog that no longer marks a task FAILED when it completed in time.
- `AbstractDbaaSTask.updateState`: `put`+`save` → `context.apply` so the status-description writes recover from concurrent version conflicts instead of aborting the task.

## How to verify

- A/B on two verify branches against a throwaway snapshot of the same library code: [verify/process-engine-race-fix](https://github.com/Netcracker/qubership-dbaas/tree/verify/process-engine-race-fix) (feat/operator-dev base) and [verify/pe-race-fix-nb-status](https://github.com/Netcracker/qubership-dbaas/tree/verify/pe-race-fix-nb-status) (feat/namespacebinding-status base): DBaaS Integration Tests pass on both, zero `VersionMismatchException` in aggregator pod logs (previously present in every failing run).
- Locally on this branch: `DeclarativeControllerTest` + `BlueGreenStabilityTest` (orchestrator-backed) 12/12 against the fresh snapshot.

Follow-up: cut a proper `1.5.5` release of process-engine and replace the SNAPSHOT pin before promoting to main.