### PR TITLE
ci(sample-service): email the test report like the main integration tests

### DIFF
--- a/.github/scripts/build-test-report.py
+++ b/.github/scripts/build-test-report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build a markdown summary of Surefire reports for posting to a GitHub Issue."""
+"""Build a markdown summary of Surefire reports for a GitHub Issue comment or a report email."""
 import html
 import os
 import xml.etree.ElementTree as ET
@@ -14,6 +14,13 @@ BRANCH = os.environ.get("BRANCH", "")
 COMMIT_SHA = os.environ.get("COMMIT_SHA", "")[:7]
 RUN_NUMBER = os.environ.get("RUN_NUMBER", "")
 MENTIONS = os.environ.get("MENTIONS", "").strip()
+# What the report calls itself (heading, email subject) and what its first column groups by.
+# The defaults keep the wording of the main integration-tests workflow.
+REPORT_LABEL = os.environ.get("REPORT_LABEL", "Integration tests").strip() or "Integration tests"
+GROUP_LABEL = os.environ.get("GROUP_LABEL", "Module").strip() or "Module"
+# Groups that must be present. A group listed here with no Surefire reports is reported as
+# "did not run" and fails the report, so a pass that never executed cannot look green.
+EXPECTED_GROUPS = [g.strip() for g in os.environ.get("EXPECTED_GROUPS", "").split(",") if g.strip()]
 
 STACK_TRACE_LINE_LIMIT = 60
 COMMENT_BYTE_BUDGET = 60000  # GitHub hard limit is 65536; leave headroom
@@ -28,6 +35,7 @@ class ModuleStats:
     skipped: int = 0
     time: float = 0.0
     failed_cases: list = field(default_factory=list)
+    missing: bool = False
 
 
 def fmt_time(seconds: float) -> str:
@@ -78,13 +86,17 @@ def parse_module(module_dir: Path) -> ModuleStats:
 
 
 def collect_all() -> list[ModuleStats]:
-    if not ARTIFACTS_DIR.is_dir():
-        return []
-    return [
-        parse_module(child)
-        for child in sorted(ARTIFACTS_DIR.iterdir())
-        if child.is_dir() and (child / "surefire-reports").is_dir()
-    ]
+    present = {}
+    if ARTIFACTS_DIR.is_dir():
+        for child in sorted(ARTIFACTS_DIR.iterdir()):
+            if child.is_dir() and (child / "surefire-reports").is_dir():
+                present[child.name] = parse_module(child)
+    if not EXPECTED_GROUPS:
+        return list(present.values())
+    # Keep the declared order, and stand in for every expected group that produced nothing.
+    ordered = [present.pop(name, ModuleStats(name=name, missing=True)) for name in EXPECTED_GROUPS]
+    ordered.extend(present.values())
+    return ordered
 
 
 def truncate_trace(text: str) -> str:
@@ -95,37 +107,47 @@ def truncate_trace(text: str) -> str:
     return "\n".join(lines[:STACK_TRACE_LINE_LIMIT]) + f"\n... ({omitted} more lines — see Surefire artifact)"
 
 
-def build_title(status: str, bad: int) -> str:
+def failure_summary(bad: int, missing: list[str]) -> str:
+    parts = []
+    if bad:
+        parts.append(f"{bad} {'test' if bad == 1 else 'tests'}")
+    if missing:
+        parts.append(f"{len(missing)} did not run")
+    return ", ".join(parts)
+
+
+def build_title(status: str, bad: int, missing: list[str]) -> str:
     if status == "failed":
-        word = "test" if bad == 1 else "tests"
-        return f"❌ Integration tests #{RUN_NUMBER} FAILED ({bad} {word}) — {BRANCH}"
+        return f"❌ {REPORT_LABEL} #{RUN_NUMBER} FAILED ({failure_summary(bad, missing)}) — {BRANCH}"
     if status == "success":
-        return f"✅ Integration tests #{RUN_NUMBER} PASSED — {BRANCH}"
-    return f"⚠️ Integration tests #{RUN_NUMBER} DID NOT RUN — {BRANCH}"
+        return f"✅ {REPORT_LABEL} #{RUN_NUMBER} PASSED — {BRANCH}"
+    return f"⚠️ {REPORT_LABEL} #{RUN_NUMBER} DID NOT RUN — {BRANCH}"
 
 
 def render(modules: list[ModuleStats]) -> tuple[str, str, str, int]:
-    total_tests = sum(m.tests for m in modules)
-    total_failed = sum(m.failures for m in modules)
-    total_errors = sum(m.errors for m in modules)
-    total_skipped = sum(m.skipped for m in modules)
-    total_time = sum(m.time for m in modules)
+    ran = [m for m in modules if not m.missing]
+    missing = [m.name for m in modules if m.missing]
+    total_tests = sum(m.tests for m in ran)
+    total_failed = sum(m.failures for m in ran)
+    total_errors = sum(m.errors for m in ran)
+    total_skipped = sum(m.skipped for m in ran)
+    total_time = sum(m.time for m in ran)
     bad = total_failed + total_errors
 
-    if not modules:
+    if not ran:
         status = "no-tests"
-    elif bad > 0:
+    elif bad > 0 or missing:
         status = "failed"
     else:
         status = "success"
-    title = build_title(status, bad)
+    title = build_title(status, bad, missing)
 
     lines = []
     meta = f"**Branch:** `{BRANCH}` · **Commit:** `{COMMIT_SHA}`"
 
     if status == "no-tests":
         lines += [
-            f"### ⚠️ Integration tests #{RUN_NUMBER} — DID NOT RUN",
+            f"### ⚠️ {REPORT_LABEL} #{RUN_NUMBER} — DID NOT RUN",
             meta,
             "",
             "No Surefire reports found — a step before `mvn test` likely failed.",
@@ -137,10 +159,9 @@ def render(modules: list[ModuleStats]) -> tuple[str, str, str, int]:
         return "\n".join(lines), status, title, 0
 
     if status == "failed":
-        word = "test" if bad == 1 else "tests"
-        lines.append(f"### ❌ Integration tests #{RUN_NUMBER} — FAILED ({bad} {word})")
+        lines.append(f"### ❌ {REPORT_LABEL} #{RUN_NUMBER} — FAILED ({failure_summary(bad, missing)})")
     else:
-        lines.append(f"### ✅ Integration tests #{RUN_NUMBER} — PASSED")
+        lines.append(f"### ✅ {REPORT_LABEL} #{RUN_NUMBER} — PASSED")
 
     lines.append(f"{meta} · **Test time:** {fmt_time(total_time)}")
     if MENTIONS:
@@ -148,16 +169,26 @@ def render(modules: list[ModuleStats]) -> tuple[str, str, str, int]:
 
     lines += [
         "",
-        "| Module | Tests | Failed | Errors | Skipped | Time |",
+        f"| {GROUP_LABEL} | Tests | Failed | Errors | Skipped | Time |",
         "|---|---:|---:|---:|---:|---:|",
     ]
     for m in modules:
+        if m.missing:
+            lines.append(f"| {m.name} | — | — | — | — | did not run |")
+            continue
         lines.append(
             f"| {m.name} | {m.tests} | {m.failures} | {m.errors} | {m.skipped} | {fmt_time(m.time)} |"
         )
     lines.append(
         f"| **Total** | **{total_tests}** | **{total_failed}** | **{total_errors}** | **{total_skipped}** | **{fmt_time(total_time)}** |"
     )
+
+    if missing:
+        names = ", ".join(f"`{name}`" for name in missing)
+        lines += [
+            "",
+            f"No Surefire reports for {names} — the step never ran, or wrote its reports elsewhere.",
+        ]
 
     if status == "failed":
         lines.append("")

--- a/.github/scripts/build-test-report.py
+++ b/.github/scripts/build-test-report.py
@@ -89,7 +89,10 @@ def collect_all() -> list[ModuleStats]:
     present = {}
     if ARTIFACTS_DIR.is_dir():
         for child in sorted(ARTIFACTS_DIR.iterdir()):
-            if child.is_dir() and (child / "surefire-reports").is_dir():
+            # A group counts as run only once it has produced a Surefire XML. Maven creates the
+            # reports directory before it writes anything, so an empty one means the tests died
+            # first — reporting that as zero failures would turn a dead pass into a green row.
+            if child.is_dir() and any((child / "surefire-reports").glob("TEST-*.xml")):
                 present[child.name] = parse_module(child)
     if not EXPECTED_GROUPS:
         return list(present.values())

--- a/.github/workflows/integration-tests-sample-service.yml
+++ b/.github/workflows/integration-tests-sample-service.yml
@@ -2,6 +2,12 @@ name: Sample Services Integration Tests
 
 on:
   workflow_call:
+    secrets:
+      EMAIL_PASSWORD:
+        required: false
+        # Called workflows inherit vars but not secrets. A caller must pass `secrets: inherit`,
+        # otherwise the password arrives empty and the report email step fails (non-fatally).
+        description: SMTP password used to email the test report.
   workflow_dispatch:
   schedule:
     - cron: "0 2 * * *"  # Daily at 02:00 UTC
@@ -317,6 +323,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Surefire reports
+        id: upload_surefire
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -407,23 +414,67 @@ jobs:
           path: diagnostics/**
           if-no-files-found: ignore
 
-      - name: Fail job if sample service tests failed
+      - name: Aggregate Surefire reports
         if: always()
+        # build-test-report.py reads <ARTIFACTS_DIR>/<group>/surefire-reports/TEST-*.xml and uses the
+        # directory name as the row label, so each pass is copied under a name that reads well in the
+        # report table. EXPECTED_GROUPS below must list exactly these names.
         run: |
-          shopt -s nullglob
-          # Check every pass separately, and require reports from each one. A missing set means the
-          # pass never ran or wrote elsewhere — treat both as failures, or a broken pass stays green.
-          rc=0
-          for pass in pass-a pass-b phase-c; do
-            reports=(test-apps/test-apps-integration-tests/target/surefire-reports/"$pass"/TEST-*.xml)
-            if [ "${#reports[@]}" -eq 0 ]; then
-              echo "::error::No Surefire XML reports were generated for $pass"
-              rc=1
-              continue
-            fi
-            if grep -E 'failures="[1-9]|errors="[1-9]' "${reports[@]}" >/dev/null 2>&1; then
-              echo "::error::Sample service integration tests failed in $pass"
-              rc=1
-            fi
+          set -euo pipefail
+          src=test-apps/test-apps-integration-tests/target/surefire-reports
+          mkdir -p artifacts   # keep the report step's input directory present even if no pass ran
+          for pair in "pass-a:pass-a-mounted-secret" \
+                      "pass-b:pass-b-rest-fallback" \
+                      "phase-c:phase-c-direct-m2m"; do
+            from="${pair%%:*}"; to="${pair##*:}"
+            [ -d "$src/$from" ] || continue
+            mkdir -p "artifacts/$to/surefire-reports"
+            cp "$src/$from"/TEST-*.xml "artifacts/$to/surefire-reports/" 2>/dev/null || true
           done
-          exit $rc
+          find artifacts -name 'TEST-*.xml' | sort
+
+      - name: Build test report
+        id: build_report
+        if: always()
+        env:
+          ARTIFACTS_DIR: artifacts
+          OUTPUT_FILE: report.md
+          REPORT_LABEL: Sample services integration tests
+          GROUP_LABEL: Pass
+          # A pass with no reports never ran — it must show up in the report and fail the job,
+          # otherwise a pass that died during deploy would leave the run looking green.
+          EXPECTED_GROUPS: pass-a-mounted-secret,pass-b-rest-fallback,phase-c-direct-m2m
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ARTIFACT_URL: ${{ steps.upload_surefire.outputs.artifact-url }}
+          BRANCH: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: python3 .github/scripts/build-test-report.py
+
+      - name: Email test report
+        if: always() && steps.build_report.outcome == 'success'
+        continue-on-error: true
+        # Pinned to the commit that adds email-action (#782); no release tag includes it yet.
+        uses: Netcracker/qubership-workflow-hub/actions/email-action@f4a2c6f57cfdd620676d0dc7321491b33d7c214b
+        env:
+          EMAIL_SMTP_HOST: ${{ vars.EMAIL_SMTP_HOST }}
+          EMAIL_SMTP_PORT: ${{ vars.EMAIL_SMTP_PORT }}
+          EMAIL_FROM: ${{ vars.EMAIL_FROM }}
+          EMAIL_USERNAME: ${{ vars.EMAIL_FROM }}
+          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+          EMAIL_TO: ${{ vars.EMAIL_TO }}
+        with:
+          subject: ${{ steps.build_report.outputs.title }}
+          # convert-markdown only applies to html-body (dawidd6/action-send-mail
+          # renders markdown→HTML for the html part); body stays as the plain-text fallback.
+          body: file://report.md
+          html-body: file://report.md
+          convert-markdown: "true"
+
+      - name: Fail job if sample service tests failed
+        # The report is the single gate: it fails on a failed test AND on a pass that produced no
+        # reports at all ("no-tests" when every pass is missing).
+        if: always() && steps.build_report.outputs.status != 'success'
+        run: |
+          echo "::error::Sample service integration tests did not pass (status=${{ steps.build_report.outputs.status }}, failed tests=${{ steps.build_report.outputs.failed_count }})"
+          exit 1

--- a/.github/workflows/integration-tests-sample-service.yml
+++ b/.github/workflows/integration-tests-sample-service.yml
@@ -5,8 +5,10 @@ on:
     secrets:
       EMAIL_PASSWORD:
         required: false
-        # Called workflows inherit vars but not secrets. A caller must pass `secrets: inherit`,
-        # otherwise the password arrives empty and the report email step fails (non-fatally).
+        # Called workflows inherit vars but not secrets, so a caller must pass this one explicitly:
+        #   secrets:
+        #     EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+        # Without it the password arrives empty and the report email step fails (non-fatally).
         description: SMTP password used to email the test report.
   workflow_dispatch:
   schedule:
@@ -421,15 +423,19 @@ jobs:
         # report table. EXPECTED_GROUPS below must list exactly these names.
         run: |
           set -euo pipefail
+          shopt -s nullglob
           src=test-apps/test-apps-integration-tests/target/surefire-reports
           mkdir -p artifacts   # keep the report step's input directory present even if no pass ran
           for pair in "pass-a:pass-a-mounted-secret" \
                       "pass-b:pass-b-rest-fallback" \
                       "phase-c:phase-c-direct-m2m"; do
             from="${pair%%:*}"; to="${pair##*:}"
-            [ -d "$src/$from" ] || continue
+            # Copy only when the pass actually produced reports. Maven creates the directory before
+            # it writes anything, so copying an empty one would claim the pass ran.
+            xmls=("$src/$from"/TEST-*.xml)
+            [ "${#xmls[@]}" -gt 0 ] || continue
             mkdir -p "artifacts/$to/surefire-reports"
-            cp "$src/$from"/TEST-*.xml "artifacts/$to/surefire-reports/" 2>/dev/null || true
+            cp "${xmls[@]}" "artifacts/$to/surefire-reports/"
           done
           find artifacts -name 'TEST-*.xml' | sort
 


### PR DESCRIPTION
## Why

`integration-tests.yml` builds a Surefire summary and emails it to `vars.EMAIL_TO` after every run.
`integration-tests-sample-service.yml` runs nightly at 02:00 UTC and produced nothing comparable:
the three passes wrote per-pass Surefire directories, a bash gate failed the job, and the result
was visible only to whoever opened the Actions UI.

## What

Reuse the existing report pipeline instead of duplicating it. `.github/scripts/build-test-report.py`
gains three env knobs, all with defaults that keep `integration-tests.yml` byte-identical in output:

| Variable | Default | Sample-service value |
|---|---|---|
| `REPORT_LABEL` | `Integration tests` | `Sample services integration tests` |
| `GROUP_LABEL` | `Module` | `Pass` |
| `EXPECTED_GROUPS` | *(empty)* | `pass-a-mounted-secret,pass-b-rest-fallback,phase-c-direct-m2m` |

A group listed in `EXPECTED_GROUPS` with no Surefire reports renders as a `did not run` row and sets
`status=failed`, which preserves the strictness of the bash gate this PR replaces: a pass that died
during deploy cannot leave the run looking green.

In the workflow:

- `Upload Surefire reports` gets `id: upload_surefire` so the report can link the artifact.
- New `Aggregate Surefire reports` step copies `target/surefire-reports/<pass>` to
  `artifacts/<readable-name>/surefire-reports`, the layout the script expects.
- New `Build test report` and `Email test report` steps mirror `integration-tests.yml`, including the
  pinned `email-action` commit and `continue-on-error: true` on the send.
- The bash gate is replaced by `steps.build_report.outputs.status != 'success'`, so the gate and the
  email now come from one source of truth.
- `on.workflow_call` declares `EMAIL_PASSWORD` as an optional secret. Nothing calls this workflow
  today; the declaration plus its comment is there so a future caller knows to pass `EMAIL_PASSWORD` explicitly (rather than `secrets: inherit`, which would hand the whole caller secret set to this workflow).

Email subject, for example: `✅ Sample services integration tests #123 PASSED — feat/operator-dev`.
Recipients stay `vars.EMAIL_TO`, the same list the main integration tests use.

## How to verify

The report script was exercised locally against synthetic Surefire trees, covering all five paths:

| Scenario | `status` | Title |
|---|---|---|
| three passes green | `success` | `✅ Sample services integration tests #42 PASSED — …` |
| one failing test in pass B | `failed` | `❌ … FAILED (1 test) — …` |
| pass B and phase C never ran | `failed` | `❌ … FAILED (2 did not run) — …` |
| nothing ran at all | `no-tests` | `⚠️ … DID NOT RUN — …` |
| no new env vars (main workflow) | `success` | `✅ Integration tests #42 PASSED — …` |

The aggregation step was run against a simulated `target/surefire-reports/{pass-a,pass-b}` tree and
produced the expected `artifacts/**` layout, with `phase-c-direct-m2m` reported as `did not run`.

End-to-end check after merge: trigger the workflow (`workflow_dispatch`) and confirm the email arrives
with all three passes in the table.