### PR TITLE
feat: improve DBaaS operator dashboard

### DIFF
--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -158,8 +158,10 @@ The dashboard exposes three variables:
 
 Every panel query is scoped by `cluster=~"$cluster"` and `namespace=~"$namespace"`. This allows one
 provisioned dashboard to switch between operator instances without changing its UID. The default
-range is the last 30 minutes and automatic refresh is disabled; refresh manually when testing a
-short-lived state such as deletion.
+range is the last 30 minutes and the dashboard refreshes every minute. This operational dashboard
+uses the monitoring design guide's explicit auto-refresh exception so that reconciliation lag,
+active errors, deletion state, and time-based health metrics stay current. With metrics scraped
+every 30 seconds, this issues one dashboard query refresh per two scrape cycles.
 
 **To open it:** in Grafana, open the **DBaaS Operator** dashboard (the name may differ per
 installation), select the **datasource**, **cluster**, and **DBaaS Operator Namespace**.

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -166,7 +166,7 @@ every 30 seconds, this issues one dashboard query refresh per two scrape cycles.
 **To open it:** in Grafana, open the **DBaaS Operator** dashboard (the name may differ per
 installation), select the **datasource**, **cluster**, and **DBaaS Operator Namespace**.
 The dashboard is organized into rows that mirror the metric groups above. `CR Health Overview`
-is expanded by default as the landing overview; all detailed rows are collapsed until needed.
+appears first and is expanded by default; all detailed rows are collapsed until needed.
 
 ### Credentials & Secret Resolution
 

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -143,16 +143,18 @@ title **"DBaaS Operator"**) from `templates/Dashboard.yaml`, gated on
 `DBAAS_OPERATOR_ENABLED && MONITORING_ENABLED` (chart defaults: `DBAAS_OPERATOR_ENABLED: false`,
 `MONITORING_ENABLED: true` — so it ships once the operator is enabled) and reconciled by the
 **Grafana Operator**. Its UID follows the monitoring convention
-`<dashboard-namespace>-dbaas-operator`; Helm derives it from `NAMESPACE` and truncates the namespace portion to keep the
-Grafana 40-character limit.
+`<namespace-prefix>-<namespace-hash>-dbaas-operator`; Helm derives it from `NAMESPACE`, keeps up
+to 18 characters as a readable prefix, and appends the first six characters of its SHA-256 hash
+to preserve uniqueness while staying within Grafana's 40-character UID limit.
 
 The dashboard exposes three variables:
 
-- **`datasource`** - Prometheus, VictoriaMetrics, or Promxy data source.
-- **`cluster`** - source Kubernetes cluster added by Promxy. `All` uses `.*`, which also matches
+- **`datasource`** — Prometheus, VictoriaMetrics, or Promxy data source.
+- **`cluster`** — source Kubernetes cluster added by Promxy. `All` uses `.*`, which also matches
   metrics without a `cluster` label when the dashboard uses Prometheus/VictoriaMetrics directly.
-- **`namespace`** - DBaaS Operator namespace discovered from
-  `dbaas_resource_collector_success`, restricted to the selected cluster.
+- **`namespace`** — DBaaS Operator namespace discovered from
+  `dbaas_resource_collector_success`, restricted to the selected cluster. It defaults to the
+  namespace of the chart installation that provisioned the dashboard.
 
 Every panel query is scoped by `cluster=~"$cluster"` and `namespace=~"$namespace"`. This allows one
 provisioned dashboard to switch between operator instances without changing its UID. The default

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -142,14 +142,25 @@ The chart ships a ready-made Grafana dashboard for these metrics. It is delivere
 title **"DBaaS Operator"**) from `templates/Dashboard.yaml`, gated on
 `DBAAS_OPERATOR_ENABLED && MONITORING_ENABLED` (chart defaults: `DBAAS_OPERATOR_ENABLED: false`,
 `MONITORING_ENABLED: true` — so it ships once the operator is enabled) and reconciled by the
-**Grafana Operator**. The panel queries are pre-scoped to the operator's namespace at install time (the chart
-substitutes the operator `NAMESPACE` for the dashboard's `#namespace#` placeholder), so there is no
-namespace picker. The dashboard exposes one variable — **`datasource`** — to select the
-Prometheus/VictoriaMetrics data source.
+**Grafana Operator**. Its UID follows the monitoring convention
+`<dashboard-namespace>-dbaas-operator`; Helm derives it from `NAMESPACE` and truncates the namespace portion to keep the
+Grafana 40-character limit.
+
+The dashboard exposes three variables:
+
+- **`datasource`** - Prometheus, VictoriaMetrics, or Promxy data source.
+- **`cluster`** - source Kubernetes cluster added by Promxy. `All` uses `.*`, which also matches
+  metrics without a `cluster` label when the dashboard uses Prometheus/VictoriaMetrics directly.
+- **`namespace`** - DBaaS Operator namespace discovered from
+  `dbaas_resource_collector_success`, restricted to the selected cluster.
+
+Every panel query is scoped by `cluster=~"$cluster"` and `namespace=~"$namespace"`. This allows one
+provisioned dashboard to switch between operator instances without changing its UID. The default
+range is the last 30 minutes and automatic refresh is disabled; refresh manually when testing a
+short-lived state such as deletion.
 
 **To open it:** in Grafana, open the **DBaaS Operator** dashboard (the name may differ per
-installation), select the **datasource**, and set the time range.
-
+installation), select the **datasource**, **cluster**, and **DBaaS Operator Namespace**.
 The dashboard is organized into rows that mirror the metric groups above.
 
 ### Credentials & Secret Resolution
@@ -202,9 +213,9 @@ The dashboard is organized into rows that mirror the metric groups above.
 
 | Panel | What it shows | Based on |
 |---|---|---|
-| Balancing Rule Desired vs Applied Targets | Desired (spec) vs. applied (status) target counts | `dbaas_balancing_rule_desired_targets`, `dbaas_balancing_rule_applied_targets` |
+| Balancing Rule Desired vs Applied Targets | Desired (spec) vs. applied (status) target counts. No data means no owned balancing-rule CRs currently exist. | `dbaas_balancing_rule_desired_targets`, `dbaas_balancing_rule_applied_targets` |
 | NamespaceBinding States | NamespaceBindings by state (`mine` / `foreign` / `deleting` …) | `dbaas_namespace_binding_state` |
-| Resources being deleted | CRs stuck in deletion | `dbaas_resource_deletion_state` |
+| Resources being deleted | CRs currently in deletion. No data means no resources are being deleted. | `dbaas_resource_deletion_state` |
 
 ---
 

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -165,7 +165,8 @@ every 30 seconds, this issues one dashboard query refresh per two scrape cycles.
 
 **To open it:** in Grafana, open the **DBaaS Operator** dashboard (the name may differ per
 installation), select the **datasource**, **cluster**, and **DBaaS Operator Namespace**.
-The dashboard is organized into rows that mirror the metric groups above.
+The dashboard is organized into rows that mirror the metric groups above. `CR Health Overview`
+is expanded by default as the landing overview; all detailed rows are collapsed until needed.
 
 ### Credentials & Secret Resolution
 

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -8,7 +8,7 @@
                  "k8s"
              ],
     "schemaVersion":  39,
