### PR TITLE
fix: propagate request id to the aggregator

### DIFF
--- a/dbaas-operator/AGENTS.md
+++ b/dbaas-operator/AGENTS.md
@@ -80,24 +80,21 @@ github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders
 ### Initialization (in `main()`)
 
 ```go
-ctxmanager.Register([]ctxmanager.ContextProvider{
-    xrequestid.XRequestIdProvider{},
-})
+requestcontext.RegisterProviders()
 ```
 
 ### Per-reconcile / per-request
 
-Every reconcile loop or incoming request handler must generate a unique request ID and
-attach it to the context:
+Every reconcile loop or incoming request handler must use the shared helper to generate
+a unique request ID and attach it to the context:
 
 ```go
-requestID := uuid.New().String()
-ctx = ctxmanager.InitContext(ctx, map[string]any{
-    "X-Request-Id": requestID,
-})
+ctx, requestID := requestcontext.WithFreshRequestID(ctx)
 ```
 
 This enables end-to-end tracing across operator → aggregator → adapter logs.
+It is also a hard precondition for aggregator calls: the client rejects a request
+when the provider is not registered or the caller did not initialize the context.
 
 ---
 
@@ -474,8 +471,7 @@ docs/monitoring/                      Metrics & Grafana dashboard reference docs
 ```go
 func (r *MyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
     // 1. Generate request ID
-    requestID := uuid.New().String()
-    ctx = ctxmanager.InitContext(ctx, map[string]any{"X-Request-Id": requestID})
+    ctx, requestID := requestcontext.WithFreshRequestID(ctx)
 
     // 2. Fetch the CR
     obj := &myapi.MyResource{}

--- a/dbaas-operator/cmd/context_providers_test.go
+++ b/dbaas-operator/cmd/context_providers_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
+)
+
+func TestRegisterContextProviders(t *testing.T) {
+	registerContextProviders()
+
+	ctx, want := requestcontext.WithFreshRequestID(context.Background())
+	got, err := requestcontext.RequestID(ctx)
+	if err != nil {
+		t.Fatalf("registered provider did not initialize request context: %v", err)
+	}
+	if got != want {
+		t.Fatalf("request ID = %q, want %q", got, want)
+	}
+}

--- a/dbaas-operator/cmd/main.go
+++ b/dbaas-operator/cmd/main.go
@@ -46,8 +46,6 @@ import (
 	httpserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
 	"github.com/netcracker/qubership-core-lib-go/v3/logging"
 	_ "github.com/netcracker/qubership-core-lib-go/v3/memlimit"
 	dbaasv1 "github.com/netcracker/qubership-dbaas/dbaas-operator/api/v1"
@@ -55,6 +53,7 @@ import (
 	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/controller"
 	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/ownership"
 	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/poller"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -72,9 +71,7 @@ func init() {
 
 // nolint:gocyclo
 func main() {
-	ctxmanager.Register([]ctxmanager.ContextProvider{
-		xrequestid.XRequestIdProvider{},
-	})
+	registerContextProviders()
 
 	var httpAddr string
 	var enableLeaderElection bool
@@ -352,6 +349,10 @@ func main() {
 		setupLog.Errorf("Failed to run manager: %v", err)
 		os.Exit(1)
 	}
+}
+
+func registerContextProviders() {
+	requestcontext.RegisterProviders()
 }
 
 // ownershipWarmupRunnable pre-populates the ownership cache before the

--- a/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
+++ b/dbaas-operator/docs/monitoring/DBaaS Operator Metrics.md
@@ -91,7 +91,7 @@ The operator publishes two families of metrics:
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `dbaas_reconcile_trigger_total` | Counter | `controller`, `trigger` | Reconcile invocations broken down by what triggered them. Complements the framework's reconcile totals with the trigger dimension. |
-| `dbaas_aggregator_requests_total` | Counter | `controller`, `operation`, `result` | Calls to dbaas-aggregator by controller, operation, and outcome. The `result` label separates user errors (`spec_rejection`) from platform errors (`auth_error`, `server_error`). |
+| `dbaas_aggregator_requests_total` | Counter | `controller`, `operation`, `result` | Calls to dbaas-aggregator by controller, operation, and outcome. The `result` label separates user errors (`spec_rejection`), local operator wiring errors (`configuration_error`), and platform errors (`auth_error`, `server_error`). |
 | `dbaas_aggregator_request_duration_seconds` | Histogram | `controller`, `operation` | Latency of HTTP calls to dbaas-aggregator. Buckets: `0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30` s. |
 | `dbaas_async_operation_duration_seconds` | Histogram | `result` | End-to-end duration of asynchronous `InternalDatabase` provisioning, from async submit (HTTP 202) to the final poll outcome. Buckets: `1, 5, 10, 30, 60, 300, 600, 1800, 3600, 7200` s. The submit timestamp is held in operator memory, so an operation that was in flight across an operator restart or a leadership change is never observed — `_count` under-reports completions after a restart. |
 | `dbaas_secret_resolution_errors_total` | Counter | `namespace`, `reason` | Failures reading the credential `Secret` referenced by an `ExternalDatabase`, scoped to namespaces owned by this operator instance. A non-zero value means a database may be left without valid credentials — direct service impact. |
@@ -277,6 +277,7 @@ value — it is not recorded in `dbaas_aggregator_requests_total` at all.
 |---|---|---|
 | `success` | Call succeeded | — |
 | `spec_rejection` | Aggregator rejected the request (400/403/409/410/422) | User error — fix the CR |
+| `configuration_error` | The operator could not propagate its required request context; the call was rejected locally | Operator wiring error — verify provider registration and request-context initialization |
 | `auth_error` | Authentication failed (401) | Platform error |
 | `server_error` | Aggregator 5xx | Platform error |
 | `network_error` | Connection/timeout, no HTTP response | Platform error |

--- a/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
+++ b/dbaas-operator/helm-templates/dbaas-operator/dashboards/dbaas-operator-dashboard.json
@@ -394,7 +394,7 @@
                                           "id":  7,
                                           "type":  "timeseries",
                                           "title":  "Aggregator Call Outcomes (calls/s)",
-                                          "description":  "Result breakdown: database_not_found = DatabaseSecretClaim waiting for DB registration, spec_rejection = CR/spec owner, auth_error = operator credentials/RBAC, server_error = aggregator, network_error = connectivity/platform.",
+                                          "description":  "Result breakdown: database_not_found = DatabaseSecretClaim waiting for DB registration, spec_rejection = CR/spec owner, configuration_error = operator request-context wiring, auth_error = operator credentials/RBAC, server_error = aggregator, network_error = connectivity/platform.",
                                           "gridPos":  {
                                                           "h":  8,
                                                           "w":  12,
@@ -450,6 +450,21 @@
                                                                                                            "id":  "color",
                                                                                                            "value":  {
                                                                                                                          "fixedColor":  "blue",
+                                                                                                                         "mode":  "fixed"
+                                                                                                                     }
+                                                                                                       }
+                                                                                                   ]
+                                                                                },
+                                                                                {
+                                                                                    "matcher":  {
+                                                                                                    "id":  "byName",
+                                                                                                    "options":  "configuration_error"
+                                                                                                },
+                                                                                    "properties":  [
+                                                                                                       {
+                                                                                                           "id":  "color",
+                                                                                                           "value":  {
+                                                                                                                         "fixedColor":  "red",
                                                                                                                          "mode":  "fixed"
                                                                                                                      }
                                                                                                        }

--- a/dbaas-operator/internal/client/aggregator_client.go
+++ b/dbaas-operator/internal/client/aggregator_client.go
@@ -30,7 +30,10 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/netcracker/qubership-core-lib-go-error-handling/v3/tmf"
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxhelper"
 	"github.com/netcracker/qubership-core-lib-go/v3/security/tokensource"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -113,6 +116,20 @@ func newClient(baseURL string, getToken func(ctx context.Context) (string, error
 		// so the warning is pure noise logged on every call (incl. the rotation poll loop).
 		SetDisableWarn(true).
 		OnBeforeRequest(func(_ *resty.Client, r *resty.Request) error {
+			if _, err := requestcontext.RequestID(r.Context()); err != nil {
+				return &RequestContextError{Cause: err}
+			}
+			if err := ctxhelper.AddSerializableContextData(r.Context(), func(name, value string) {
+				r.SetHeader(name, value)
+			}); err != nil {
+				return &RequestContextError{Cause: fmt.Errorf("serialize request context: %w", err)}
+			}
+			if r.Header.Get(xrequestid.X_REQUEST_ID_HEADER_NAME) == "" {
+				return &RequestContextError{Cause: fmt.Errorf(
+					"serialization did not add required header %s; verify that request-ID propagation is not restricted",
+					xrequestid.X_REQUEST_ID_HEADER_NAME)}
+			}
+
 			// M2M mode — fetch a fresh dbaas-audience token per request.
 			if c.getToken != nil {
 				token, err := c.getToken(r.Context())

--- a/dbaas-operator/internal/client/aggregator_client_test.go
+++ b/dbaas-operator/internal/client/aggregator_client_test.go
@@ -22,14 +22,34 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // dbTypePostgresql is the database type used throughout these client tests.
 const dbTypePostgresql = "postgresql"
+
+func TestMain(m *testing.M) {
+	requestcontext.RegisterProviders()
+	os.Exit(m.Run())
+}
+
+func contextWithRequestID(requestID string) context.Context {
+	return ctxmanager.InitContext(context.Background(), map[string]any{
+		xrequestid.X_REQUEST_ID_HEADER_NAME: requestID,
+	})
+}
+
+func requestContext() context.Context {
+	return contextWithRequestID("client-test-request-id")
+}
 
 // staticToken returns a TokenSource function that always returns the given token.
 // Used in tests to avoid touching the global tokensource state.
@@ -80,6 +100,78 @@ func bearerToken(r *http.Request) string {
 	return strings.TrimPrefix(h, "Bearer ")
 }
 
+func TestAggregatorClient_PropagatesRequestID(t *testing.T) {
+	const requestID = "operator-reconcile-request-id"
+	tests := []struct {
+		name           string
+		newClient      func(string) *AggregatorClient
+		wantAuthPrefix string
+	}{
+		{
+			name: "M2M",
+			newClient: func(baseURL string) *AggregatorClient {
+				return newClient(baseURL, staticToken("test-token"))
+			},
+			wantAuthPrefix: "Bearer ",
+		},
+		{
+			name: "BasicAuth",
+			newClient: func(baseURL string) *AggregatorClient {
+				return NewBasicAuthClient(baseURL, "dbaas-operator", "password")
+			},
+			wantAuthPrefix: "Basic ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotRequestID, gotAuthorization string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotRequestID = r.Header.Get(xrequestid.X_REQUEST_ID_HEADER_NAME)
+				gotAuthorization = r.Header.Get("Authorization")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			c := tt.newClient(srv.URL)
+			err := c.RegisterExternalDatabase(contextWithRequestID(requestID), "ns", minimalExtDBRequest())
+			if err != nil {
+				t.Fatalf("RegisterExternalDatabase: %v", err)
+			}
+			if gotRequestID != requestID {
+				t.Errorf("%s header: got %q, want %q",
+					xrequestid.X_REQUEST_ID_HEADER_NAME, gotRequestID, requestID)
+			}
+			if !strings.HasPrefix(gotAuthorization, tt.wantAuthPrefix) {
+				t.Errorf("Authorization: got %q, want prefix %q", gotAuthorization, tt.wantAuthPrefix)
+			}
+		})
+	}
+}
+
+func TestAggregatorClient_RejectsMissingRequestID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("request without X-Request-Id reached the server")
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, staticToken("test-token"))
+	err := c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+	if err == nil {
+		t.Fatal("expected missing request ID to reject the request")
+	}
+	var requestContextErr *RequestContextError
+	if !errors.As(err, &requestContextErr) {
+		t.Fatalf("error type = %T, want *RequestContextError", err)
+	}
+	if !strings.Contains(err.Error(), "request ID context is not initialized") ||
+		!strings.Contains(err.Error(), "call WithFreshRequestID") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 // ── RegisterExternalDatabase ──────────────────────────────────────────────────
 
 func TestRegisterExternalDatabase_UsesCorrectURLAndMethod(t *testing.T) {
@@ -94,7 +186,7 @@ func TestRegisterExternalDatabase_UsesCorrectURLAndMethod(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if err := c.RegisterExternalDatabase(context.Background(), "my-namespace", minimalExtDBRequest()); err != nil {
+	if err := c.RegisterExternalDatabase(requestContext(), "my-namespace", minimalExtDBRequest()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -118,7 +210,7 @@ func TestRegisterExternalDatabase_SendsBearerToken(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("my-dbaas-token"))
-	_ = c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+	_ = c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
 
 	if gotToken != "my-dbaas-token" {
 		t.Errorf("Authorization: got Bearer %q, want Bearer my-dbaas-token", gotToken)
@@ -147,8 +239,8 @@ func TestRegisterExternalDatabase_TokenFetchedPerRequest(t *testing.T) {
 	}
 
 	c := newClient(srv.URL, tokenFn)
-	_ = c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
-	_ = c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+	_ = c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
+	_ = c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
 
 	if len(tokens) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(tokens))
@@ -179,7 +271,7 @@ func TestBasicAuthClient_SendsBasicAuth(t *testing.T) {
 	defer srv.Close()
 
 	c := NewBasicAuthClient(srv.URL, "dbaas-operator", "s3cr3t")
-	_ = c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+	_ = c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
 
 	if !gotOK || gotUser != "dbaas-operator" || gotPass != "s3cr3t" {
 		t.Errorf("BasicAuth: got (%q,%q,ok=%v), want (dbaas-operator,s3cr3t,ok=true)", gotUser, gotPass, gotOK)
@@ -203,9 +295,9 @@ func TestBasicAuthClient_SetCredentialsHotSwap(t *testing.T) {
 	defer srv.Close()
 
 	c := NewBasicAuthClient(srv.URL, "dbaas-operator", "old-pass")
-	_ = c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+	_ = c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
 	c.SetCredentials("dbaas-operator", "new-pass")
-	_ = c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+	_ = c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
 
 	if len(passwords) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(passwords))
@@ -237,7 +329,7 @@ func TestRegisterExternalDatabase_SerializesRequestBody(t *testing.T) {
 		UpdateConnectionProperties: true,
 	}
 	c := newClient(srv.URL, staticToken("test-token"))
-	if err := c.RegisterExternalDatabase(context.Background(), "ns", req); err != nil {
+	if err := c.RegisterExternalDatabase(requestContext(), "ns", req); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -258,7 +350,7 @@ func TestRegisterExternalDatabase_HTTP200IsSuccess(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if err := c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest()); err != nil {
+	if err := c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest()); err != nil {
 		t.Errorf("HTTP 200 should be success, got: %v", err)
 	}
 }
@@ -271,7 +363,7 @@ func TestRegisterExternalDatabase_HTTP201IsSuccess(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if err := c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest()); err != nil {
+	if err := c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest()); err != nil {
 		t.Errorf("HTTP 201 should be success, got: %v", err)
 	}
 }
@@ -296,7 +388,7 @@ func TestRegisterExternalDatabase_NonSuccessReturnsAggregatorError(t *testing.T)
 			defer srv.Close()
 
 			c := newClient(srv.URL, staticToken("test-token"))
-			err := c.RegisterExternalDatabase(context.Background(), "ns", minimalExtDBRequest())
+			err := c.RegisterExternalDatabase(requestContext(), "ns", minimalExtDBRequest())
 			if err == nil {
 				t.Fatalf("expected error for HTTP %d, got nil", code)
 			}
@@ -319,7 +411,7 @@ func TestRegisterExternalDatabase_ContextCancellation(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(requestContext())
 	cancel() // cancel immediately
 
 	c := newClient(srv.URL, staticToken("test-token"))
@@ -345,7 +437,7 @@ func TestApplyMicroserviceBalancingRules_UsesCorrectURLMethodAndBody(t *testing.
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.ApplyMicroserviceBalancingRules(context.Background(), "payments", []OnMicroserviceRuleRequest{{
+	err := c.ApplyMicroserviceBalancingRules(requestContext(), "payments", []OnMicroserviceRuleRequest{{
 		Type:          dbTypePostgresql,
 		Rules:         []RuleOnMicroservice{{Label: "zone=fast"}},
 		Microservices: []string{"billing-service"},
@@ -382,7 +474,7 @@ func TestApplyNamespaceBalancingRule_UsesCorrectURLMethodAndBody(t *testing.T) {
 
 	order := int64(3)
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.ApplyNamespaceBalancingRule(context.Background(), "payments", "pg-fast", &NamespaceBalancingRuleRequest{
+	err := c.ApplyNamespaceBalancingRule(requestContext(), "payments", "pg-fast", &NamespaceBalancingRuleRequest{
 		Order: &order,
 		Type:  dbTypePostgresql,
 		Rule: NamespaceBalancingRuleBody{
@@ -419,7 +511,7 @@ func TestDeleteNamespaceBalancingRule_UsesCorrectURLAndMethod(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if err := c.DeleteNamespaceBalancingRule(context.Background(), "payments", "pg-fast"); err != nil {
+	if err := c.DeleteNamespaceBalancingRule(requestContext(), "payments", "pg-fast"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gotMethod != http.MethodDelete {
@@ -443,7 +535,7 @@ func TestDeleteNamespaceBalancingRule_SuccessStatuses(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(srv.URL, staticToken("test-token"))
-			if err := c.DeleteNamespaceBalancingRule(context.Background(), "payments", "pg-fast"); err != nil {
+			if err := c.DeleteNamespaceBalancingRule(requestContext(), "payments", "pg-fast"); err != nil {
 				t.Errorf("HTTP %d should be success, got: %v", code, err)
 			}
 		})
@@ -462,7 +554,7 @@ func TestDeleteNamespaceBalancingRule_NonSuccessReturnsError(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(srv.URL, staticToken("test-token"))
-			if err := c.DeleteNamespaceBalancingRule(context.Background(), "payments", "pg-fast"); err == nil {
+			if err := c.DeleteNamespaceBalancingRule(requestContext(), "payments", "pg-fast"); err == nil {
 				t.Fatalf("expected error for HTTP %d, got nil", code)
 			}
 		})
@@ -472,7 +564,7 @@ func TestDeleteNamespaceBalancingRule_NonSuccessReturnsError(t *testing.T) {
 func TestDeleteNamespaceBalancingRule_ContextCancellation(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(requestContext())
 	cancel()
 
 	c := newClient("http://127.0.0.1", staticToken("test-token"))
@@ -497,7 +589,7 @@ func TestApplyPermanentBalancingRules_UsesCorrectURLMethodAndBody(t *testing.T) 
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.ApplyPermanentBalancingRules(context.Background(), []PermanentBalancingRuleRequest{{
+	err := c.ApplyPermanentBalancingRules(requestContext(), []PermanentBalancingRuleRequest{{
 		DBType:             dbTypePostgresql,
 		PhysicalDatabaseID: "postgresql-prod-a",
 		Namespaces:         []string{"payments", "orders"},
@@ -533,7 +625,7 @@ func TestDeletePermanentBalancingRules_UsesCorrectURLMethodAndBody(t *testing.T)
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.DeletePermanentBalancingRules(context.Background(), []PermanentBalancingRuleDeleteRequest{{
+	err := c.DeletePermanentBalancingRules(requestContext(), []PermanentBalancingRuleDeleteRequest{{
 		DBType:     dbTypePostgresql,
 		Namespaces: []string{"payments"},
 	}})
@@ -566,7 +658,7 @@ func TestApplyConfig_UsesCorrectURLAndMethod(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if _, err := c.ApplyConfig(context.Background(), minimalDeclarativePayload()); err != nil {
+	if _, err := c.ApplyConfig(requestContext(), minimalDeclarativePayload()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -593,7 +685,7 @@ func TestApplyConfig_HTTP200SyncResponse(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	got, err := c.ApplyConfig(context.Background(), minimalDeclarativePayload())
+	got, err := c.ApplyConfig(requestContext(), minimalDeclarativePayload())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -621,7 +713,7 @@ func TestApplyConfig_HTTP202AsyncResponse(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	got, err := c.ApplyConfig(context.Background(), minimalDeclarativePayload())
+	got, err := c.ApplyConfig(requestContext(), minimalDeclarativePayload())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -651,7 +743,7 @@ func TestApplyConfig_NonSuccessReturnsAggregatorError(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(srv.URL, staticToken("test-token"))
-			_, err := c.ApplyConfig(context.Background(), minimalDeclarativePayload())
+			_, err := c.ApplyConfig(requestContext(), minimalDeclarativePayload())
 			if err == nil {
 				t.Fatalf("expected error for HTTP %d, got nil", code)
 			}
@@ -681,7 +773,7 @@ func TestApplyConfig_SerializesDeclarationVersion(t *testing.T) {
 	payload.DeclarationVersion = "v2"
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if _, err := c.ApplyConfig(context.Background(), payload); err != nil {
+	if _, err := c.ApplyConfig(requestContext(), payload); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -702,7 +794,7 @@ func TestApplyConfig_OmitsDeclarationVersionWhenEmpty(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if _, err := c.ApplyConfig(context.Background(), minimalDeclarativePayload()); err != nil {
+	if _, err := c.ApplyConfig(requestContext(), minimalDeclarativePayload()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -725,7 +817,7 @@ func TestGetOperationStatus_UsesCorrectURLAndMethod(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	if _, err := c.GetOperationStatus(context.Background(), "track-99"); err != nil {
+	if _, err := c.GetOperationStatus(requestContext(), "track-99"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -751,7 +843,7 @@ func TestGetOperationStatus_InProgressResponse(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	got, err := c.GetOperationStatus(context.Background(), "track-99")
+	got, err := c.GetOperationStatus(requestContext(), "track-99")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -779,7 +871,7 @@ func TestGetOperationStatus_AllTerminalStates(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(srv.URL, staticToken("test-token"))
-			got, err := c.GetOperationStatus(context.Background(), "tid")
+			got, err := c.GetOperationStatus(requestContext(), "tid")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -808,7 +900,7 @@ func TestGetOperationStatus_NonSuccessReturnsAggregatorError(t *testing.T) {
 			defer srv.Close()
 
 			c := newClient(srv.URL, staticToken("test-token"))
-			_, err := c.GetOperationStatus(context.Background(), "tid")
+			_, err := c.GetOperationStatus(requestContext(), "tid")
 			if err == nil {
 				t.Fatalf("expected error for HTTP %d, got nil", code)
 			}
@@ -837,7 +929,7 @@ func TestGetOperationStatus_ParsesTmfMessage(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	_, err := c.GetOperationStatus(context.Background(), "tid")
+	_, err := c.GetOperationStatus(requestContext(), "tid")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -942,7 +1034,7 @@ func TestRegisterExternalDatabase_ParsesTmfMessage(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.RegisterExternalDatabase(context.Background(), "test", minimalExtDBRequest())
+	err := c.RegisterExternalDatabase(requestContext(), "test", minimalExtDBRequest())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -977,7 +1069,7 @@ func TestRegisterExternalDatabase_NonTmfBodyFallback(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.RegisterExternalDatabase(context.Background(), "test", minimalExtDBRequest())
+	err := c.RegisterExternalDatabase(requestContext(), "test", minimalExtDBRequest())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1007,7 +1099,7 @@ func TestRegisterExternalDatabase_TmfEmptyMessageFallback(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	err := c.RegisterExternalDatabase(context.Background(), "test", minimalExtDBRequest())
+	err := c.RegisterExternalDatabase(requestContext(), "test", minimalExtDBRequest())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1039,7 +1131,7 @@ func TestGetChangedSince_EmptyBodyReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	got, err := c.GetChangedSince(context.Background(), nil, 0)
+	got, err := c.GetChangedSince(requestContext(), nil, 0)
 	if err == nil {
 		t.Fatalf("expected an error for an empty 200 body, got nil (result=%+v)", got)
 	}
@@ -1059,7 +1151,7 @@ func TestGetDatabaseByClassifier_EmptyBodyReturnsError(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	got, err := c.GetDatabaseByClassifier(context.Background(), "test-ns", dbTypePostgresql,
+	got, err := c.GetDatabaseByClassifier(requestContext(), "test-ns", dbTypePostgresql,
 		&GetByClassifierRequest{Classifier: map[string]any{"namespace": "test-ns"}})
 	if err == nil {
 		t.Fatalf("expected an error for an empty 200 body, got nil (result=%+v)", got)
@@ -1080,7 +1172,7 @@ func TestGetOperationStatus_EmptyBodyIsZeroValue(t *testing.T) {
 	defer srv.Close()
 
 	c := newClient(srv.URL, staticToken("test-token"))
-	got, err := c.GetOperationStatus(context.Background(), "tracking-123")
+	got, err := c.GetOperationStatus(requestContext(), "tracking-123")
 	if err != nil {
 		t.Fatalf("empty declarative body must not error, got %v", err)
 	}
@@ -1127,7 +1219,7 @@ func TestCreateDatabase_StatusHandling(t *testing.T) {
 			defer srv.Close()
 
 			pending, err := NewBasicAuthClient(srv.URL, "dbaas-operator", "s3cr3t").CreateDatabase(
-				context.Background(), "ns", &CreateDatabaseRequest{Type: "postgresql"})
+				requestContext(), "ns", &CreateDatabaseRequest{Type: "postgresql"})
 
 			if tt.wantErr {
 				if err == nil {

--- a/dbaas-operator/internal/client/changed_databases_test.go
+++ b/dbaas-operator/internal/client/changed_databases_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -41,7 +40,7 @@ func TestGetChangedSince_SeedCallOmitsCursorParams(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithTokenFunc(srv.URL, staticToken("tok"))
-	resp, err := c.GetChangedSince(context.Background(), nil, 0)
+	resp, err := c.GetChangedSince(requestContext(), nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -87,7 +86,7 @@ func TestGetChangedSince_SendsCursorParamsAndParsesItems(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithTokenFunc(srv.URL, staticToken("tok"))
-	resp, err := c.GetChangedSince(context.Background(), &cursor, 100)
+	resp, err := c.GetChangedSince(requestContext(), &cursor, 100)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -132,7 +131,7 @@ func TestGetChangedSince_PreservesLargeIntClassifier(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithTokenFunc(srv.URL, staticToken("tok"))
-	resp, err := c.GetChangedSince(context.Background(), nil, 0)
+	resp, err := c.GetChangedSince(requestContext(), nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -152,7 +151,7 @@ func TestGetChangedSince_NonOKReturnsAggregatorError(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClientWithTokenFunc(srv.URL, staticToken("tok"))
-	_, err := c.GetChangedSince(context.Background(), nil, 0)
+	_, err := c.GetChangedSince(requestContext(), nil, 0)
 	if err == nil {
 		t.Fatal("expected an error on HTTP 403")
 	}

--- a/dbaas-operator/internal/client/types.go
+++ b/dbaas-operator/internal/client/types.go
@@ -263,6 +263,21 @@ type ChangedDatabasesResponse struct {
 
 // ─── Errors ───────────────────────────────────────────────────────────────────
 
+// RequestContextError reports a local request-context invariant violation.
+// It is deterministic and retrying the same call cannot fix it, so controllers
+// classify it as InvalidConfiguration rather than a transport failure.
+type RequestContextError struct {
+	Cause error
+}
+
+func (e *RequestContextError) Error() string {
+	return fmt.Sprintf("invalid aggregator request context: %v", e.Cause)
+}
+
+func (e *RequestContextError) Unwrap() error {
+	return e.Cause
+}
+
 // AggregatorError represents a non-2xx HTTP response from dbaas-aggregator.
 type AggregatorError struct {
 	StatusCode int

--- a/dbaas-operator/internal/controller/events.go
+++ b/dbaas-operator/internal/controller/events.go
@@ -53,6 +53,11 @@ const (
 	// validation before the aggregator is even contacted. Type: Warning.
 	EventReasonInvalidSpec = "InvalidSpec"
 
+	// EventReasonInvalidRequestContext is emitted when the operator cannot
+	// propagate its required X-Request-Id to dbaas-aggregator. This is a local
+	// wiring error, not an aggregator or network failure. Type: Warning.
+	EventReasonInvalidRequestContext = "InvalidRequestContext"
+
 	// EventReasonSecretError is emitted when a Secret referenced by
 	// ConnectionProperties.credentialsSecretRef cannot be read. Type: Warning.
 	EventReasonSecretError = "SecretError"

--- a/dbaas-operator/internal/controller/helpers.go
+++ b/dbaas-operator/internal/controller/helpers.go
@@ -19,15 +19,12 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
-	"github.com/google/uuid"
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
 	"github.com/netcracker/qubership-core-lib-go/v3/logging"
 	aggregatorclient "github.com/netcracker/qubership-dbaas/dbaas-operator/internal/client"
 	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/ownership"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -42,7 +39,6 @@ var log = logging.GetLogger("dbaas-operator")
 
 const (
 	apiVersionV1 = "core.netcracker.com/v1"
-	xRequestID   = "X-Request-Id"
 )
 
 // bindingTriggerTracker is a concurrency-safe set of "the next reconcile for this
@@ -117,22 +113,10 @@ func enqueueForBindingList[L client.ObjectList](
 	return reqs
 }
 
-// requestIDFromContext returns the reconcile request ID from ctx.
-// It panics if the reconcile context was not initialized.
-func requestIDFromContext(ctx context.Context) string {
-	xrid, err := xrequestid.Of(ctx)
-	if err != nil {
-		log.ErrorC(ctx, "failed to retrieve request ID from context: %v", err)
-		panic(fmt.Sprintf("requestIDFromContext: context not initialized, error: %v", err))
-	}
-	return xrid.GetRequestId()
-}
-
 // initReconcileContext seeds ctx with a fresh X-Request-Id and returns both
 // the enriched context and the raw ID string (used in status fields and event messages).
 func initReconcileContext(ctx context.Context) (context.Context, string) {
-	id := uuid.New().String()
-	return ctxmanager.InitContext(ctx, map[string]any{xRequestID: id}), id
+	return requestcontext.WithFreshRequestID(ctx)
 }
 
 // checkOwnership returns whether reconciliation should proceed for namespace.
@@ -241,6 +225,7 @@ func invalidSpec[P ~string](
 }
 
 // handleAggregatorError maps an aggregator failure to status, event, and retry behavior:
+//   - invalid request context -> InvalidConfiguration (permanent, no retry)
 //   - 401 → BackingOff (transient, retry)
 //   - 400/403/409/410/422 → InvalidConfiguration (permanent, no retry)
 //   - 5xx/network → BackingOff (transient, retry)
@@ -253,6 +238,16 @@ func handleAggregatorError[P ~string](
 	err error,
 	requestID string,
 ) (ctrl.Result, error) {
+	var requestContextErr *aggregatorclient.RequestContextError
+	if errors.As(err, &requestContextErr) {
+		markPermanentFailure(phase, conditions, generation,
+			EventReasonInvalidRequestContext, requestContextErr.Error())
+		recorder.Eventf(obj, corev1.EventTypeWarning, EventReasonInvalidRequestContext,
+			"operator request context is invalid: %s (requestId=%s)",
+			requestContextErr.Error(), requestID)
+		return ctrl.Result{}, nil
+	}
+
 	var aggErr *aggregatorclient.AggregatorError
 	if errors.As(err, &aggErr) {
 		switch {

--- a/dbaas-operator/internal/controller/helpers_test.go
+++ b/dbaas-operator/internal/controller/helpers_test.go
@@ -17,11 +17,84 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	dbaasv1 "github.com/netcracker/qubership-dbaas/dbaas-operator/api/v1"
+	aggregatorclient "github.com/netcracker/qubership-dbaas/dbaas-operator/internal/client"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 )
+
+func TestHandleAggregatorError_RequestContextFailureIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	phase := dbaasv1.PhaseProcessing
+	var conditions []metav1.Condition
+	recorder := record.NewFakeRecorder(1)
+	obj := &dbaasv1.ExternalDatabase{}
+	contextErr := &aggregatorclient.RequestContextError{Cause: errors.New("request ID provider is not registered")}
+
+	result, err := handleAggregatorError(&phase, &conditions, 7, recorder, obj, contextErr, "request-123")
+	if err != nil {
+		t.Fatalf("handleAggregatorError() error = %v, want nil", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("handleAggregatorError() result = %+v, want zero result", result)
+	}
+	if phase != dbaasv1.PhaseInvalidConfiguration {
+		t.Fatalf("phase = %q, want %q", phase, dbaasv1.PhaseInvalidConfiguration)
+	}
+
+	ready := findCondition(conditions, conditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != EventReasonInvalidRequestContext {
+		t.Fatalf("Ready condition = %+v, want False/%s", ready, EventReasonInvalidRequestContext)
+	}
+	stalled := findCondition(conditions, conditionTypeStalled)
+	if stalled == nil || stalled.Status != metav1.ConditionTrue || stalled.Reason != EventReasonInvalidRequestContext {
+		t.Fatalf("Stalled condition = %+v, want True/%s", stalled, EventReasonInvalidRequestContext)
+	}
+
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, corev1.EventTypeWarning+" "+EventReasonInvalidRequestContext) ||
+			!strings.Contains(event, "request ID provider is not registered") {
+			t.Fatalf("event = %q, want actionable InvalidRequestContext warning", event)
+		}
+	default:
+		t.Fatal("expected InvalidRequestContext warning event")
+	}
+}
+
+func TestHandlePollError_RequestContextFailureIsPermanent(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &InternalDatabaseReconciler{Recorder: record.NewFakeRecorder(1)}
+	database := &dbaasv1.InternalDatabase{
+		ObjectMeta: metav1.ObjectMeta{Generation: 3},
+		Status:     dbaasv1.InternalDatabaseStatus{OperatorStatus: dbaasv1.OperatorStatus{Phase: dbaasv1.PhaseWaitingForDependency}},
+	}
+	contextErr := &aggregatorclient.RequestContextError{Cause: errors.New("request ID context is not initialized")}
+
+	result, err := reconciler.handlePollError(context.Background(), database, "tracking-123", "request-123", contextErr)
+	if err != nil {
+		t.Fatalf("handlePollError() error = %v, want nil", err)
+	}
+	if !result.IsZero() {
+		t.Fatalf("handlePollError() result = %+v, want zero result", result)
+	}
+	if database.Status.Phase != dbaasv1.PhaseInvalidConfiguration {
+		t.Fatalf("phase = %q, want %q", database.Status.Phase, dbaasv1.PhaseInvalidConfiguration)
+	}
+	stalled := findCondition(database.Status.Conditions, conditionTypeStalled)
+	if stalled == nil || stalled.Status != metav1.ConditionTrue || stalled.Reason != EventReasonInvalidRequestContext {
+		t.Fatalf("Stalled condition = %+v, want True/%s", stalled, EventReasonInvalidRequestContext)
+	}
+}
 
 // TestSetCondition_LastTransitionTime verifies that LastTransitionTime follows
 // Kubernetes API conventions: it is preserved when Status is unchanged,

--- a/dbaas-operator/internal/controller/internaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller.go
@@ -74,8 +74,7 @@ type InternalDatabaseReconciler struct {
 }
 
 func (r *InternalDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
-	// requestID is stored in ctx; sub-methods retrieve it via requestIDFromContext.
-	ctx, _ = initReconcileContext(ctx)
+	ctx, requestID := initReconcileContext(ctx)
 
 	dd := &dbaasv1.InternalDatabase{}
 	if err := r.Get(ctx, req.NamespacedName, dd); err != nil {
@@ -133,14 +132,17 @@ func (r *InternalDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	recordReconcileTrigger(controllerIDB, trigger)
 
 	if dd.Status.TrackingID != "" {
-		return r.reconcilePoll(ctx, dd)
+		return r.reconcilePoll(ctx, dd, requestID)
 	}
-	return r.reconcileSubmit(ctx, dd)
+	return r.reconcileSubmit(ctx, dd, requestID)
 }
 
 // reconcileSubmit handles the SUBMIT branch: pre-flight validation + POST /apply.
-func (r *InternalDatabaseReconciler) reconcileSubmit(ctx context.Context, dd *dbaasv1.InternalDatabase) (ctrl.Result, error) {
-	requestID := requestIDFromContext(ctx)
+func (r *InternalDatabaseReconciler) reconcileSubmit(
+	ctx context.Context,
+	dd *dbaasv1.InternalDatabase,
+	requestID string,
+) (ctrl.Result, error) {
 	dd.Status.Phase = dbaasv1.PhaseProcessing
 
 	if msg := validateInternalDatabaseSpec(dd); msg != "" {
@@ -194,9 +196,11 @@ func (r *InternalDatabaseReconciler) reconcileSubmit(ctx context.Context, dd *db
 }
 
 // reconcilePoll handles the POLL branch: GET /operation/{trackingId}/status.
-func (r *InternalDatabaseReconciler) reconcilePoll(ctx context.Context, dd *dbaasv1.InternalDatabase) (ctrl.Result, error) {
-	requestID := requestIDFromContext(ctx)
-
+func (r *InternalDatabaseReconciler) reconcilePoll(
+	ctx context.Context,
+	dd *dbaasv1.InternalDatabase,
+	requestID string,
+) (ctrl.Result, error) {
 	trackingID := dd.Status.TrackingID
 	log.DebugC(ctx, "polling operation status trackingId=%v", trackingID)
 
@@ -449,6 +453,12 @@ func (r *InternalDatabaseReconciler) handlePollError(
 	requestID string,
 	err error,
 ) (ctrl.Result, error) {
+	var requestContextErr *aggregatorclient.RequestContextError
+	if errors.As(err, &requestContextErr) {
+		return handleAggregatorError(&dd.Status.Phase, &dd.Status.Conditions, dd.Generation,
+			r.Recorder, dd, err, requestID)
+	}
+
 	var aggErr *aggregatorclient.AggregatorError
 	if errors.As(err, &aggErr) {
 		if aggErr.IsAuthError() {

--- a/dbaas-operator/internal/controller/internaldatabase_controller_test.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,6 +62,7 @@ var _ = Describe("InternalDatabase Controller", func() {
 		pollCode           int
 		pollBody           string
 		capturedApplyBody  []byte
+		capturedRequestID  string
 		createCode         int
 		capturedCreateBody []byte
 		createPath         string
@@ -88,6 +90,7 @@ var _ = Describe("InternalDatabase Controller", func() {
 		pollCode = http.StatusOK
 		pollBody = statusCompleted
 		capturedApplyBody = nil
+		capturedRequestID = ""
 		createCode = http.StatusOK
 		capturedCreateBody = nil
 		createPath = ""
@@ -98,6 +101,7 @@ var _ = Describe("InternalDatabase Controller", func() {
 
 			if r.Method == http.MethodPost && r.URL.Path == "/api/declarations/v1/apply" {
 				capturedApplyBody, _ = io.ReadAll(r.Body)
+				capturedRequestID = r.Header.Get(xrequestid.X_REQUEST_ID_HEADER_NAME)
 				w.WriteHeader(applyCode)
 				if applyBody != "" {
 					_, _ = w.Write([]byte(applyBody))
@@ -646,7 +650,7 @@ var _ = Describe("InternalDatabase Controller", func() {
 	// ── HTTP 200 — synchronous success ───────────────────────────────────────
 
 	Context("HTTP 200 — database provisioned synchronously", func() {
-		It("sets Phase=Succeeded, Ready=True, Stalled=False, emits Normal/DatabaseProvisioned, does not requeue", func() {
+		It("propagates status.lastRequestId, sets successful status, emits DatabaseProvisioned, and does not requeue", func() {
 			applyCode = http.StatusOK
 			applyBody = statusCompleted
 			Expect(k8sClient.Create(ctx, &dbaasv1.InternalDatabase{
@@ -661,6 +665,9 @@ var _ = Describe("InternalDatabase Controller", func() {
 			Expect(dd.Status.Phase).To(Equal(dbaasv1.PhaseSucceeded))
 			Expect(dd.Status.ObservedGeneration).To(Equal(dd.Generation))
 			Expect(dd.Status.TrackingID).To(BeEmpty())
+			Expect(capturedRequestID).NotTo(BeEmpty())
+			Expect(capturedRequestID).To(Equal(dd.Status.LastRequestID),
+				"the reconciler request ID stored in status must reach the aggregator")
 
 			ready := findCondition(dd.Status.Conditions, conditionTypeReady)
 			Expect(ready).NotTo(BeNil())

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -46,12 +46,13 @@ const (
 	triggerSiblingSecretClaim     = "sibling_secret_claim_change"
 	triggerSafetyNet              = "safety_net"
 
-	resultSuccess          = "success"
-	resultAuthError        = "auth_error"
-	resultSpecRejection    = "spec_rejection"
-	resultDatabaseNotFound = "database_not_found"
-	resultServerError      = "server_error"
-	resultNetworkError     = "network_error"
+	resultSuccess            = "success"
+	resultAuthError          = "auth_error"
+	resultSpecRejection      = "spec_rejection"
+	resultDatabaseNotFound   = "database_not_found"
+	resultConfigurationError = "configuration_error"
+	resultServerError        = "server_error"
+	resultNetworkError       = "network_error"
 
 	asyncResultFailed     = "failed"
 	asyncResultTerminated = "terminated"
@@ -113,9 +114,9 @@ var dbaasAggregatorRequestDurationSeconds = prometheus.NewHistogramVec(
 
 // dbaasAggregatorRequestsTotal counts aggregator calls by controller, operation,
 // and result. The result label distinguishes user errors (spec_rejection) from
-// platform errors (auth_error, server_error). database_not_found is a normal
-// DatabaseSecretClaim waiting state and should not be routed as an aggregator
-// server failure.
+// operator wiring errors (configuration_error) and platform errors (auth_error,
+// server_error). database_not_found is a normal DatabaseSecretClaim waiting
+// state and should not be routed as an aggregator server failure.
 var dbaasAggregatorRequestsTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "dbaas_aggregator_requests_total",
@@ -163,6 +164,10 @@ func recordAggregatorCall(controller, operation string, start time.Time, err err
 func aggregatorResult(err error) string {
 	if err == nil {
 		return resultSuccess
+	}
+	var requestContextErr *aggregatorclient.RequestContextError
+	if errors.As(err, &requestContextErr) {
+		return resultConfigurationError
 	}
 	var aggErr *aggregatorclient.AggregatorError
 	if errors.As(err, &aggErr) {

--- a/dbaas-operator/internal/controller/metrics_test.go
+++ b/dbaas-operator/internal/controller/metrics_test.go
@@ -18,6 +18,8 @@ func TestAggregatorResultClassifiesOwnershipBuckets(t *testing.T) {
 		{name: "auth", err: &aggregatorclient.AggregatorError{StatusCode: 401}, want: resultAuthError},
 		{name: "spec rejection", err: &aggregatorclient.AggregatorError{StatusCode: 409}, want: resultSpecRejection},
 		{name: "database not found", err: &aggregatorclient.AggregatorError{StatusCode: 404, TmfCode: "CORE-DBAAS-4006"}, want: resultDatabaseNotFound},
+		{name: "configuration", err: &aggregatorclient.RequestContextError{Cause: errors.New("request ID missing")}, want: resultConfigurationError},
+		{name: "wrapped configuration", err: fmt.Errorf("wrapped: %w", &aggregatorclient.RequestContextError{Cause: errors.New("provider missing")}), want: resultConfigurationError},
 		{name: "server", err: &aggregatorclient.AggregatorError{StatusCode: 500}, want: resultServerError},
 		{name: "wrapped server", err: fmt.Errorf("wrapped: %w", &aggregatorclient.AggregatorError{StatusCode: 503}), want: resultServerError},
 		{name: "network", err: errors.New("dial tcp: connection refused"), want: resultNetworkError},

--- a/dbaas-operator/internal/controller/suite_test.go
+++ b/dbaas-operator/internal/controller/suite_test.go
@@ -23,12 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,6 +36,7 @@ import (
 	httpserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	dbaasv1 "github.com/netcracker/qubership-dbaas/dbaas-operator/api/v1"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -63,13 +61,9 @@ func TestControllers(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctxmanager.Register([]ctxmanager.ContextProvider{
-		xrequestid.XRequestIdProvider{},
-	})
+	requestcontext.RegisterProviders()
 
-	baseCtx := ctxmanager.InitContext(context.Background(), map[string]any{
-		xRequestID: uuid.New().String(),
-	})
+	baseCtx, _ := requestcontext.WithFreshRequestID(context.Background())
 	ctx, cancel = context.WithCancel(baseCtx)
 
 	var err error

--- a/dbaas-operator/internal/poller/rotation_poller.go
+++ b/dbaas-operator/internal/poller/rotation_poller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aggregatorclient "github.com/netcracker/qubership-dbaas/dbaas-operator/internal/client"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 )
 
 // DefaultLimit is the page size requested per poll. Excess changes are drained on
@@ -107,6 +108,10 @@ func (p *RotationPoller) Start(ctx context.Context) error {
 // rotations — already synced by the startup reconcile — are not replayed. A failed
 // seed returns nil so the next tick retries it.
 func (p *RotationPoller) pollOnce(ctx context.Context, cursor *aggregatorclient.ChangeCursor, limit int) *aggregatorclient.ChangeCursor {
+	// Give each poll iteration its own correlation scope instead of reusing an ID
+	// inherited from the long-lived manager context.
+	ctx, _ = requestcontext.WithFreshRequestID(ctx)
+
 	if cursor == nil {
 		resp, err := p.Source.GetChangedSince(ctx, nil, 0)
 		if err != nil {

--- a/dbaas-operator/internal/poller/rotation_poller_test.go
+++ b/dbaas-operator/internal/poller/rotation_poller_test.go
@@ -19,11 +19,21 @@ package poller
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
+
 	aggregatorclient "github.com/netcracker/qubership-dbaas/dbaas-operator/internal/client"
+	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/requestcontext"
 )
+
+func TestMain(m *testing.M) {
+	requestcontext.RegisterProviders()
+	os.Exit(m.Run())
+}
 
 // fakeSource is a stub ChangedSource that records the cursors it was called with
 // and returns a fixed response/error.
@@ -39,6 +49,40 @@ func (f *fakeSource) GetChangedSince(_ context.Context, cursor *aggregatorclient
 		return nil, f.err
 	}
 	return f.resp, nil
+}
+
+type requestIDSource struct {
+	requestIDs []string
+}
+
+func (s *requestIDSource) GetChangedSince(ctx context.Context, _ *aggregatorclient.ChangeCursor, _ int) (*aggregatorclient.ChangedDatabasesResponse, error) {
+	requestID, err := xrequestid.Of(ctx)
+	if err != nil {
+		s.requestIDs = append(s.requestIDs, "")
+	} else {
+		s.requestIDs = append(s.requestIDs, requestID.GetRequestId())
+	}
+	return &aggregatorclient.ChangedDatabasesResponse{}, nil
+}
+
+func TestPollOnce_InitializesFreshRequestID(t *testing.T) {
+	src := &requestIDSource{}
+	p := &RotationPoller{Client: newFakeClient(), Source: src}
+
+	p.pollOnce(context.Background(), nil, DefaultLimit)
+	p.pollOnce(context.Background(), nil, DefaultLimit)
+
+	if len(src.requestIDs) != 2 {
+		t.Fatalf("request IDs = %v, want two", src.requestIDs)
+	}
+	for _, requestID := range src.requestIDs {
+		if _, err := uuid.Parse(requestID); err != nil {
+			t.Errorf("request ID %q is not a UUID: %v", requestID, err)
+		}
+	}
+	if src.requestIDs[0] == src.requestIDs[1] {
+		t.Errorf("poll iterations reused request ID %q", src.requestIDs[0])
+	}
 }
 
 func TestPollOnce_SeedFromHighWaterMark(t *testing.T) {

--- a/dbaas-operator/internal/requestcontext/context.go
+++ b/dbaas-operator/internal/requestcontext/context.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package requestcontext centralizes the operator's X-Request-Id lifecycle.
+package requestcontext
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/baseproviders/xrequestid"
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
+)
+
+// RegisterProviders registers every context provider required by the operator.
+// It must run during process startup, before any context is initialized or read.
+func RegisterProviders() {
+	ctxmanager.Register([]ctxmanager.ContextProvider{xrequestid.XRequestIdProvider{}})
+}
+
+// WithFreshRequestID creates a new correlation scope and returns both the
+// enriched context and the generated ID used by status and event reporting.
+func WithFreshRequestID(ctx context.Context) (context.Context, string) {
+	id := uuid.New().String()
+	return ctxmanager.InitContext(ctx, map[string]any{
+		xrequestid.X_REQUEST_ID_HEADER_NAME: id,
+	}), id
+}
+
+// RequestID returns the initialized request ID with an actionable error that
+// distinguishes missing startup registration from a caller that omitted setup.
+func RequestID(ctx context.Context) (string, error) {
+	if _, err := ctxmanager.GetProvider(xrequestid.X_REQUEST_ID_COTEXT_NAME); err != nil {
+		return "", fmt.Errorf("request ID provider is not registered; register context providers during process startup: %w", err)
+	}
+
+	requestID, err := xrequestid.Of(ctx)
+	if err != nil {
+		return "", fmt.Errorf("request ID context is not initialized; call WithFreshRequestID before invoking the aggregator: %w", err)
+	}
+	if requestID.GetRequestId() == "" {
+		return "", fmt.Errorf("request ID context contains an empty %s value; initialize a fresh request context before invoking the aggregator",
+			xrequestid.X_REQUEST_ID_HEADER_NAME)
+	}
+	return requestID.GetRequestId(), nil
+}

--- a/dbaas-operator/internal/requestcontext/context_test.go
+++ b/dbaas-operator/internal/requestcontext/context_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestcontext
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestMain(m *testing.M) {
+	RegisterProviders()
+	os.Exit(m.Run())
+}
+
+func TestWithFreshRequestID(t *testing.T) {
+	t.Parallel()
+
+	ctx, generated := WithFreshRequestID(context.Background())
+	if _, err := uuid.Parse(generated); err != nil {
+		t.Fatalf("generated request ID %q is not a UUID: %v", generated, err)
+	}
+
+	got, err := RequestID(ctx)
+	if err != nil {
+		t.Fatalf("RequestID() error = %v", err)
+	}
+	if got != generated {
+		t.Fatalf("RequestID() = %q, want %q", got, generated)
+	}
+}
+
+func TestRequestIDExplainsUninitializedContext(t *testing.T) {
+	t.Parallel()
+
+	_, err := RequestID(context.Background())
+	if err == nil {
+		t.Fatal("expected an uninitialized context error")
+	}
+	if !strings.Contains(err.Error(), "call WithFreshRequestID") {
+		t.Fatalf("error = %q, want actionable WithFreshRequestID guidance", err)
+	}
+}


### PR DESCRIPTION
## Fix

Previously, the operator generated an `X-Request-Id` for each reconcile and exposed it through logs and `status.lastRequestId`, but the ID was not included in requests sent to dbaas-aggregator.

This change:

- propagates the request ID through the shared Resty client for every aggregator endpoint;
- generates a fresh request ID for every reconcile and rotation-poller iteration;
- centralizes provider registration and request-ID initialization;
- validates the request context before sending the request;
- classifies missing or invalid request context as permanent `InvalidConfiguration` / `Stalled=True` instead of a retryable network failure;
- reports these failures as `configuration_error` in aggregator request metrics;
- adds regression coverage for startup registration, HTTP header propagation, controller status handling, InternalDatabase polling, and the rotation poller.

The request ID sent to the aggregator now matches the ID associated with the corresponding operator operation, enabling correlation between operator and aggregator logs.

## Scope

Each poll and reconcile propagates its own request ID. Linking a poll request to the multiple reconciles it asynchronously triggers through Kubernetes requires a separate parent-correlation design and is outside the scope of this PR.