### PR TITLE
test(operator): reproduce asynchronous tenant materialization (202) in the dev mock

### DIFF
--- a/dbaas-operator/dev/README.md
+++ b/dbaas-operator/dev/README.md
@@ -66,6 +66,14 @@ The script runs these steps in order:
 6. `kubectl apply` — creates namespace `test-ns`, its `NamespaceBinding`, the namespaced Secret **`Role`+`RoleBinding`** (`secret-rbac.yaml`), and secret `pg-credentials`
 7. Waits for `rollout status` on both deployments
 
+Re-running the script on an existing cluster rebuilds and reloads the images, but both
+Deployments keep their `:dev` tag, so Kubernetes sees no change and the pods keep running the
+previous build. Restart them to pick up the new images:
+
+```bash
+kubectl rollout restart deployment/dbaas-operator deployment/dbaas-aggregator -n dbaas-system
+```
+
 ## Test scenarios
 
 **Namespace ownership** is now declared through `NamespaceBinding` rather than a
@@ -184,6 +192,21 @@ a matching `DatabaseSecretClaim` would wait forever). The mock answers the get-o
 from `create-db-rules.json` (keyed by `originService`); missing rule → 200. See
 `idb-tenant-materialize.yaml`.
 
+An aggregator that creates the database **asynchronously** answers the same call with
+`202 Accepted`. Reproduce it with a `pendingCalls` budget on the rule:
+
+```json
+{ "tenant-svc-202": { "httpCode": 200, "pendingCalls": 3 } }
+```
+
+The first three get-or-create calls then answer `202 Accepted` with no usable credentials
+(`id`, `name` and `connectionProperties.password` are null), and the database stays invisible
+to get-by-classifier until the fourth call creates it. The operator reports
+`WaitingForDependency` with an **empty** `status.trackingId` and repeats the call until the
+database answers. Before that path was handled the same response left the `InternalDatabase`
+in `BackingOff` and the consuming pod on `FailedMount`. See `idb-tenant-materialize-202.yaml`
+and `dev/e2e-tenant-materialize-202.sh`.
+
 Expected output (`kubectl get internaldatabase -n test-ns`):
 
 ```
@@ -192,6 +215,7 @@ idb-success-sync         Succeeded              postgresql
 idb-success-async        Succeeded              postgresql
 idb-custom-keys          Succeeded              postgresql
 idb-tenant-materialize   Succeeded              postgresql
+idb-tenant-materialize-202  Succeeded           postgresql
 idb-400-bad-request      InvalidConfiguration   postgresql
 idb-401-unauthorized     BackingOff             postgresql
 idb-500-server-error     BackingOff             postgresql
@@ -207,6 +231,7 @@ idb-invalid-no-source    InvalidConfiguration   postgresql
 | `idb-success-async.yaml` | `idb-svc-async` | 202 (default) | `COMPLETED` (default) | `Succeeded` | `DatabaseProvisioned` | `False` |
 | `idb-custom-keys.yaml` | `idb-svc-custom-keys` | 202 (default) | `COMPLETED` (default) | `Succeeded` | `DatabaseProvisioned` | `False` |
 | `idb-tenant-materialize.yaml` | `idb-tenant` | 202 (default) | `COMPLETED` (default) + get-or-create 200 | `Succeeded` | `DatabaseProvisioned` | `False` |
+| `idb-tenant-materialize-202.yaml` | `tenant-svc-202` | 202 (default) | `COMPLETED` (default) + get-or-create 202 ×3, then 200 | `WaitingForDependency` while pending, then `Succeeded` | `ProvisioningStarted`, then `DatabaseProvisioned` | `False` |
 | `idb-400-bad-request.yaml` | `idb-svc-400` | 400 (rule) | — | `InvalidConfiguration` | `AggregatorRejected` | `True` |
 | `idb-401-unauthorized.yaml` | `idb-svc-401` | 401 (rule) | — | `BackingOff` | `Unauthorized` | `False` |
 | `idb-500-server-error.yaml` | `idb-svc-500` | 500 (rule) | — | `BackingOff` | `AggregatorError` | `False` |
@@ -340,6 +365,33 @@ It asserts:
 Restart the mock (`kubectl rollout restart deployment/dbaas-aggregator -n dbaas-system`) to
 clear the in-memory store, then apply the claim alone — it backs off on `DatabaseNotFound`
 until the `InternalDatabase` materializes its database. Pass `KEEP=1` to keep the CRs and Secret.
+
+#### asynchronous tenant materialization (`dev/e2e-tenant-materialize-202.sh`)
+
+The aggregator may answer the get-or-create with `202 Accepted` instead of creating the database
+on the spot: the response carries no credentials, and the database is not resolvable yet. The
+`tenant-svc-202` rule reproduces it with a `pendingCalls` budget of 3, so the operator has to
+retry the call three times before the database exists:
+
+```bash
+./dev/kind-up.sh                     # if not already up
+./dev/e2e-tenant-materialize-202.sh
+```
+
+It applies `idb-tenant-materialize-202.yaml` and `dsc-tenant-materialize-202.yaml` together —
+the pairing a service uses in production — and asserts:
+
+1. while the mock answers 202, the `InternalDatabase` reports `WaitingForDependency` with
+   `Ready=False/ProvisioningStarted`, `Stalled=False` and an **empty** `status.trackingId` (an
+   empty trackingId is what tells this wait apart from the async-provisioning wait), and the
+   claim's Secret does not exist yet;
+2. once the budget is spent, the `InternalDatabase` reaches `Succeeded`, the mock logs at least
+   two 202 answers (the operator did retry), the claim reaches `Succeeded` and its Secret
+   carries the tenant identity (`scope=tenant`, `tenantId=acme-202`).
+
+Before the operator accepted 202, step 1 ended in `BackingOff` and step 2 never happened. The
+pending budget lives in the mock process, so the script restarts the mock to keep repeated runs
+deterministic. Pass `KEEP=1` to keep the CRs and Secret.
 
 ### Changing rules without rebuilding
 

--- a/dbaas-operator/dev/aggregator-mock/main.go
+++ b/dbaas-operator/dev/aggregator-mock/main.go
@@ -60,7 +60,9 @@ limitations under the License.
 //	                      it to materialize the concrete {scope=tenant, tenantId} database
 //	                      for a tenant declaration that pins a tenantId
 //	                      (default: /config/create-db-rules.json). Missing = not an error;
-//	                      no rule → 200 with a synthetic database descriptor.
+//	                      no rule → 200 with a synthetic database descriptor. A rule may set
+//	                      "pendingCalls": N to answer 202 Accepted the first N times, which
+//	                      reproduces the aggregator creating the database asynchronously.
 package main
 
 import (
@@ -93,6 +95,37 @@ type MockRule struct {
 	TmfCode  string `json:"tmfCode,omitempty"` // e.g. "CORE-DBAAS-4010"
 	Reason   string `json:"reason,omitempty"`
 	Message  string `json:"message,omitempty"`
+	// PendingCalls makes the get-or-create endpoint answer 202 Accepted that many times
+	// before creating the database for real. It reproduces the aggregator's asynchronous
+	// creation: the 202 body carries no usable credentials, so a client must retry.
+	PendingCalls int `json:"pendingCalls,omitempty"`
+}
+
+// pendingCounter tracks how many 202 answers are still owed per rule key.
+type pendingCounter struct {
+	mu   sync.Mutex
+	left map[string]int
+}
+
+func newPendingCounter(rules map[string]MockRule) *pendingCounter {
+	left := make(map[string]int, len(rules))
+	for k, r := range rules {
+		if r.PendingCalls > 0 {
+			left[k] = r.PendingCalls
+		}
+	}
+	return &pendingCounter{left: left}
+}
+
+// consume reports whether this call must still answer 202, decrementing the counter.
+func (p *pendingCounter) consume(key string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.left[key] <= 0 {
+		return false
+	}
+	p.left[key]--
+	return true
 }
 
 // MockPollRule describes the poll response for a specific trackingId.
@@ -329,6 +362,7 @@ func handler(
 	// store records databases materialized via PUT .../databases so get-by-classifier
 	// can emulate the real aggregator's lazy-tenant 404 before materialization.
 	store := newDBStore()
+	pending := newPendingCounter(createDbRules)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		body := logRequest(r)
 
@@ -353,7 +387,7 @@ func handler(
 			handleGetByClassifier(w, r, body, gbcRules, store)
 
 		case reCreateDB.MatchString(r.URL.Path) && r.Method == http.MethodPut:
-			handleCreateDatabase(w, r, body, createDbRules, store)
+			handleCreateDatabase(w, r, body, createDbRules, store, pending)
 
 		case reMicroserviceBalancingRule.MatchString(r.URL.Path) && r.Method == http.MethodPut:
 			handleMicroserviceBalancingRule(w, r)
@@ -739,7 +773,7 @@ func defaultConnProps(role string) map[string]any {
 // inspects only the status code, so a minimal descriptor is enough.
 func handleCreateDatabase(
 	w http.ResponseWriter, r *http.Request, body []byte,
-	createDbRules map[string]MockRule, store *dbStore,
+	createDbRules map[string]MockRule, store *dbStore, pending *pendingCounter,
 ) {
 	m := reCreateDB.FindStringSubmatch(r.URL.Path)
 	namespace := m[1]
@@ -756,6 +790,15 @@ func handleCreateDatabase(
 		key, _ = req.Classifier["microserviceName"].(string)
 	}
 	tenantID, _ := req.Classifier["tenantId"].(string)
+
+	if pending != nil && pending.consume(key) {
+		log.Printf("  → create database originService=%q tenantId=%q namespace=%q → 202 (still creating)",
+			key, tenantID, namespace)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		writeAcceptedDatabase(w, namespace, req.Type, req.Classifier)
+		return
+	}
 
 	if rule, ok := createDbRules[key]; ok {
 		log.Printf("  → create database originService=%q tenantId=%q namespace=%q → httpCode=%d (rule)",
@@ -793,6 +836,23 @@ func writeCreatedDatabase(w http.ResponseWriter, namespace, dbType, originServic
 		"namespace":            namespace,
 		"type":                 dbType,
 		"connectionProperties": defaultConnProps("admin"),
+	})
+}
+
+// writeAcceptedDatabase writes the body the aggregator returns with 202 Accepted: the database
+// is still being created, so it has no id, no name, and connectionProperties carry the requested
+// role with a null password. A client that mistakes this for success ends up with no credentials.
+func writeAcceptedDatabase(w http.ResponseWriter, namespace, dbType string, classifier map[string]any) {
+	writeJSON(w, map[string]any{
+		"id":         nil,
+		"name":       nil,
+		"classifier": classifier,
+		"namespace":  namespace,
+		"type":       dbType,
+		"connectionProperties": map[string]any{
+			"password": nil,
+			"role":     "admin",
+		},
 	})
 }
 

--- a/dbaas-operator/dev/aggregator-mock/main_test.go
+++ b/dbaas-operator/dev/aggregator-mock/main_test.go
@@ -218,3 +218,99 @@ func TestGetByClassifier_ServiceNoMaterializationNeeded(t *testing.T) {
 		t.Fatalf("service get-by-classifier: want 200 (no materialization needed), got %d", w.Code)
 	}
 }
+
+// TestCreateDatabase_PendingCalls_Returns202ThenCreates reproduces the aggregator's asynchronous
+// creation, which broke tenant materialization before the operator learned to handle it: the first
+// get-or-create answers 202 with no usable credentials, and only a later call returns the database.
+// A client that treats the 202 as either success or failure never gets credentials.
+func TestCreateDatabase_PendingCalls_Returns202ThenCreates(t *testing.T) {
+	rules := map[string]MockRule{"slow-svc": {HTTPCode: http.StatusOK, PendingCalls: 2}}
+	h := newTestHandler(http.StatusOK, rules)
+	body := tenantCreateBody(t, "slow-svc", "acme")
+	const path = "/api/v3/dbaas/test-ns/databases"
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		w := doReq(t, h, http.MethodPut, path, body, true)
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("attempt %d: want 202, got %d (%s)", attempt, w.Code, w.Body.String())
+		}
+
+		var resp struct {
+			ID                   any `json:"id"`
+			Name                 any `json:"name"`
+			ConnectionProperties struct {
+				Password any    `json:"password"`
+				Role     string `json:"role"`
+			} `json:"connectionProperties"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("attempt %d: decode body: %v", attempt, err)
+		}
+		if resp.ID != nil || resp.Name != nil {
+			t.Errorf("attempt %d: a database being created has no id/name, got id=%v name=%v",
+				attempt, resp.ID, resp.Name)
+		}
+		if resp.ConnectionProperties.Password != nil {
+			t.Errorf("attempt %d: 202 must not carry a password, got %v",
+				attempt, resp.ConnectionProperties.Password)
+		}
+		if resp.ConnectionProperties.Role != "admin" {
+			t.Errorf("attempt %d: role: want admin, got %q", attempt, resp.ConnectionProperties.Role)
+		}
+	}
+
+	// The third call is past the pending budget: the database is created for real.
+	w := doReq(t, h, http.MethodPut, path, body, true)
+	if w.Code != http.StatusOK {
+		t.Fatalf("third attempt: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var created struct {
+		Name                 string `json:"name"`
+		ConnectionProperties struct {
+			Password string `json:"password"`
+		} `json:"connectionProperties"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created body: %v", err)
+	}
+	if created.ConnectionProperties.Password == "" {
+		t.Error("the created database must carry a password")
+	}
+	if !strings.Contains(created.Name, "acme") {
+		t.Errorf("expected tenantId in db name, got %q", created.Name)
+	}
+}
+
+// TestCreateDatabase_PendingCalls_NotVisibleUntilCreated asserts that a database still being
+// created is not resolvable through get-by-classifier — the state a DatabaseSecretClaim sees while
+// the operator waits on the 202.
+func TestCreateDatabase_PendingCalls_NotVisibleUntilCreated(t *testing.T) {
+	rules := map[string]MockRule{"slow-svc": {HTTPCode: http.StatusOK, PendingCalls: 1}}
+	h := newTestHandler(http.StatusOK, rules)
+	classifier := map[string]any{
+		"microserviceName": "slow-svc",
+		"scope":            "tenant",
+		"namespace":        "test-ns",
+		"tenantId":         "acme",
+	}
+
+	w := doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases",
+		tenantCreateBody(t, "slow-svc", "acme"), true)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", w.Code)
+	}
+
+	w = doReq(t, h, http.MethodPost, gbcPath, gbcReqBody(t, classifier, "slow-svc"), true)
+	if w.Code == http.StatusOK {
+		t.Fatalf("a database that is still being created must not resolve, got 200: %s", w.Body.String())
+	}
+
+	// After the creation completes it resolves normally.
+	if w = doReq(t, h, http.MethodPut, "/api/v3/dbaas/test-ns/databases",
+		tenantCreateBody(t, "slow-svc", "acme"), true); w.Code != http.StatusOK {
+		t.Fatalf("second create: want 200, got %d", w.Code)
+	}
+	if w = doReq(t, h, http.MethodPost, gbcPath, gbcReqBody(t, classifier, "slow-svc"), true); w.Code != http.StatusOK {
+		t.Fatalf("after creation get-by-classifier must return 200, got %d (%s)", w.Code, w.Body.String())
+	}
+}

--- a/dbaas-operator/dev/e2e-tenant-materialize-202.sh
+++ b/dbaas-operator/dev/e2e-tenant-materialize-202.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# e2e-tenant-materialize-202.sh — end-to-end check that a tenant-scoped InternalDatabase
+# survives an ASYNCHRONOUS tenant database creation: the aggregator answers the get-or-create
+# with 202 Accepted (no credentials yet) for a while, and the operator has to keep retrying
+# until the database answers for real.
+#
+# Prerequisite: the dev environment is up (./dev/kind-up.sh).
+#
+# Flow (against the aggregator-mock, rule originService=tenant-svc-202 → pendingCalls=3):
+#   1. Apply idb-tenant-materialize-202.yaml + dsc-tenant-materialize-202.yaml together —
+#      the same shape a service uses in production: a tenant declaration plus a claim that
+#      turns it into a Secret.
+#   2. While the mock answers 202, the InternalDatabase must report Phase=WaitingForDependency
+#      with Ready=False/ProvisioningStarted, Stalled=False and an EMPTY status.trackingId
+#      (an empty trackingId is what tells this wait apart from the async-provisioning wait).
+#      The database is not recorded yet, so the claim's Secret must NOT exist.
+#   3. After the pending budget is spent the mock creates the database (200); the
+#      InternalDatabase reaches Succeeded and the claim writes the Secret.
+#
+# Before the operator accepted 202 (PR #624) step 2 ended in Phase=BackingOff and step 3 never
+# happened: the Secret stayed missing and the consuming pod hung on FailedMount.
+#
+# Usage:
+#   ./dev/kind-up.sh
+#   ./dev/e2e-tenant-materialize-202.sh
+#
+# The mock's pending budget is per-process, so the script restarts the mock to make repeated
+# runs deterministic. Override the kept-resource cleanup with KEEP=1.
+set -euo pipefail
+
+NS="test-ns"
+IDB="idb-tenant-materialize-202"
+DSC="dsc-tenant-materialize-202"
+SECRET="dsc-tenant-materialize-202-secret"
+TENANT="acme-202"
+MOCK_DEPLOY="deployment/dbaas-aggregator"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗ %s\033[0m\n' "$1"; exit 1; }
+info() { printf '\033[1m%s\033[0m\n' "$1"; }
+
+for bin in kubectl jq base64; do
+  command -v "$bin" >/dev/null 2>&1 || fail "required tool not found: $bin"
+done
+
+cleanup_crs() {
+  kubectl delete -f "$SCRIPT_DIR/test-resources/dsc-tenant-materialize-202.yaml" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete -f "$SCRIPT_DIR/test-resources/idb-tenant-materialize-202.yaml" --ignore-not-found >/dev/null 2>&1 || true
+  kubectl delete "secret/$SECRET" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+}
+
+info "0. Preconditions"
+kubectl get ns "$NS" >/dev/null 2>&1 || fail "namespace $NS not found — run ./dev/kind-up.sh first"
+kubectl -n dbaas-system get deploy/dbaas-operator >/dev/null 2>&1 \
+  || fail "dbaas-operator not deployed — run ./dev/kind-up.sh first"
+kubectl -n dbaas-system get cm/aggregator-mock-rules -o jsonpath='{.data.create-db-rules\.json}' \
+  | jq -e '."tenant-svc-202".pendingCalls > 0' >/dev/null 2>&1 \
+  || fail "mock rule tenant-svc-202 has no pendingCalls budget — re-apply dev/k8s/mock-aggregator.yaml"
+pass "kind dev environment is up, mock has the pendingCalls rule"
+
+# The pending budget lives in the mock process; restart it so a re-run starts from a clean count.
+cleanup_crs
+kubectl -n dbaas-system rollout restart "$MOCK_DEPLOY" >/dev/null
+kubectl -n dbaas-system rollout status "$MOCK_DEPLOY" --timeout=120s >/dev/null
+pass "aggregator-mock restarted (pending budget reset)"
+
+info "1. Apply the tenant InternalDatabase and its claim (tenantId=$TENANT)"
+kubectl apply -f "$SCRIPT_DIR/test-resources/idb-tenant-materialize-202.yaml" >/dev/null
+kubectl apply -f "$SCRIPT_DIR/test-resources/dsc-tenant-materialize-202.yaml" >/dev/null
+pass "CRs applied"
+
+info "2. While the aggregator is still creating the database"
+# Sample the whole status at once: the CR also passes through WaitingForDependency for the
+# declarative apply, but that wait carries a trackingId — this one must not.
+snapshot=""
+deadline=$((SECONDS + 90))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  json="$(kubectl get "internaldatabase/$IDB" -n "$NS" -o json 2>/dev/null || true)"
+  if [ -n "$json" ] && echo "$json" | jq -e '
+        .status.phase == "WaitingForDependency"
+        and ((.status.trackingId // "") == "")
+        and ((.status.conditions // []) | any(.type == "Ready"   and .status == "False" and .reason == "ProvisioningStarted"))
+        and ((.status.conditions // []) | any(.type == "Stalled" and .status == "False"))' >/dev/null 2>&1; then
+    snapshot="$json"
+    break
+  fi
+  sleep 1
+done
+if [ -z "$snapshot" ]; then
+  phase=$(kubectl get "internaldatabase/$IDB" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "?")
+  fail "InternalDatabase never reported the materialization wait (last phase=$phase)"
+fi
+pass "InternalDatabase: Phase=WaitingForDependency, Ready=False/ProvisioningStarted, Stalled=False"
+pass "status.trackingId is empty — the wait is the materialization one, not the async provisioning one"
+
+if kubectl logs -n dbaas-system "$MOCK_DEPLOY" 2>/dev/null | grep -q "202 (still creating)"; then
+  pass "mock answered the get-or-create with 202 Accepted"
+else
+  fail "mock never logged a 202 for the get-or-create — the scenario did not exercise the pending path"
+fi
+
+if kubectl get "secret/$SECRET" -n "$NS" >/dev/null 2>&1; then
+  fail "Secret $SECRET exists while the database is still being created"
+fi
+pass "Secret $SECRET absent — the claim is still waiting (the production symptom: FailedMount)"
+
+info "3. Convergence once the database is created for real"
+if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
+    "internaldatabase/$IDB" -n "$NS" --timeout=120s >/dev/null 2>&1; then
+  pass "InternalDatabase reached Phase=Succeeded"
+else
+  phase=$(kubectl get "internaldatabase/$IDB" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "?")
+  fail "InternalDatabase did not converge (phase=$phase) — the operator gave up on the 202 path"
+fi
+
+pending_count=$(kubectl logs -n dbaas-system "$MOCK_DEPLOY" 2>/dev/null | grep -c "202 (still creating)" || true)
+echo "    mock answered 202 $pending_count time(s) before creating the database"
+[ "$pending_count" -ge 2 ] || fail "expected the operator to retry the get-or-create at least twice"
+pass "operator retried the get-or-create until it succeeded"
+
+if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
+    "databasesecretclaim/$DSC" -n "$NS" --timeout=120s >/dev/null 2>&1; then
+  pass "DatabaseSecretClaim reached Phase=Succeeded"
+else
+  phase=$(kubectl get "databasesecretclaim/$DSC" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "?")
+  fail "DatabaseSecretClaim did not reach Succeeded (phase=$phase)"
+fi
+
+kubectl get "secret/$SECRET" -n "$NS" >/dev/null 2>&1 || fail "Secret $SECRET was not created"
+meta="$(kubectl get "secret/$SECRET" -n "$NS" -o jsonpath='{.data.metadata\.json}' | base64 -d)"
+echo "    metadata.json .classifier = $(echo "$meta" | jq -c '.classifier')"
+echo "$meta" | jq -e ".classifier.scope == \"tenant\" and .classifier.tenantId == \"$TENANT\" and .classifier.microserviceName == \"tenant-svc-202\"" >/dev/null \
+  || fail "Secret descriptor classifier is not the expected tenant identity"
+pass "Secret carries the tenant classifier (scope=tenant, tenantId=$TENANT)"
+
+info "RESULT: PASS — the operator waited out an asynchronous tenant database creation and converged"
+
+if [ "${KEEP:-0}" != "1" ]; then
+  cleanup_crs
+fi

--- a/dbaas-operator/dev/k8s/mock-aggregator.yaml
+++ b/dbaas-operator/dev/k8s/mock-aggregator.yaml
@@ -157,7 +157,8 @@ data:
   # Per-originService response rules for the get-or-create database call
   # PUT /api/v3/dbaas/{ns}/databases — the operator's pinned-tenant materialization
   # for a tenant InternalDatabase. Falls back to 200 (success) when no rule matches;
-  # the rule below is illustrative, to simulate a materialization failure on demand.
+  # the rules below are illustrative: one simulates a materialization failure, the other
+  # an asynchronous creation (202 Accepted, no credentials yet) for the first N calls.
   create-db-rules.json: |
     {
       "tenant-svc-500": {
@@ -165,6 +166,10 @@ data:
         "tmfCode": "CORE-DBAAS-2000",
         "reason": "Unexpected exception",
         "message": "Unexpected exception"
+      },
+      "tenant-svc-202": {
+        "httpCode": 200,
+        "pendingCalls": 3
       }
     }
 ---

--- a/dbaas-operator/dev/test-resources/dsc-tenant-materialize-202.yaml
+++ b/dbaas-operator/dev/test-resources/dsc-tenant-materialize-202.yaml
@@ -1,0 +1,28 @@
+# DatabaseSecretClaim — tenant scope; consumes the database that
+# idb-tenant-materialize-202.yaml materializes asynchronously.
+#
+# The claim's classifier matches idb-tenant-materialize-202's:
+#   {microserviceName: tenant-svc-202, scope: tenant, tenantId: acme-202, namespace: test-ns}.
+# While the mock is still answering 202 the database is NOT recorded, so get-by-classifier
+# answers 404 and the claim waits. Once the InternalDatabase reaches Succeeded the database
+# exists and the operator writes the Secret "dsc-tenant-materialize-202-secret" — this is the
+# step that used to be blocked forever, leaving pods on FailedMount.
+#
+# The app.kubernetes.io/name label is REQUIRED — its value is sent as originService.
+# See dev/e2e-tenant-materialize-202.sh for the end-to-end check.
+apiVersion: dbaas.netcracker.com/v1
+kind: DatabaseSecretClaim
+metadata:
+  name: dsc-tenant-materialize-202
+  namespace: test-ns
+  labels:
+    app.kubernetes.io/name: tenant-svc-202
+spec:
+  type: postgresql
+  userRole: admin
+  secretName: dsc-tenant-materialize-202-secret
+  classifier:
+    microserviceName: tenant-svc-202
+    scope: tenant
+    tenantId: acme-202
+    namespace: test-ns

--- a/dbaas-operator/dev/test-resources/idb-tenant-materialize-202.yaml
+++ b/dbaas-operator/dev/test-resources/idb-tenant-materialize-202.yaml
@@ -1,0 +1,21 @@
+# InternalDatabase — tenant scope with a pinned tenantId, materialized ASYNCHRONOUSLY.
+#
+# The mock rule for originService=tenant-svc-202 carries "pendingCalls": 3, so the first
+# three get-or-create calls (PUT /api/v3/dbaas/{ns}/databases) answer 202 Accepted with no
+# usable credentials and the database stays invisible to get-by-classifier. The fourth call
+# creates it for real (200).
+#
+# Expected: Phase=WaitingForDependency while the aggregator is still creating the database
+# (Ready=False/ProvisioningStarted, Stalled=False, empty status.trackingId), then Succeeded
+# once the database answers. See dev/e2e-tenant-materialize-202.sh.
+apiVersion: dbaas.netcracker.com/v1
+kind: InternalDatabase
+metadata:
+  name: idb-tenant-materialize-202
+  namespace: test-ns
+spec:
+  classifier:
+      microserviceName: tenant-svc-202
+      scope: tenant
+      tenantId: acme-202
+  type: postgresql


### PR DESCRIPTION
## Why

The aggregator may answer the tenant get-or-create (`PUT /api/v3/dbaas/{ns}/databases`) with
`202 Accepted` instead of creating the database on the spot: the response carries no credentials
and the database is not resolvable yet. #624 fixed the operator side of that path after a nightly
sample-service failure, but the path itself stayed unreachable on demand — three targeted CI runs
produced 12 synchronous materializations and never hit it. The kind dev environment could not
reproduce it either, so the behavior had no manual reproduction and no regression net outside the
controller unit tests.

## What

- `dev/aggregator-mock`: `create-db-rules.json` rules take a `pendingCalls` budget. The first N
  get-or-create calls answer `202 Accepted` with `id`, `name` and `connectionProperties.password`
  set to null, and deliberately do **not** record the database, so get-by-classifier keeps
  answering 404 until the budget is spent. Two unit tests cover the sequence and the invisibility.
- `dev/k8s/mock-aggregator.yaml`: rule `tenant-svc-202` with `pendingCalls: 3`.
- `dev/test-resources/idb-tenant-materialize-202.yaml` + `dsc-tenant-materialize-202.yaml`: the
  pairing a service uses in production — a tenant declaration plus the claim that turns it into a
  Secret.
- `dev/e2e-tenant-materialize-202.sh`: end-to-end check of both phases (details below).
- `dev/README.md`: the `pendingCalls` rule, a scenario table row, the e2e section, and a note that
  re-running `kind-up.sh` reloads the images but leaves the pods on the previous build (the `:dev`
  tag does not change), so a `rollout restart` is needed.

No product code changes — this PR only touches `dbaas-operator/dev`.

## How to verify

```bash
./dev/kind-up.sh
kubectl rollout restart deployment/dbaas-operator deployment/dbaas-aggregator -n dbaas-system
./dev/e2e-tenant-materialize-202.sh
```

The script asserts:

1. while the mock answers 202 — `InternalDatabase` reports `WaitingForDependency` with
   `Ready=False/ProvisioningStarted`, `Stalled=False` and an **empty** `status.trackingId` (an empty
   trackingId is what tells this wait apart from the async-provisioning wait), and the claim's Secret
   does not exist yet (the production symptom: the consuming pod hangs on `FailedMount`);
2. after the budget is spent — `InternalDatabase` reaches `Succeeded`, the mock logged at least two
   202 answers (the operator retried), the claim reaches `Succeeded`, and its Secret carries
   `scope=tenant`, `tenantId=acme-202`.

Before #624 step 1 ended in `BackingOff` and step 2 never happened.

Verified locally in kind: the new scenario passes twice in a row (the pending budget lives in the
mock process, so the script restarts the mock to keep runs deterministic), the existing
`e2e-tenant-materialize.sh` still passes, and `gofmt` / `go vet` / the mock unit tests / `shellcheck`
are clean.