### PR TITLE
fix(ci): pass secrets to the called integration-tests workflow

### DIFF
--- a/.github/workflows/generate-integration-tests-report.yml
+++ b/.github/workflows/generate-integration-tests-report.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   run-tests:
     uses: ./.github/workflows/integration-tests.yml
+    # Called workflows inherit vars but not secrets, so without this the report
+    # email step silently fails on an empty EMAIL_PASSWORD.
+    secrets: inherit
   update-report:
     needs: run-tests
     if: ${{ !cancelled() }}


### PR DESCRIPTION
## Why

The nightly **Generate Test Report** run calls `integration-tests.yml` as a reusable workflow. A called workflow inherits repository *variables* but **not** secrets unless they are passed explicitly, so `EMAIL_PASSWORD` arrived empty and the report email step aborted:

```
Error: Invalid `password` field in `.with` input. SMTP password is required.
```

The step is marked `continue-on-error: true`, so the failure surfaced only as an annotation and the job stayed green — the nightly report has been silently unsent (see [run 30138914962](https://github.com/Netcracker/qubership-dbaas/actions/runs/30138914962)). Manual `workflow_dispatch` runs of `integration-tests.yml` were unaffected, which is why this stayed invisible.

## What

One line on the `run-tests` job: `secrets: inherit`. This is the only reusable-workflow call site in the repository, so no other workflow is affected.

## How to verify

Run **Generate Test Report** manually and confirm the `Email test report` step reports a sent message instead of the SMTP password error.

## Note

Cherry-pick of 1b0d31d0 from `feat/operator-dev` (already merged there). Raised separately against `main` so the nightly report starts working without waiting for #605.