### PR TITLE
fix(operator): treat HTTP 202 from tenant materialization as not-yet-ready

### DIFF
--- a/dbaas-operator/docs/howto/DBaaS Operator.md
+++ b/dbaas-operator/docs/howto/DBaaS Operator.md
@@ -1565,9 +1565,16 @@ This materializes the database exactly as the tenant's first runtime connection 
 #### InternalDatabase Status Reference
 
 Shared phases, conditions, reasons, and diagnostic rules are described in
-[Common Status Model](#common-status-model). This kind adds one phase, `WaitingForDependency` — an async
-provisioning operation is in flight and the controller is polling the aggregator — and `Succeeded` means
-that operation completed.
+[Common Status Model](#common-status-model). This kind adds one phase, `WaitingForDependency`, which has
+**two** causes:
+
+- the declarative apply returned `202 Accepted` and the controller is polling the operation
+  (`status.trackingId` is set), or
+- the apply is done but the pinned-tenant get-or-create returned `202` — the database is still being
+  created, and `status.trackingId` is **empty** because that endpoint issues none (see
+  [Tenant Database Materialization](#tenant-database-materialization)).
+
+`Succeeded` means both steps finished.
 
 **`status.trackingId`** — aggregator-assigned tracking ID for an in-flight async operation.
 
@@ -1575,6 +1582,9 @@ that operation completed.
 - Cleared when polling completes (`COMPLETED`, `FAILED`) or the operation must be re-submitted (`TERMINATED`, `404 Not
   Found`).
 - While `trackingId` is non-empty, every reconcile goes through the POLL branch (no resubmission).
+- An **empty** `trackingId` together with `WaitingForDependency` is not an inconsistency: it is the
+  tenant-materialization wait, which has nothing to poll and instead repeats the idempotent apply +
+  get-or-create every 5 s.
 
 **`status.pendingOperationGeneration`** — the `metadata.generation` value captured when `trackingId` was set. If a newer
 `generation` is observed during a reconcile, the stale `trackingId` is discarded and the operation is re-submitted with
@@ -1587,7 +1597,7 @@ operation".
 | Reason | Applied to | Meaning |
 |--------|-----------|---------|
 | `DatabaseProvisioned` | `Ready=True` | Operation completed (`200 OK` synchronous, or polled `COMPLETED`) |
-| `ProvisioningStarted` | `Ready=False`, `Stalled=False` | `202 Accepted` received; async polling in progress |
+| `ProvisioningStarted` | `Ready=False`, `Stalled=False` | A `202 Accepted` is outstanding: either the declarative apply is being polled (`trackingId` set), or the pinned-tenant get-or-create is still creating the database (`trackingId` empty) |
 | `OperationTerminated` | `Ready=False`, `Stalled=False` | Poll returned `TERMINATED` (aggregator restart or admin cancellation). The stale `trackingId` is cleared and the controller resubmits on the next reconcile |
 
 For this kind `AggregatorRejected` also covers a polled `FAILED`, and `AggregatorError` also covers a
@@ -1605,7 +1615,9 @@ polling `404` (expired `trackingId`).
 | POST → 401 | `BackingOff` | `False` | `Unauthorized` | `False` | — |
 | POST → 400 / 403 / 409 / 410 / 422 | `InvalidConfiguration` | `False` | `AggregatorRejected` | `True` | — |
 | POST → 5xx / network | `BackingOff` | `False` | `AggregatorError` | `False` | — |
-| POST → 200 OK (sync) | `Succeeded` | `True` | `DatabaseProvisioned` | `False` | — |
+| POST → 200 OK (sync), materialization 200/201 or not needed | `Succeeded` | `True` | `DatabaseProvisioned` | `False` | — |
+| Apply done, tenant materialization → 202 | `WaitingForDependency` | `False` | `ProvisioningStarted` | `False` | **empty** |
+| Apply done, tenant materialization → 4xx/5xx | `BackingOff` / `InvalidConfiguration` | `False` | `AggregatorError` / `AggregatorRejected` | `False` / `True` | — |
 | POST → 202 Accepted | `WaitingForDependency` | `False` | `ProvisioningStarted` | `False` | set |
 | Poll → IN_PROGRESS | `WaitingForDependency` | `False` | `ProvisioningStarted` | `False` | set |
 | Poll → COMPLETED | `Succeeded` | `True` | `DatabaseProvisioned` | `False` | cleared |
@@ -1616,8 +1628,12 @@ polling `404` (expired `trackingId`).
 
 **Diagnostic rules** — in addition to the [shared rules](#common-status-model):
 
-- **`Ready=False` with phase `WaitingForDependency`** — not an error: async provisioning is still running and
-  the controller polls every 5 seconds. Only phase `BackingOff` means a failed call is being retried.
+- **`Ready=False` with phase `WaitingForDependency`** — not an error: something is still provisioning and the
+  controller re-checks every 5 seconds. Only phase `BackingOff` means a failed call is being retried.
+  Read `status.trackingId` to tell the two waits apart: **set** means the declarative operation is being
+  polled; **empty** means the pinned-tenant database is still being created and the controller repeats the
+  apply + get-or-create. An empty `trackingId` here is expected — that endpoint returns none. If the wait
+  does not clear, look at the tenant database on the aggregator side rather than at the CR.
 
 #### InternalDatabase Usage Examples
 

--- a/dbaas-operator/docs/howto/DBaaS Operator.md
+++ b/dbaas-operator/docs/howto/DBaaS Operator.md
@@ -194,7 +194,7 @@ The operator calls the following dbaas-aggregator endpoints:
 | `PUT` | `/api/v3/dbaas/{namespace}/databases/registration/externally_manageable` | `ExternalDatabase` reconciler | Register or update an externally managed database |
 | `POST` | `/api/declarations/v1/apply` | `DatabaseAccessPolicy` and `InternalDatabase` reconcilers | Apply a declarative database role policy (`subKind=DbPolicy`) or database declaration (`subKind=DatabaseDeclaration`) |
 | `GET` | `/api/declarations/v1/operation/{trackingId}/status` | `InternalDatabase` reconciler | Poll the status of an asynchronous provisioning operation |
-| `PUT` | `/api/v3/dbaas/{namespace}/databases` | `InternalDatabase` reconciler (tenant declarations with a pinned `tenantId`) | Get-or-create the concrete `{scope=tenant, tenantId}` database after the declarative apply — see [Tenant database materialization](#tenant-database-materialization) |
+| `PUT` | `/api/v3/dbaas/{namespace}/databases` | `InternalDatabase` reconciler (tenant declarations with a pinned `tenantId`) | Get-or-create the concrete `{scope=tenant, tenantId}` database after the declarative apply. Answers `202` while it is still creating the database — see [Tenant database materialization](#tenant-database-materialization) |
 | `POST` | `/api/v3/dbaas/{namespace}/databases/get-by-classifier/{type}` | `DatabaseSecretClaim` reconciler (and rotation-poller fan-out) | Fetch the connection properties of a registered database |
 | `PUT` | `/api/v3/dbaas/{namespace}/physical_databases/rules/onMicroservices` | `MicroserviceBalancingRule` reconciler | Apply the microservice balancing rule set for a business namespace |
 | `PUT` | `/api/v3/dbaas/{namespace}/physical_databases/balancing/rules/{ruleName}` | `NamespaceBalancingRule` reconciler | Create or update one named namespace balancing rule |
@@ -1552,6 +1552,11 @@ This materializes the database exactly as the tenant's first runtime connection 
 - **scoped** — a no-op for `scope=service`, or for a tenant declaration **without** a pinned `tenantId` (the
   tenant-agnostic template behavior is unchanged);
 - **idempotent** — get-or-create returns the existing database on subsequent reconciles;
+- **possibly asynchronous** — the aggregator answers `200`/`201` when the database is ready, and `202 Accepted` when it
+  only started creating it. A `202` body carries no usable credentials (`password: null`, requested role absent), so
+  the operator treats it as *not done*: the CR goes to `WaitingForDependency` with `Ready=False` / reason
+  `ProvisioningStarted` and is re-tried every 5 s until the database answers with credentials. There is no `trackingId`
+  for this endpoint, so the retry repeats the idempotent apply + get-or-create rather than polling;
 - **gating** — if it fails, the CR does **not** become `Succeeded`: a transient/5xx failure surfaces as `BackingOff` and
   is retried on the next reconcile, exactly like the `apply` call;
 - **observable** — recorded on `dbaas_aggregator_requests_total` and `dbaas_aggregator_request_duration_seconds` under

--- a/dbaas-operator/docs/howto/DBaaS Operator.md
+++ b/dbaas-operator/docs/howto/DBaaS Operator.md
@@ -1617,7 +1617,9 @@ polling `404` (expired `trackingId`).
 | POST → 5xx / network | `BackingOff` | `False` | `AggregatorError` | `False` | — |
 | POST → 200 OK (sync), materialization 200/201 or not needed | `Succeeded` | `True` | `DatabaseProvisioned` | `False` | — |
 | Apply done, tenant materialization → 202 | `WaitingForDependency` | `False` | `ProvisioningStarted` | `False` | **empty** |
-| Apply done, tenant materialization → 4xx/5xx | `BackingOff` / `InvalidConfiguration` | `False` | `AggregatorError` / `AggregatorRejected` | `False` / `True` | — |
+| Apply done, tenant materialization → 401 | `BackingOff` | `False` | `Unauthorized` | `False` | — |
+| Apply done, tenant materialization → 400 / 403 / 409 / 410 / 422 | `InvalidConfiguration` | `False` | `AggregatorRejected` | `True` | — |
+| Apply done, tenant materialization → 5xx / other 4xx / network | `BackingOff` | `False` | `AggregatorError` | `False` | — |
 | POST → 202 Accepted | `WaitingForDependency` | `False` | `ProvisioningStarted` | `False` | set |
 | Poll → IN_PROGRESS | `WaitingForDependency` | `False` | `ProvisioningStarted` | `False` | set |
 | Poll → COMPLETED | `Succeeded` | `True` | `DatabaseProvisioned` | `False` | cleared |

--- a/dbaas-operator/internal/client/aggregator_client.go
+++ b/dbaas-operator/internal/client/aggregator_client.go
@@ -246,14 +246,22 @@ func (c *AggregatorClient) RegisterExternalDatabase(ctx context.Context, namespa
 // CreateDatabase materializes (get-or-create) a logical database for the given classifier at
 // PUT /api/v3/dbaas/{namespace}/databases — the same call a microservice's dbaas client makes at
 // runtime. The operator uses it to eagerly create a concrete {scope=tenant, tenantId} database that
-// the declarative tenant InternalDatabase does not materialize on its own. The call is synchronous
-// for the postgresql-family adapters used here (the response body — the database descriptor — is not
-// needed, only the success status). Returns *AggregatorError on non-2xx.
-func (c *AggregatorClient) CreateDatabase(ctx context.Context, namespace string, req *CreateDatabaseRequest) error {
-	_, err := c.doRequest(ctx, http.MethodPut,
+// the declarative tenant InternalDatabase does not materialize on its own.
+//
+// The aggregator answers 200/201 when the database is ready and 202 Accepted when it started
+// creating it asynchronously — in that case the body carries no usable credentials (password is
+// null and the requested role is absent), so the caller must retry rather than treat the call as
+// done. pending reports that case; the response body is otherwise not needed.
+//
+// Returns *AggregatorError on any other non-2xx.
+func (c *AggregatorClient) CreateDatabase(ctx context.Context, namespace string, req *CreateDatabaseRequest) (pending bool, err error) {
+	resp, err := c.doRequest(ctx, http.MethodPut,
 		fmt.Sprintf("/api/v3/dbaas/%s/databases", namespace), req, nil,
-		http.StatusOK, http.StatusCreated)
-	return err
+		http.StatusOK, http.StatusCreated, http.StatusAccepted)
+	if err != nil {
+		return false, err
+	}
+	return resp.StatusCode() == http.StatusAccepted, nil
 }
 
 // ApplyMicroserviceBalancingRules sends on-microservice balancing rules to

--- a/dbaas-operator/internal/client/aggregator_client_test.go
+++ b/dbaas-operator/internal/client/aggregator_client_test.go
@@ -1091,3 +1091,56 @@ func TestGetOperationStatus_EmptyBodyIsZeroValue(t *testing.T) {
 		t.Errorf("expected zero-value DeclarativeResponse, got %+v", got)
 	}
 }
+
+// TestCreateDatabase_StatusHandling covers the three outcomes of the tenant-materialization call.
+// A 202 means the aggregator started creating the database asynchronously and its body carries no
+// usable credentials yet, so it must be reported as pending rather than as success or as an error —
+// treating it as an error left tenant InternalDatabases stuck in BackingOff and their
+// DatabaseSecretClaims without a Secret.
+func TestCreateDatabase_StatusHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantPending bool
+		wantErr     bool
+	}{
+		{name: "ready", status: http.StatusOK, body: `{"name":"db"}`},
+		{name: "created", status: http.StatusCreated, body: `{"name":"db"}`},
+		{
+			name:        "accepted, still provisioning",
+			status:      http.StatusAccepted,
+			body:        `{"classifier":{"scope":"tenant","tenantId":"acme"},"connectionProperties":{"password":null,"role":"admin"}}`,
+			wantPending: true,
+		},
+		{name: "rejected", status: http.StatusBadRequest, body: `{"message":"bad classifier"}`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut {
+					t.Errorf("method = %s, want PUT", r.Method)
+				}
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			pending, err := NewBasicAuthClient(srv.URL, "dbaas-operator", "s3cr3t").CreateDatabase(
+				context.Background(), "ns", &CreateDatabaseRequest{Type: "postgresql"})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if pending != tt.wantPending {
+				t.Errorf("pending = %v, want %v", pending, tt.wantPending)
+			}
+		})
+	}
+}

--- a/dbaas-operator/internal/controller/internaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller.go
@@ -176,9 +176,15 @@ func (r *InternalDatabaseReconciler) reconcileSubmit(ctx context.Context, dd *db
 
 	// HTTP 200 OK — synchronous completion.
 	log.InfoC(ctx, "database provisioned synchronously. microserviceName = %v", dd.Spec.Classifier.MicroserviceName)
-	if err := r.materializeTenantDatabaseIfPinned(ctx, dd); err != nil {
+	pending, err := r.materializeTenantDatabaseIfPinned(ctx, dd)
+	if err != nil {
 		log.ErrorC(ctx, "failed to materialize pinned tenant database: %v", err)
 		return handleAggregatorError(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, r.Recorder, dd, err, requestID)
+	}
+	if pending {
+		log.InfoC(ctx, "tenant database creation accepted, not ready yet; will retry")
+		markTenantMaterializationPending(dd)
+		return ctrl.Result{RequeueAfter: pollRequeueAfter}, nil
 	}
 	markSucceeded(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, EventReasonDatabaseProvisioned)
 	r.Recorder.Eventf(dd, corev1.EventTypeNormal, EventReasonDatabaseProvisioned,
@@ -232,9 +238,9 @@ func (r *InternalDatabaseReconciler) buildPayload(dd *dbaasv1.InternalDatabase) 
 // read-only get-by-classifier and waits forever (DatabaseNotFound). Calling the get-or-create database
 // API materializes the database exactly as the first runtime tenant connection would, after which the
 // claim resolves. No-op for service scope or a tenant declaration without a pinned tenantId.
-func (r *InternalDatabaseReconciler) materializeTenantDatabaseIfPinned(ctx context.Context, dd *dbaasv1.InternalDatabase) error {
+func (r *InternalDatabaseReconciler) materializeTenantDatabaseIfPinned(ctx context.Context, dd *dbaasv1.InternalDatabase) (bool, error) {
 	if !strings.EqualFold(dd.Spec.Classifier.Scope, "tenant") || dd.Spec.Classifier.TenantID == "" {
-		return nil
+		return false, nil
 	}
 	req := &aggregatorclient.CreateDatabaseRequest{
 		Classifier:    dbaasv1.ClassifierFlatMap(dbaasv1.EffectiveClassifier(dd.Spec.Classifier, dd.Namespace)),
@@ -244,9 +250,22 @@ func (r *InternalDatabaseReconciler) materializeTenantDatabaseIfPinned(ctx conte
 	log.InfoC(ctx, "materializing pinned tenant database tenantId=%v microserviceName=%v",
 		dd.Spec.Classifier.TenantID, dd.Spec.Classifier.MicroserviceName)
 	start := time.Now()
-	err := r.Aggregator.CreateDatabase(ctx, dd.Namespace, req)
+	pending, err := r.Aggregator.CreateDatabase(ctx, dd.Namespace, req)
 	recordAggregatorCall(controllerIDB, operationCreateDatabase, start, err)
-	return err
+	return pending, err
+}
+
+// markTenantMaterializationPending records that the aggregator accepted the tenant database
+// creation but has not finished it (HTTP 202). There is no trackingId to poll — that endpoint
+// returns none — so the CR stays on the submit path and the next reconcile simply repeats the
+// idempotent apply + get-or-create until the database answers with credentials.
+func markTenantMaterializationPending(dd *dbaasv1.InternalDatabase) {
+	dd.Status.Phase = dbaasv1.PhaseWaitingForDependency
+	setCondition(&dd.Status.Conditions, dd.Generation,
+		conditionTypeReady, metav1.ConditionFalse, EventReasonProvisioningStarted,
+		"tenant database creation accepted; waiting for it to become available")
+	setCondition(&dd.Status.Conditions, dd.Generation,
+		conditionTypeStalled, metav1.ConditionFalse, EventReasonProvisioningStarted, stalledMsgTransient)
 }
 
 // toWireSpec converts a InternalDatabaseSpec (CRD shape) into the wire format
@@ -481,9 +500,15 @@ func (r *InternalDatabaseReconciler) handlePollResponse(
 			trackingID, dd.Spec.Classifier.MicroserviceName)
 		clearPendingOperation(dd)
 		r.observeAsyncCompletion(dd, resultSuccess)
-		if err := r.materializeTenantDatabaseIfPinned(ctx, dd); err != nil {
+		pending, err := r.materializeTenantDatabaseIfPinned(ctx, dd)
+		if err != nil {
 			log.ErrorC(ctx, "failed to materialize pinned tenant database: %v", err)
 			return handleAggregatorError(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, r.Recorder, dd, err, requestID)
+		}
+		if pending {
+			log.InfoC(ctx, "tenant database creation accepted, not ready yet; will retry")
+			markTenantMaterializationPending(dd)
+			return ctrl.Result{RequeueAfter: pollRequeueAfter}, nil
 		}
 		markSucceeded(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation, EventReasonDatabaseProvisioned)
 		r.Recorder.Eventf(dd, corev1.EventTypeNormal, EventReasonDatabaseProvisioned,

--- a/dbaas-operator/internal/controller/internaldatabase_controller_test.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller_test.go
@@ -463,6 +463,90 @@ var _ = Describe("InternalDatabase Controller", func() {
 		})
 	})
 
+	Context("scope=tenant with a pinned tenantId — materialization returns 202", func() {
+		// The aggregator answers 202 while it is still creating the database, and the body
+		// carries no usable credentials. That is not an error: the CR must wait rather than
+		// go BackingOff, otherwise its DatabaseSecretClaims never get connection properties.
+
+		It("waits instead of failing, keeps trackingId empty, and retries on the next reconcile (synchronous apply)", func() {
+			createCode = http.StatusAccepted
+
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       tenantSpec("acme"),
+			})).To(Succeed())
+
+			dd, result, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred(), "202 must not surface as a reconcile error")
+			Expect(result.RequeueAfter).To(Equal(pollRequeueAfter))
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseWaitingForDependency))
+			Expect(dd.Status.TrackingID).To(BeEmpty(), "this endpoint returns no trackingId to poll")
+
+			ready := findCondition(dd.Status.Conditions, conditionTypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			Expect(ready.Reason).To(Equal(EventReasonProvisioningStarted))
+			stalled := findCondition(dd.Status.Conditions, conditionTypeStalled)
+			Expect(stalled).NotTo(BeNil())
+			Expect(stalled.Status).To(Equal(metav1.ConditionFalse), "waiting is not a permanent failure")
+
+			// Without a trackingId the retry repeats the whole submit path.
+			applyCountBefore := createReqCount
+			_, _, err = reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createReqCount).To(Equal(applyCountBefore+1), "get-or-create must be retried")
+			Expect(capturedApplyBody).NotTo(BeEmpty(), "the idempotent apply is repeated too")
+
+			// Once the database is ready the CR converges.
+			createCode = http.StatusOK
+			dd, result, err = reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
+		})
+
+		It("waits the same way when the apply completed asynchronously", func() {
+			applyCode = http.StatusAccepted
+			applyBody = `{"trackingId":"track-202"}`
+			createCode = http.StatusAccepted
+
+			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: ns},
+				Spec:       tenantSpec("acme"),
+			})).To(Succeed())
+
+			// First reconcile: async apply accepted, tracking stored, nothing materialized yet.
+			dd, _, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dd.Status.TrackingID).To(Equal("track-202"))
+			Expect(createReqCount).To(Equal(0))
+
+			// Second reconcile: the operation reports COMPLETED, materialization answers 202.
+			pollCode = http.StatusOK
+			pollBody = statusCompleted
+			dd, result, err := reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(pollRequeueAfter))
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseWaitingForDependency))
+			Expect(dd.Status.TrackingID).To(BeEmpty(), "the completed operation's tracking is cleared")
+			Expect(createReqCount).To(Equal(1))
+
+			ready := findCondition(dd.Status.Conditions, conditionTypeReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Reason).To(Equal(EventReasonProvisioningStarted))
+
+			// The retry goes through the submit path again and converges once ready.
+			createCode = http.StatusOK
+			applyCode = http.StatusOK
+			applyBody = statusCompleted
+			dd, result, err = reconcileAndFetch()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
+			Expect(createReqCount).To(Equal(2))
+		})
+	})
+
 	Context("scope=tenant with a pinned tenantId — materialization fails", func() {
 		It("does not mark Succeeded and requeues with an error", func() {
 			createCode = http.StatusInternalServerError


### PR DESCRIPTION
## Why

The nightly [Sample Services Integration Tests run 30418501132](https://github.com/Netcracker/qubership-dbaas/actions/runs/30418501132) failed at *Pass A — wait for sample services*: the Spring pod never started because kubelet could not mount its tenant Secrets (`FailedMount: secret ... not found`).

Tracing it back:

1. Both Spring **tenant** `DatabaseSecretClaim`s sat in `BackingOff` with *Database does not contain connection properties for specified role: admin*.
2. Their `InternalDatabase` (`spring-test-app-service-postgres-tenant`) was also `BackingOff`, with the aggregator's reply in the message: `"connectionProperties":{"password":null,"role":"admin"}`.
3. The operator log shows why: `failed to materialize pinned tenant database: dbaas-aggregator returned HTTP 202`.

`PUT /api/v3/dbaas/{ns}/databases` answers **202 Accepted** when the aggregator starts creating the database asynchronously — the body then has no usable credentials yet. `CreateDatabase` accepted only `200`/`201`, so a legitimate 202 became an `AggregatorError`, which gated the CR out of `Succeeded`, which starved the claims, which left the pod without Secrets.

**It does not self-heal.** The log has eight attempts over two minutes on exponential backoff (03:13:39 → 03:15:46) and *zero* successful materializations — all 16 recorded 202s belong to the one Spring tenant classifier. The other two apps hit already-existing databases and got 200, which is why this looks like a flake: whichever app happens to trigger the actual creation is the one that breaks. Re-running the job passed for exactly that reason — the database created by the first attempt was already there.

For contrast, the neighbouring `ApplyConfig` already handles this correctly (`http.StatusOK, http.StatusAccepted`).

## What

- `CreateDatabase` accepts `202` and returns `pending bool` alongside the error.
- Both call sites of `materializeTenantDatabaseIfPinned` (the synchronous `200 OK` path and the async `COMPLETED` poll path) now distinguish *failed* from *not ready yet*: on `pending` the CR is marked `WaitingForDependency` with `Ready=False` / reason `ProvisioningStarted` and requeued after 5 s, instead of being pushed into `AggregatorError` + exponential backoff.
- That endpoint returns no `trackingId`, so the retry repeats the idempotent apply + get-or-create rather than polling an operation. This is stated in the new `markTenantMaterializationPending` doc comment.
- Docs: the endpoint table and the *Tenant Database Materialization* section now describe the 202 case.

## How to verify

- New table test `TestCreateDatabase_StatusHandling` covers 200, 201, 202 (pending, no error) and 400 (error).
- `make test` is green: client 93.6% coverage, controller suite 79.7%, all packages pass.
- End to end: the failure reproduces only on a cold cluster where the tenant database does not exist yet, which is exactly what the nightly sample-service run does — the next scheduled run is the real check.