-    "version":  5,
+    "version":  6,
     "refresh":  "1m",
     "time":  {
                  "from":  "now-30m",
@@ -96,598 +96,606 @@
                    {
                        "id":  1,
                        "type":  "row",
-                       "title":  "Credentials & Secret Resolution",
-                       "collapsed":  false,
+                       "title":  "Credentials \u0026 Secret Resolution",
+                       "collapsed":  true,
                        "gridPos":  {
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
                                        "y":  0
-                                   }
-                   },
-                   {
-                       "id":  2,
-                       "type":  "timeseries",
-                       "title":  "Reconcile Triggers by Source (EDB)",
-                       "description":  "Reconcile invocations for ExternalDatabase by trigger source (spec_change, namespace_binding_change).",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  1
                                    },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "reqps",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        },
-                                           "overrides":  [
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "spec_change"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "blue",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             }
-                                                         ]
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (trigger) (rate(dbaas_reconcile_trigger_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"externaldatabase\"}[1m]))",
-                                           "legendFormat":  "{{trigger}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  4,
-                       "type":  "timeseries",
-                       "title":  "Secret Resolution Errors",
-                       "description":  "Failures reading a credentials Secret. Reasons are actionable: secret_not_found, key_missing, key_empty, forbidden, or secret_read_failed.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  9
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "color":  {
-                                                                          "fixedColor":  "red",
-                                                                          "mode":  "fixed"
-                                                                      },
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
-                                           "legendFormat":  "{{exported_namespace}} / {{reason}}"
-                                       }
-                                   ]
+                       "panels":  [
+                                      {
+                                          "id":  2,
+                                          "type":  "timeseries",
+                                          "title":  "Reconcile Triggers by Source (EDB)",
+                                          "description":  "Reconcile invocations for ExternalDatabase by trigger source (spec_change, namespace_binding_change).",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  1
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "reqps",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           },
+                                                              "overrides":  [
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "spec_change"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "blue",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                }
+                                                                            ]
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (trigger) (rate(dbaas_reconcile_trigger_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"externaldatabase\"}[1m]))",
+                                                              "legendFormat":  "{{trigger}}"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  4,
+                                          "type":  "timeseries",
+                                          "title":  "Secret Resolution Errors",
+                                          "description":  "Failures reading a credentials Secret. Reasons are actionable: secret_not_found, key_missing, key_empty, forbidden, or secret_read_failed.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  9
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "short",
+                                                                               "color":  {
+                                                                                             "fixedColor":  "red",
+                                                                                             "mode":  "fixed"
+                                                                                         },
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
+                                                              "legendFormat":  "{{exported_namespace}} / {{reason}}"
+                                                          }
+                                                      ]
+                                      }
+                                  ]
                    },
                    {
                        "id":  5,
                        "type":  "row",
                        "title":  "Aggregator Interaction Health",
-                       "collapsed":  false,
+                       "collapsed":  true,
                        "gridPos":  {
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  17
-                                   }
-                   },
-                   {
-                       "id":  6,
-                       "type":  "timeseries",
-                       "title":  "Aggregator Call Latency (seconds)",
-                       "description":  "P50/P90/P99 latency per controller and operation. Feeds into SLO alerting - if P99 rises, the aggregator is slow.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  0,
-                                       "y":  18
+                                       "y":  1
                                    },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "s",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "histogram_quantile(0.50, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
-                                           "legendFormat":  "P50 {{controller}}/{{operation}}"
-                                       },
-                                       {
-                                           "expr":  "histogram_quantile(0.90, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
-                                           "legendFormat":  "P90 {{controller}}/{{operation}}"
-                                       },
-                                       {
-                                           "expr":  "histogram_quantile(0.99, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
-                                           "legendFormat":  "P99 {{controller}}/{{operation}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  7,
-                       "type":  "timeseries",
-                       "title":  "Aggregator Call Outcomes (calls/s)",
-                       "description":  "Result breakdown: database_not_found = DatabaseSecretClaim waiting for DB registration, spec_rejection = CR/spec owner, auth_error = operator credentials/RBAC, server_error = aggregator, network_error = connectivity/platform.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  12,
-                                       "y":  18
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "reqps",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        },
-                                           "overrides":  [
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "success"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "green",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "spec_rejection"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "yellow",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "database_not_found"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "blue",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "auth_error"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "orange",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "server_error"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "red",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "network_error"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "purple",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             }
-                                                         ]
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
-                                           "legendFormat":  "{{result}}"
-                                       }
-                                   ]
+                       "panels":  [
+                                      {
+                                          "id":  6,
+                                          "type":  "timeseries",
+                                          "title":  "Aggregator Call Latency (seconds)",
+                                          "description":  "P50/P90/P99 latency per controller and operation. Feeds into SLO alerting - if P99 rises, the aggregator is slow.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  0,
+                                                          "y":  2
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "s",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "histogram_quantile(0.50, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                                                              "legendFormat":  "P50 {{controller}}/{{operation}}"
+                                                          },
+                                                          {
+                                                              "expr":  "histogram_quantile(0.90, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                                                              "legendFormat":  "P90 {{controller}}/{{operation}}"
+                                                          },
+                                                          {
+                                                              "expr":  "histogram_quantile(0.99, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                                                              "legendFormat":  "P99 {{controller}}/{{operation}}"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  7,
+                                          "type":  "timeseries",
+                                          "title":  "Aggregator Call Outcomes (calls/s)",
+                                          "description":  "Result breakdown: database_not_found = DatabaseSecretClaim waiting for DB registration, spec_rejection = CR/spec owner, auth_error = operator credentials/RBAC, server_error = aggregator, network_error = connectivity/platform.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  12,
+                                                          "y":  2
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "reqps",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           },
+                                                              "overrides":  [
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "success"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "green",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "spec_rejection"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "yellow",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "database_not_found"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "blue",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "auth_error"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "orange",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "server_error"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "red",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "network_error"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "purple",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                }
+                                                                            ]
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
+                                                              "legendFormat":  "{{result}}"
+                                                          }
+                                                      ]
+                                      }
+                                  ]
                    },
                    {
                        "id":  8,
                        "type":  "row",
                        "title":  "Historical Failure Activity",
-                       "collapsed":  false,
+                       "collapsed":  true,
                        "gridPos":  {
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  26
-                                   }
-                   },
-                   {
-                       "id":  9,
-                       "type":  "timeseries",
-                       "title":  "Recent Failed Operations by Owner",
-                       "description":  "Historical failed operations by owner bucket. Use the CR Health Overview row for exact current CR state.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  0,
-                                       "y":  27
+                                       "y":  2
                                    },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        },
-                                           "overrides":  [
+                       "panels":  [
+                                      {
+                                          "id":  9,
+                                          "type":  "timeseries",
+                                          "title":  "Recent Failed Operations by Owner",
+                                          "description":  "Historical failed operations by owner bucket. Use the CR Health Overview row for exact current CR state.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  0,
+                                                          "y":  3
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "short",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           },
+                                                              "overrides":  [
 
-                                                         ]
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom",
-                                                      "showLegend":  true
-                                                  },
-                                       "tooltip":  {
-                                                       "mode":  "multi",
-                                                       "sort":  "none"
-                                                   }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (controller, result) (increase(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",result!~\"success|database_not_found\"}[$__range]))",
-                                           "legendFormat":  "aggregator {{controller}} / {{result}}",
-                                           "refId":  "A"
-                                       },
-                                       {
-                                           "expr":  "sum by (exported_namespace, reason) (increase(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__range]))",
-                                           "legendFormat":  "secret {{exported_namespace}} / {{reason}}",
-                                           "refId":  "B"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  10,
-                       "type":  "timeseries",
-                       "title":  "Sustained Failure Signals",
-                       "description":  "Failure signals that continue over the recent window. This is event-based history; use CR phase and condition panels for exact current stuck CRs.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  12,
-                                       "y":  27
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        },
-                                           "overrides":  [
+                                                                            ]
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom",
+                                                                         "showLegend":  true
+                                                                     },
+                                                          "tooltip":  {
+                                                                          "mode":  "multi",
+                                                                          "sort":  "none"
+                                                                      }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (controller, result) (increase(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",result!~\"success|database_not_found\"}[$__range]))",
+                                                              "legendFormat":  "aggregator {{controller}} / {{result}}",
+                                                              "refId":  "A"
+                                                          },
+                                                          {
+                                                              "expr":  "sum by (exported_namespace, reason) (increase(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__range]))",
+                                                              "legendFormat":  "secret {{exported_namespace}} / {{reason}}",
+                                                              "refId":  "B"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  10,
+                                          "type":  "timeseries",
+                                          "title":  "Sustained Failure Signals",
+                                          "description":  "Failure signals that continue over the recent window. This is event-based history; use CR phase and condition panels for exact current stuck CRs.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  12,
+                                                          "y":  3
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "short",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           },
+                                                              "overrides":  [
 
-                                                         ]
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom",
-                                                      "showLegend":  true
-                                                  },
-                                       "tooltip":  {
-                                                       "mode":  "multi",
-                                                       "sort":  "none"
-                                                   }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (controller, result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",result!~\"success|database_not_found\"}[15m])) \u003e 0",
-                                           "legendFormat":  "aggregator {{controller}} / {{result}}",
-                                           "refId":  "A"
-                                       },
-                                       {
-                                           "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[15m])) \u003e 0",
-                                           "legendFormat":  "secret {{exported_namespace}} / {{reason}}",
-                                           "refId":  "B"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  11,
-                       "type":  "timeseries",
-                       "title":  "Async Provisioning Activity",
-                       "description":  "Dashboard-only substitute for async operations in flight. Compares InternalDatabase polling activity with terminal completions.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  35
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "reqps",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        },
-                                           "overrides":  [
+                                                                            ]
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom",
+                                                                         "showLegend":  true
+                                                                     },
+                                                          "tooltip":  {
+                                                                          "mode":  "multi",
+                                                                          "sort":  "none"
+                                                                      }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (controller, result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",result!~\"success|database_not_found\"}[15m])) \u003e 0",
+                                                              "legendFormat":  "aggregator {{controller}} / {{result}}",
+                                                              "refId":  "A"
+                                                          },
+                                                          {
+                                                              "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[15m])) \u003e 0",
+                                                              "legendFormat":  "secret {{exported_namespace}} / {{reason}}",
+                                                              "refId":  "B"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  11,
+                                          "type":  "timeseries",
+                                          "title":  "Async Provisioning Activity",
+                                          "description":  "Dashboard-only substitute for async operations in flight. Compares InternalDatabase polling activity with terminal completions.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  11
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "reqps",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           },
+                                                              "overrides":  [
 
-                                                         ]
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom",
-                                                      "showLegend":  true
-                                                  },
-                                       "tooltip":  {
-                                                       "mode":  "multi",
-                                                       "sort":  "none"
-                                                   }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum(rate(dbaas_reconcile_trigger_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"internaldatabase\",trigger=\"polling\"}[15m]))",
-                                           "legendFormat":  "polling rate",
-                                           "refId":  "A"
-                                       },
-                                       {
-                                           "expr":  "sum(rate(dbaas_async_operation_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[15m]))",
-                                           "legendFormat":  "completion rate",
-                                           "refId":  "B"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  15,
-                       "type":  "timeseries",
-                       "title":  "Async Provisioning End-to-End Duration (seconds)",
-                       "description":  "How long it takes from HTTP 202 (async accepted) to a terminal state (completed / failed / terminated). This is the user-visible provisioning SLO.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  44
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "s",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "histogram_quantile(0.50, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
-                                           "legendFormat":  "P50 {{result}}"
-                                       },
-                                       {
-                                           "expr":  "histogram_quantile(0.90, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
-                                           "legendFormat":  "P90 {{result}}"
-                                       },
-                                       {
-                                           "expr":  "histogram_quantile(0.99, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
-                                           "legendFormat":  "P99 {{result}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  16,
-                       "type":  "timeseries",
-                       "title":  "Async Completion Rate by Outcome",
-                       "description":  "Rate of async operations completing per second, split by result (success / failed / terminated). Terminated means the aggregator canceled and the operator will resubmit.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  52
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "reqps",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        },
-                                           "overrides":  [
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "success"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "green",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "failed"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "red",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             },
-                                                             {
-                                                                 "matcher":  {
-                                                                                 "id":  "byName",
-                                                                                 "options":  "terminated"
-                                                                             },
-                                                                 "properties":  [
-                                                                                    {
-                                                                                        "id":  "color",
-                                                                                        "value":  {
-                                                                                                      "fixedColor":  "orange",
-                                                                                                      "mode":  "fixed"
-                                                                                                  }
-                                                                                    }
-                                                                                ]
-                                                             }
-                                                         ]
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (result) (rate(dbaas_async_operation_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
-                                           "legendFormat":  "{{result}}"
-                                       }
-                                   ]
+                                                                            ]
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom",
+                                                                         "showLegend":  true
+                                                                     },
+                                                          "tooltip":  {
+                                                                          "mode":  "multi",
+                                                                          "sort":  "none"
+                                                                      }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum(rate(dbaas_reconcile_trigger_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"internaldatabase\",trigger=\"polling\"}[15m]))",
+                                                              "legendFormat":  "polling rate",
+                                                              "refId":  "A"
+                                                          },
+                                                          {
+                                                              "expr":  "sum(rate(dbaas_async_operation_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[15m]))",
+                                                              "legendFormat":  "completion rate",
+                                                              "refId":  "B"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  15,
+                                          "type":  "timeseries",
+                                          "title":  "Async Provisioning End-to-End Duration (seconds)",
+                                          "description":  "How long it takes from HTTP 202 (async accepted) to a terminal state (completed / failed / terminated). This is the user-visible provisioning SLO.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  20
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "s",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "histogram_quantile(0.50, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                                                              "legendFormat":  "P50 {{result}}"
+                                                          },
+                                                          {
+                                                              "expr":  "histogram_quantile(0.90, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                                                              "legendFormat":  "P90 {{result}}"
+                                                          },
+                                                          {
+                                                              "expr":  "histogram_quantile(0.99, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                                                              "legendFormat":  "P99 {{result}}"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  16,
+                                          "type":  "timeseries",
+                                          "title":  "Async Completion Rate by Outcome",
+                                          "description":  "Rate of async operations completing per second, split by result (success / failed / terminated). Terminated means the aggregator canceled and the operator will resubmit.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  28
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "reqps",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           },
+                                                              "overrides":  [
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "success"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "green",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "failed"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "red",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "terminated"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "orange",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                }
+                                                                            ]
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (result) (rate(dbaas_async_operation_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
+                                                              "legendFormat":  "{{result}}"
+                                                          }
+                                                      ]
+                                      }
+                                  ]
                    },
                    {
                        "id":  17,
                        "type":  "row",
                        "title":  "Balancing Rules",
-                       "collapsed":  false,
+                       "collapsed":  true,
                        "gridPos":  {
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  60
-                                   }
-                   },
-                   {
-                       "id":  18,
-                       "type":  "timeseries",
-                       "title":  "Balancing Rule Aggregator Calls",
-                       "description":  "Rate of balancing-rule requests sent by the operator to dbaas-aggregator, split by operation and result.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  61
+                                       "y":  3
                                    },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "reqps",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (operation, result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"balancingrule\"}[1m]))",
-                                           "legendFormat":  "{{operation}} / {{result}}"
-                                       }
-                                   ]
+                       "panels":  [
+                                      {
+                                          "id":  18,
+                                          "type":  "timeseries",
+                                          "title":  "Balancing Rule Aggregator Calls",
+                                          "description":  "Rate of balancing-rule requests sent by the operator to dbaas-aggregator, split by operation and result.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  4
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "reqps",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (operation, result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"balancingrule\"}[1m]))",
+                                                              "legendFormat":  "{{operation}} / {{result}}"
+                                                          }
+                                                      ]
+                                      }
+                                  ]
                    },
                    {
                        "id":  19,
@@ -698,7 +706,7 @@
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  69
+                                       "y":  4
                                    }
                    },
                    {
@@ -710,7 +718,7 @@
                                        "h":  8,
                                        "w":  12,
                                        "x":  0,
-                                       "y":  70
+                                       "y":  5
                                    },
                        "datasource":  "$datasource",
                        "fieldConfig":  {
@@ -729,7 +737,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
+                                           "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
                                            "legendFormat":  "{{kind}} / {{phase}}"
                                        }
                                    ]
@@ -743,7 +751,7 @@
                                        "h":  8,
                                        "w":  12,
                                        "x":  12,
-                                       "y":  70
+                                       "y":  5
                                    },
                        "datasource":  "$datasource",
                        "fieldConfig":  {
@@ -762,7 +770,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{cluster=~\"$cluster\",namespace=~\"$namespace\",condition=\"Ready\",status!=\"True\"}))",
+                                           "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{cluster=~\"$cluster\",namespace=~\"$namespace\",condition=\"Ready\",status!=\"True\"}))",
                                            "legendFormat":  "{{kind}} / {{reason}}"
                                        }
                                    ]
@@ -776,7 +784,7 @@
                                        "h":  8,
                                        "w":  12,
                                        "x":  0,
-                                       "y":  78
+                                       "y":  13
                                    },
                        "datasource":  "$datasource",
                        "fieldConfig":  {
@@ -795,7 +803,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{cluster=~\"$cluster\",namespace=~\"$namespace\"}) > 0)",
+                                           "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{cluster=~\"$cluster\",namespace=~\"$namespace\"}) \u003e 0)",
                                            "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}}"
                                        }
                                    ]
@@ -809,7 +817,7 @@
                                        "h":  8,
                                        "w":  12,
                                        "x":  12,
-                                       "y":  78
+                                       "y":  13
                                    },
                        "datasource":  "$datasource",
                        "fieldConfig":  {
@@ -837,197 +845,200 @@
                        "id":  24,
                        "type":  "row",
                        "title":  "DatabaseSecretClaim Health",
-                       "collapsed":  false,
+                       "collapsed":  true,
                        "gridPos":  {
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  86
-                                   }
-                   },
-                   {
-                       "id":  25,
-                       "type":  "timeseries",
-                       "title":  "SecretClaim DatabaseNotFound Age",
-                       "description":  "Age of the current DatabaseNotFound streak per DatabaseSecretClaim. Persistent values point to missing DB provisioning or classifier mismatch.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  0,
-                                       "y":  87
+                                       "y":  21
                                    },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "s",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                          "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_first_not_found_timestamp_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
-                                           "legendFormat":  "{{resource_namespace}}/{{name}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  26,
-                       "type":  "timeseries",
-                       "title":  "SecretClaim Time Since Last Rotation",
-                       "description":  "Seconds since each DatabaseSecretClaim last applied rotated connection properties.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  12,
-                                       "y":  87
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "s",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_last_rotation_timestamp_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
-                                           "legendFormat":  "{{resource_namespace}}/{{name}}"
-                                       }
-                                   ]
+                       "panels":  [
+                                      {
+                                          "id":  25,
+                                          "type":  "timeseries",
+                                          "title":  "SecretClaim DatabaseNotFound Age",
+                                          "description":  "Age of the current DatabaseNotFound streak per DatabaseSecretClaim. Persistent values point to missing DB provisioning or classifier mismatch.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  0,
+                                                          "y":  22
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "s",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_first_not_found_timestamp_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+                                                              "legendFormat":  "{{resource_namespace}}/{{name}}"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  26,
+                                          "type":  "timeseries",
+                                          "title":  "SecretClaim Time Since Last Rotation",
+                                          "description":  "Seconds since each DatabaseSecretClaim last applied rotated connection properties.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  12,
+                                                          "y":  22
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "s",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_last_rotation_timestamp_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+                                                              "legendFormat":  "{{resource_namespace}}/{{name}}"
+                                                          }
+                                                      ]
+                                      }
+                                  ]
                    },
                    {
                        "id":  27,
                        "type":  "row",
                        "title":  "Placement and Namespace Ownership",
-                       "collapsed":  false,
+                       "collapsed":  true,
                        "gridPos":  {
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  95
-                                   }
-                   },
-                   {
-                       "id":  28,
-                       "type":  "timeseries",
-                       "title":  "Balancing Rule Desired vs Applied Targets",
-                       "description":  "Compares placement intent from spec with the last applied state recorded in status. These counts do not prove referenced physical databases exist or independently read back aggregator state. No data means no owned balancing-rule CRs currently exist.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  0,
-                                       "y":  96
+                                       "y":  22
                                    },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_desired_targets{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
-                                           "legendFormat":  "desired {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
-                                           "refId":  "A"
-                                       },
-                                       {
-                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_applied_targets{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
-                                           "legendFormat":  "applied {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
-                                           "refId":  "B"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  29,
-                       "type":  "timeseries",
-                       "title":  "NamespaceBinding States",
-                       "description":  "Current namespace ownership state from this operator instance's point of view. deleting_with_finalizer means deletion is in progress and the protection finalizer remains; it does not by itself prove blocking resources still exist.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  12,
-                                       "y":  96
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                          "expr":  "sum by (state) (max without (pod, instance) (dbaas_namespace_binding_state{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
-                                           "legendFormat":  "{{state}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  30,
-                       "type":  "timeseries",
-                       "title":  "Resources being deleted",
-                       "description":  "Current dbaas resources that have deletionTimestamp set. deleting_with_finalizer means cleanup/finalizer removal is still pending. No data means no resources are currently being deleted.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  104
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                          "expr":  "sum by (kind, resource_namespace, name, state) (max without (pod, instance) (dbaas_resource_deletion_state{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
-                                           "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}} / {{state}}"
-                                       }
-                                   ]
+                       "panels":  [
+                                      {
+                                          "id":  28,
+                                          "type":  "timeseries",
+                                          "title":  "Balancing Rule Desired vs Applied Targets",
+                                          "description":  "Compares placement intent from spec with the last applied state recorded in status. These counts do not prove referenced physical databases exist or independently read back aggregator state. No data means no owned balancing-rule CRs currently exist.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  0,
+                                                          "y":  23
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "short",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_desired_targets{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
+                                                              "legendFormat":  "desired {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
+                                                              "refId":  "A"
+                                                          },
+                                                          {
+                                                              "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_applied_targets{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
+                                                              "legendFormat":  "applied {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
+                                                              "refId":  "B"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  29,
+                                          "type":  "timeseries",
+                                          "title":  "NamespaceBinding States",
+                                          "description":  "Current namespace ownership state from this operator instance\u0027s point of view. deleting_with_finalizer means deletion is in progress and the protection finalizer remains; it does not by itself prove blocking resources still exist.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  12,
+                                                          "x":  12,
+                                                          "y":  23
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "short",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (state) (max without (pod, instance) (dbaas_namespace_binding_state{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
+                                                              "legendFormat":  "{{state}}"
+                                                          }
+                                                      ]
+                                      },
+                                      {
+                                          "id":  30,
+                                          "type":  "timeseries",
+                                          "title":  "Resources being deleted",
+                                          "description":  "Current dbaas resources that have deletionTimestamp set. deleting_with_finalizer means cleanup/finalizer removal is still pending. No data means no resources are currently being deleted.",
+                                          "gridPos":  {
+                                                          "h":  8,
+                                                          "w":  24,
+                                                          "x":  0,
+                                                          "y":  31
+                                                      },
+                                          "datasource":  "$datasource",
+                                          "fieldConfig":  {
+                                                              "defaults":  {
+                                                                               "unit":  "short",
+                                                                               "custom":  {
+                                                                                              "lineWidth":  2
+                                                                                          }
+                                                                           }
+                                                          },
+                                          "options":  {
+                                                          "legend":  {
+                                                                         "displayMode":  "list",
+                                                                         "placement":  "bottom"
+                                                                     }
+                                                      },
+                                          "targets":  [
+                                                          {
+                                                              "expr":  "sum by (kind, resource_namespace, name, state) (max without (pod, instance) (dbaas_resource_deletion_state{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
+                                                              "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}} / {{state}}"
+                                                          }
+                                                      ]
+                                      }
+                                  ]
                    }
                ]
 }
-

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -64,6 +64,11 @@
                                         "type":  "query"
                                     },
                                     {
+                                        "current":  {
+                                                        "selected":  true,
+                                                        "text":  "namespace-default-placeholder",
+                                                        "value":  "namespace-default-placeholder"
+                                                    },
                                         "datasource":  "$datasource",
                                         "definition":  "label_values(dbaas_resource_collector_success{cluster=~\"$cluster\"}, namespace)",
                                         "hide":  0,

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -8,7 +8,8 @@
                  "k8s"
              ],
     "schemaVersion":  39,
-    "version":  4,
+    "version":  5,
+    "refresh":  "1m",
     "time":  {
                  "from":  "now-30m",
                  "to":  "now"

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -8,7 +8,7 @@
                  "k8s"
              ],
     "schemaVersion":  39,
-    "version":  6,
+    "version":  7,
     "refresh":  "1m",
     "time":  {
                  "from":  "now-30m",
@@ -94,6 +94,150 @@
                    },
     "panels":  [
                    {
+                       "id":  19,
+                       "type":  "row",
+                       "title":  "CR Health Overview",
+                       "collapsed":  false,
+                       "gridPos":  {
+                                       "h":  1,
+                                       "w":  24,
+                                       "x":  0,
+                                       "y":  0
+                                   }
+                   },
+                   {
+                       "id":  20,
+                       "type":  "timeseries",
+                       "title":  "CRs by Current Phase",
+                       "description":  "Current phase for dbaas operator CRs. This is a current-state gauge, not a reconcile counter.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  0,
+                                       "y":  1
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
+                                           "legendFormat":  "{{kind}} / {{phase}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  21,
+                       "type":  "timeseries",
+                       "title":  "Unready CRs by Reason",
+                       "description":  "Current Ready=False/Unknown conditions by kind and reason. Reasons are intended to route ownership quickly.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  12,
+                                       "y":  1
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{cluster=~\"$cluster\",namespace=~\"$namespace\",condition=\"Ready\",status!=\"True\"}))",
+                                           "legendFormat":  "{{kind}} / {{reason}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  22,
+                       "type":  "timeseries",
+                       "title":  "CRs Waiting for Observed Generation",
+                       "description":  "Shows CRs whose metadata.generation is ahead of status.observedGeneration. This is convergence lag, not elapsed time.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  0,
+                                       "y":  9
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{cluster=~\"$cluster\",namespace=~\"$namespace\"}) \u003e 0)",
+                                           "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}}"
+                                       }
+                                   ]
+                   },
+                   {
+                       "id":  23,
+                       "type":  "timeseries",
+                       "title":  "CR Metrics Collector Health",
+                       "description":  "A value of 0 means the custom CR-state collector failed to list that kind during scrape.",
+                       "gridPos":  {
+                                       "h":  8,
+                                       "w":  12,
+                                       "x":  12,
+                                       "y":  9
+                                   },
+                       "datasource":  "$datasource",
+                       "fieldConfig":  {
+                                           "defaults":  {
+                                                            "unit":  "short",
+                                                            "custom":  {
+                                                                           "lineWidth":  2
+                                                                       }
+                                                        }
+                                       },
+                       "options":  {
+                                       "legend":  {
+                                                      "displayMode":  "list",
+                                                      "placement":  "bottom"
+                                                  }
+                                   },
+                       "targets":  [
+                                       {
+                                           "expr":  "min by (kind) (dbaas_resource_collector_success{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
+                                           "legendFormat":  "{{kind}}"
+                                       }
+                                   ]
+                   },
+                   {
                        "id":  1,
                        "type":  "row",
                        "title":  "Credentials \u0026 Secret Resolution",
@@ -102,7 +246,7 @@
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  0
+                                       "y":  17
                                    },
                        "panels":  [
                                       {
@@ -114,7 +258,7 @@
                                                           "h":  8,
                                                           "w":  24,
                                                           "x":  0,
-                                                          "y":  1
+                                                          "y":  18
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -164,7 +308,7 @@
                                                           "h":  8,
                                                           "w":  24,
                                                           "x":  0,
-                                                          "y":  9
+                                                          "y":  26
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -203,7 +347,7 @@
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  1
+                                       "y":  18
                                    },
                        "panels":  [
                                       {
@@ -215,7 +359,7 @@
                                                           "h":  8,
                                                           "w":  12,
                                                           "x":  0,
-                                                          "y":  2
+                                                          "y":  19
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -256,7 +400,7 @@
                                                           "h":  8,
                                                           "w":  12,
                                                           "x":  12,
-                                                          "y":  2
+                                                          "y":  19
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -383,7 +527,7 @@
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  2
+                                       "y":  19
                                    },
                        "panels":  [
                                       {
@@ -395,7 +539,7 @@
                                                           "h":  8,
                                                           "w":  12,
                                                           "x":  0,
-                                                          "y":  3
+                                                          "y":  20
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -442,7 +586,7 @@
                                                           "h":  8,
                                                           "w":  12,
                                                           "x":  12,
-                                                          "y":  3
+                                                          "y":  20
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -489,7 +633,7 @@
                                                           "h":  8,
                                                           "w":  24,
                                                           "x":  0,
-                                                          "y":  11
+                                                          "y":  28
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -536,7 +680,7 @@
                                                           "h":  8,
                                                           "w":  24,
                                                           "x":  0,
-                                                          "y":  20
+                                                          "y":  37
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -577,7 +721,7 @@
                                                           "h":  8,
                                                           "w":  24,
                                                           "x":  0,
-                                                          "y":  28
+                                                          "y":  45
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -659,7 +803,7 @@
                                        "h":  1,
                                        "w":  24,
                                        "x":  0,
-                                       "y":  3
+                                       "y":  20
                                    },
                        "panels":  [
                                       {
@@ -671,7 +815,7 @@
                                                           "h":  8,
                                                           "w":  24,
                                                           "x":  0,
-                                                          "y":  4
+                                                          "y":  21
                                                       },
                                           "datasource":  "$datasource",
                                           "fieldConfig":  {
@@ -696,150 +840,6 @@
                                                       ]
                                       }
                                   ]
-                   },
-                   {
-                       "id":  19,
-                       "type":  "row",
-                       "title":  "CR Health Overview",
-                       "collapsed":  false,
-                       "gridPos":  {
-                                       "h":  1,
-                                       "w":  24,
-                                       "x":  0,
-                                       "y":  4
-                                   }
-                   },
-                   {
-                       "id":  20,
-                       "type":  "timeseries",
-                       "title":  "CRs by Current Phase",
-                       "description":  "Current phase for dbaas operator CRs. This is a current-state gauge, not a reconcile counter.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  0,
-                                       "y":  5
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
-                                           "legendFormat":  "{{kind}} / {{phase}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  21,
-                       "type":  "timeseries",
-                       "title":  "Unready CRs by Reason",
-                       "description":  "Current Ready=False/Unknown conditions by kind and reason. Reasons are intended to route ownership quickly.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  12,
-                                       "y":  5
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{cluster=~\"$cluster\",namespace=~\"$namespace\",condition=\"Ready\",status!=\"True\"}))",
-                                           "legendFormat":  "{{kind}} / {{reason}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  22,
-                       "type":  "timeseries",
-                       "title":  "CRs Waiting for Observed Generation",
-                       "description":  "Shows CRs whose metadata.generation is ahead of status.observedGeneration. This is convergence lag, not elapsed time.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  0,
-                                       "y":  13
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{cluster=~\"$cluster\",namespace=~\"$namespace\"}) \u003e 0)",
-                                           "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}}"
-                                       }
-                                   ]
-                   },
-                   {
-                       "id":  23,
-                       "type":  "timeseries",
-                       "title":  "CR Metrics Collector Health",
-                       "description":  "A value of 0 means the custom CR-state collector failed to list that kind during scrape.",
-                       "gridPos":  {
-                                       "h":  8,
-                                       "w":  12,
-                                       "x":  12,
-                                       "y":  13
-                                   },
-                       "datasource":  "$datasource",
-                       "fieldConfig":  {
-                                           "defaults":  {
-                                                            "unit":  "short",
-                                                            "custom":  {
-                                                                           "lineWidth":  2
-                                                                       }
-                                                        }
-                                       },
-                       "options":  {
-                                       "legend":  {
-                                                      "displayMode":  "list",
-                                                      "placement":  "bottom"
-                                                  }
-                                   },
-                       "targets":  [
-                                       {
-                                           "expr":  "min by (kind) (dbaas_resource_collector_success{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
-                                           "legendFormat":  "{{kind}}"
-                                       }
-                                   ]
                    },
                    {
                        "id":  24,

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -1,11 +1,16 @@
 {
     "title":  "DBaaS Operator",
-    "uid":  "dbaas-operator",
+    "uid":  "dashboard-uid-placeholder",
+    "tags":  [
+                 "dbaas",
+                 "operator",
+                 "prometheus",
+                 "k8s"
+             ],
     "schemaVersion":  39,
-    "version":  3,
-    "refresh":  "30s",
+    "version":  4,
     "time":  {
-                 "from":  "now-15m",
+                 "from":  "now-30m",
                  "to":  "now"
              },
     "timezone":  "browser",
@@ -30,6 +35,54 @@
                                         "regex":  "",
                                         "skipUrlSync":  false,
                                         "type":  "datasource"
+                                    },
+                                    {
+                                        "current":  {
+                                                        "selected":  true,
+                                                        "text":  "All",
+                                                        "value":  "$__all"
+                                                    },
+                                        "datasource":  "$datasource",
+                                        "definition":  "label_values(dbaas_resource_collector_success, cluster)",
+                                        "hide":  0,
+                                        "includeAll":  true,
+                                        "allValue":  ".*",
+                                        "label":  "Cluster",
+                                        "multi":  false,
+                                        "name":  "cluster",
+                                        "options":  [
+
+                                                    ],
+                                        "query":  {
+                                                      "query":  "label_values(dbaas_resource_collector_success, cluster)",
+                                                      "refId":  "StandardVariableQuery"
+                                                  },
+                                        "refresh":  1,
+                                        "regex":  "",
+                                        "skipUrlSync":  false,
+                                        "sort":  1,
+                                        "type":  "query"
+                                    },
+                                    {
+                                        "datasource":  "$datasource",
+                                        "definition":  "label_values(dbaas_resource_collector_success{cluster=~\"$cluster\"}, namespace)",
+                                        "hide":  0,
+                                        "includeAll":  false,
+                                        "label":  "DBaaS Operator Namespace",
+                                        "multi":  false,
+                                        "name":  "namespace",
+                                        "options":  [
+
+                                                    ],
+                                        "query":  {
+                                                      "query":  "label_values(dbaas_resource_collector_success{cluster=~\"$cluster\"}, namespace)",
+                                                      "refId":  "StandardVariableQuery"
+                                                  },
+                                        "refresh":  1,
+                                        "regex":  "",
+                                        "skipUrlSync":  false,
+                                        "sort":  1,
+                                        "type":  "query"
                                     }
                                 ]
                    },
@@ -53,7 +106,7 @@
                        "description":  "Reconcile invocations for ExternalDatabase by trigger source (spec_change, namespace_binding_change).",
                        "gridPos":  {
                                        "h":  8,
-                                       "w":  12,
+                                       "w":  24,
                                        "x":  0,
                                        "y":  1
                                    },
@@ -91,7 +144,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (trigger) (rate(dbaas_reconcile_trigger_total{namespace=\"#namespace#\",controller=\"externaldatabase\"}[1m]))",
+                                           "expr":  "sum by (trigger) (rate(dbaas_reconcile_trigger_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"externaldatabase\"}[1m]))",
                                            "legendFormat":  "{{trigger}}"
                                        }
                                    ]
@@ -103,7 +156,7 @@
                        "description":  "Failures reading a credentials Secret. Reasons are actionable: secret_not_found, key_missing, key_empty, forbidden, or secret_read_failed.",
                        "gridPos":  {
                                        "h":  8,
-                                       "w":  12,
+                                       "w":  24,
                                        "x":  0,
                                        "y":  9
                                    },
@@ -128,7 +181,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{namespace=\"#namespace#\"}[1m]))",
+                                           "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
                                            "legendFormat":  "{{exported_namespace}} / {{reason}}"
                                        }
                                    ]
@@ -173,15 +226,15 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "histogram_quantile(0.50, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{namespace=\"#namespace#\"}[5m])))",
+                                           "expr":  "histogram_quantile(0.50, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
                                            "legendFormat":  "P50 {{controller}}/{{operation}}"
                                        },
                                        {
-                                           "expr":  "histogram_quantile(0.90, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{namespace=\"#namespace#\"}[5m])))",
+                                           "expr":  "histogram_quantile(0.90, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
                                            "legendFormat":  "P90 {{controller}}/{{operation}}"
                                        },
                                        {
-                                           "expr":  "histogram_quantile(0.99, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{namespace=\"#namespace#\"}[5m])))",
+                                           "expr":  "histogram_quantile(0.99, sum by (controller, operation, le) (rate(dbaas_aggregator_request_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
                                            "legendFormat":  "P99 {{controller}}/{{operation}}"
                                        }
                                    ]
@@ -306,7 +359,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (result) (rate(dbaas_aggregator_requests_total{namespace=\"#namespace#\"}[1m]))",
+                                           "expr":  "sum by (result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
                                            "legendFormat":  "{{result}}"
                                        }
                                    ]
@@ -359,12 +412,12 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (controller, result) (increase(dbaas_aggregator_requests_total{namespace=\"#namespace#\",result!~\"success|database_not_found\"}[$__range]))",
+                                           "expr":  "sum by (controller, result) (increase(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",result!~\"success|database_not_found\"}[$__range]))",
                                            "legendFormat":  "aggregator {{controller}} / {{result}}",
                                            "refId":  "A"
                                        },
                                        {
-                                           "expr":  "sum by (exported_namespace, reason) (increase(dbaas_secret_resolution_errors_total{namespace=\"#namespace#\"}[$__range]))",
+                                           "expr":  "sum by (exported_namespace, reason) (increase(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__range]))",
                                            "legendFormat":  "secret {{exported_namespace}} / {{reason}}",
                                            "refId":  "B"
                                        }
@@ -406,12 +459,12 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (controller, result) (rate(dbaas_aggregator_requests_total{namespace=\"#namespace#\",result!~\"success|database_not_found\"}[15m])) \u003e 0",
+                                           "expr":  "sum by (controller, result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",result!~\"success|database_not_found\"}[15m])) \u003e 0",
                                            "legendFormat":  "aggregator {{controller}} / {{result}}",
                                            "refId":  "A"
                                        },
                                        {
-                                           "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{namespace=\"#namespace#\"}[15m])) \u003e 0",
+                                           "expr":  "sum by (exported_namespace, reason) (rate(dbaas_secret_resolution_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[15m])) \u003e 0",
                                            "legendFormat":  "secret {{exported_namespace}} / {{reason}}",
                                            "refId":  "B"
                                        }
@@ -453,12 +506,12 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum(rate(dbaas_reconcile_trigger_total{namespace=\"#namespace#\",controller=\"internaldatabase\",trigger=\"polling\"}[15m]))",
+                                           "expr":  "sum(rate(dbaas_reconcile_trigger_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"internaldatabase\",trigger=\"polling\"}[15m]))",
                                            "legendFormat":  "polling rate",
                                            "refId":  "A"
                                        },
                                        {
-                                           "expr":  "sum(rate(dbaas_async_operation_duration_seconds_count{namespace=\"#namespace#\"}[15m]))",
+                                           "expr":  "sum(rate(dbaas_async_operation_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[15m]))",
                                            "legendFormat":  "completion rate",
                                            "refId":  "B"
                                        }
@@ -471,8 +524,8 @@
                        "description":  "How long it takes from HTTP 202 (async accepted) to a terminal state (completed / failed / terminated). This is the user-visible provisioning SLO.",
                        "gridPos":  {
                                        "h":  8,
-                                       "w":  18,
-                                       "x":  6,
+                                       "w":  24,
+                                       "x":  0,
                                        "y":  44
                                    },
                        "datasource":  "$datasource",
@@ -492,15 +545,15 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "histogram_quantile(0.50, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{namespace=\"#namespace#\"}[5m])))",
+                                           "expr":  "histogram_quantile(0.50, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
                                            "legendFormat":  "P50 {{result}}"
                                        },
                                        {
-                                           "expr":  "histogram_quantile(0.90, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{namespace=\"#namespace#\"}[5m])))",
+                                           "expr":  "histogram_quantile(0.90, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
                                            "legendFormat":  "P90 {{result}}"
                                        },
                                        {
-                                           "expr":  "histogram_quantile(0.99, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{namespace=\"#namespace#\"}[5m])))",
+                                           "expr":  "histogram_quantile(0.99, sum by (result, le) (rate(dbaas_async_operation_duration_seconds_bucket{cluster=~\"$cluster\",namespace=~\"$namespace\"}[5m])))",
                                            "legendFormat":  "P99 {{result}}"
                                        }
                                    ]
@@ -512,7 +565,7 @@
                        "description":  "Rate of async operations completing per second, split by result (success / failed / terminated). Terminated means the aggregator canceled and the operator will resubmit.",
                        "gridPos":  {
                                        "h":  8,
-                                       "w":  12,
+                                       "w":  24,
                                        "x":  0,
                                        "y":  52
                                    },
@@ -580,7 +633,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (result) (rate(dbaas_async_operation_duration_seconds_count{namespace=\"#namespace#\"}[1m]))",
+                                           "expr":  "sum by (result) (rate(dbaas_async_operation_duration_seconds_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[1m]))",
                                            "legendFormat":  "{{result}}"
                                        }
                                    ]
@@ -625,7 +678,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "sum by (operation, result) (rate(dbaas_aggregator_requests_total{namespace=\"#namespace#\",controller=\"balancingrule\"}[1m]))",
+                                           "expr":  "sum by (operation, result) (rate(dbaas_aggregator_requests_total{cluster=~\"$cluster\",namespace=~\"$namespace\",controller=\"balancingrule\"}[1m]))",
                                            "legendFormat":  "{{operation}} / {{result}}"
                                        }
                                    ]
@@ -670,7 +723,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{namespace=\"#namespace#\"}))",
+                                          "expr":  "sum by (kind, phase) (max without (pod, instance) (dbaas_resource_phase{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
                                            "legendFormat":  "{{kind}} / {{phase}}"
                                        }
                                    ]
@@ -703,7 +756,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{namespace=\"#namespace#\",condition=\"Ready\",status!=\"True\"}))",
+                                          "expr":  "sum by (kind, reason) (max without (pod, instance) (dbaas_resource_condition{cluster=~\"$cluster\",namespace=~\"$namespace\",condition=\"Ready\",status!=\"True\"}))",
                                            "legendFormat":  "{{kind}} / {{reason}}"
                                        }
                                    ]
@@ -736,7 +789,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{namespace=\"#namespace#\"}) > 0)",
+                                          "expr":  "sum by (kind, resource_namespace, name) (max without (pod, instance) (dbaas_resource_observed_generation_lag{cluster=~\"$cluster\",namespace=~\"$namespace\"}) > 0)",
                                            "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}}"
                                        }
                                    ]
@@ -769,7 +822,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "min by (kind) (dbaas_resource_collector_success{namespace=\"#namespace#\"})",
+                                           "expr":  "min by (kind) (dbaas_resource_collector_success{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
                                            "legendFormat":  "{{kind}}"
                                        }
                                    ]
@@ -814,7 +867,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_first_not_found_timestamp_seconds{namespace=\"#namespace#\"})",
+                                          "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_first_not_found_timestamp_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
                                            "legendFormat":  "{{resource_namespace}}/{{name}}"
                                        }
                                    ]
@@ -847,7 +900,7 @@
                                    },
                        "targets":  [
                                        {
-                                           "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_last_rotation_timestamp_seconds{namespace=\"#namespace#\"})",
+                                           "expr":  "max by (resource_namespace, name) (time() - dbaas_secret_claim_last_rotation_timestamp_seconds{cluster=~\"$cluster\",namespace=~\"$namespace\"})",
                                            "legendFormat":  "{{resource_namespace}}/{{name}}"
                                        }
                                    ]
@@ -868,7 +921,7 @@
                        "id":  28,
                        "type":  "timeseries",
                        "title":  "Balancing Rule Desired vs Applied Targets",
-                       "description":  "Compares placement intent from spec with the last applied state recorded in status. These counts do not prove referenced physical databases exist or independently read back aggregator state.",
+                       "description":  "Compares placement intent from spec with the last applied state recorded in status. These counts do not prove referenced physical databases exist or independently read back aggregator state. No data means no owned balancing-rule CRs currently exist.",
                        "gridPos":  {
                                        "h":  8,
                                        "w":  12,
@@ -892,12 +945,12 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_desired_targets{namespace=\"#namespace#\"}))",
+                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_desired_targets{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
                                            "legendFormat":  "desired {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
                                            "refId":  "A"
                                        },
                                        {
-                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_applied_targets{namespace=\"#namespace#\"}))",
+                                          "expr":  "sum by (kind, resource_namespace, name, target_type) (max without (pod, instance) (dbaas_balancing_rule_applied_targets{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
                                            "legendFormat":  "applied {{kind}} {{resource_namespace}}/{{name}} / {{target_type}}",
                                            "refId":  "B"
                                        }
@@ -931,7 +984,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (state) (max without (pod, instance) (dbaas_namespace_binding_state{namespace=\"#namespace#\"}))",
+                                          "expr":  "sum by (state) (max without (pod, instance) (dbaas_namespace_binding_state{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
                                            "legendFormat":  "{{state}}"
                                        }
                                    ]
@@ -940,7 +993,7 @@
                        "id":  30,
                        "type":  "timeseries",
                        "title":  "Resources being deleted",
-                       "description":  "Current dbaas resources that have deletionTimestamp set. deleting_with_finalizer means cleanup/finalizer removal is still pending.",
+                       "description":  "Current dbaas resources that have deletionTimestamp set. deleting_with_finalizer means cleanup/finalizer removal is still pending. No data means no resources are currently being deleted.",
                        "gridPos":  {
                                        "h":  8,
                                        "w":  24,
@@ -964,7 +1017,7 @@
                                    },
                        "targets":  [
                                        {
-                                          "expr":  "sum by (kind, resource_namespace, name, state) (max without (pod, instance) (dbaas_resource_deletion_state{namespace=\"#namespace#\"}))",
+                                          "expr":  "sum by (kind, resource_namespace, name, state) (max without (pod, instance) (dbaas_resource_deletion_state{cluster=~\"$cluster\",namespace=~\"$namespace\"}))",
                                            "legendFormat":  "{{kind}} {{resource_namespace}}/{{name}} / {{state}}"
                                        }
                                    ]

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/Dashboard.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/Dashboard.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.DBAAS_OPERATOR_ENABLED .Values.MONITORING_ENABLED }}
+{{- $dashboardNamespace := .Values.NAMESPACE | trunc 25 | trimSuffix "-" }}
+{{- $dashboardUID := printf "%s-dbaas-operator" $dashboardNamespace }}
 ---
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
@@ -13,5 +15,5 @@ metadata:
     deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID | default "unimplemented" }}'
 spec:
   name: dbaas-operator-dashboard.json
-  json: {{ .Files.Get "dashboards/dbaas-operator-dashboard.json" | toJson | replace "#namespace#" .Values.NAMESPACE }}
+  json: {{ .Files.Get "dashboards/dbaas-operator-dashboard.json" | toJson | replace "dashboard-uid-placeholder" $dashboardUID }}
 {{- end }}

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/Dashboard.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/Dashboard.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.DBAAS_OPERATOR_ENABLED .Values.MONITORING_ENABLED }}
-{{- $dashboardNamespace := .Values.NAMESPACE | trunc 25 | trimSuffix "-" }}
-{{- $dashboardUID := printf "%s-dbaas-operator" $dashboardNamespace }}
+{{- $namespaceHash := sha256sum .Values.NAMESPACE | trunc 6 }}
+{{- $dashboardNamespace := .Values.NAMESPACE | trunc 18 | trimSuffix "-" }}
+{{- $dashboardUID := printf "%s-%s-dbaas-operator" $dashboardNamespace $namespaceHash }}
 ---
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
@@ -15,5 +16,5 @@ metadata:
     deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID | default "unimplemented" }}'
 spec:
   name: dbaas-operator-dashboard.json
-  json: {{ .Files.Get "dashboards/dbaas-operator-dashboard.json" | toJson | replace "dashboard-uid-placeholder" $dashboardUID }}
+  json: {{ .Files.Get "dashboards/dbaas-operator-dashboard.json" | toJson | replace "dashboard-uid-placeholder" $dashboardUID | replace "namespace-default-placeholder" .Values.NAMESPACE }}
 {{- end }}

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/Dashboard.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/Dashboard.yaml
@@ -2,6 +2,11 @@
 {{- $namespaceHash := sha256sum .Values.NAMESPACE | trunc 6 }}
 {{- $dashboardNamespace := .Values.NAMESPACE | trunc 18 | trimSuffix "-" }}
 {{- $dashboardUID := printf "%s-%s-dbaas-operator" $dashboardNamespace $namespaceHash }}
+{{- /*
+The dashboard intentionally refreshes every minute because it presents operational health,
+reconciliation lag, and active error states. This is one query refresh per two 30-second
+metric scrapes, and the monitoring design guide permits auto-refresh when justified.
+*/}}
 ---
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard


### PR DESCRIPTION
Updates the DBaaS Operator Grafana dashboard to support multiple operator instances and DR clusters.
- Generates a namespace-specific dashboard UID to prevent collisions.
- Adds namespace and cluster selectors to all queries.
- Improves panel layout, tags, descriptions, and default time settings.
- Documents dashboard behavior, including conditionally empty panels.