### PR TITLE
fix: wait for source database readiness before backup

### DIFF
--- a/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/processengine/tasks/BackupDatabaseTask.java
+++ b/dbaas/dbaas-aggregator/src/main/java/com/netcracker/cloud/dbaas/service/processengine/tasks/BackupDatabaseTask.java
@@ -2,6 +2,7 @@ package com.netcracker.cloud.dbaas.service.processengine.tasks;
 
 import com.netcracker.cloud.dbaas.dto.bluegreen.CloneDatabaseProcessObject;
 import com.netcracker.cloud.dbaas.entity.pg.DatabaseRegistry;
+import com.netcracker.cloud.dbaas.entity.shared.AbstractDbState.DatabaseStateStatus;
 import com.netcracker.cloud.dbaas.repositories.dbaas.LogicalDbDbaasRepository;
 import com.netcracker.cloud.dbaas.service.BlueGreenService;
 import com.netcracker.core.scheduler.po.DataContext;
@@ -46,7 +47,11 @@ public class BackupDatabaseTask extends AbstractDbaaSTask implements Serializabl
             if (databaseRegistry.isEmpty()) {
                 throw new RuntimeException("Can't find source DB with classifier " + sourceClassifier);
             }
-            sourceRegistry.set(databaseRegistry.get());
+            DatabaseRegistry registry = databaseRegistry.get();
+            if (!isSourceDatabaseReady(registry)) {
+                throw new RuntimeException("Source DB with classifier " + sourceClassifier + " is not ready");
+            }
+            sourceRegistry.set(registry);
         });
 
         updateState(context, "Backup source DB with classifier " + sourceClassifier, false);
@@ -55,5 +60,12 @@ public class BackupDatabaseTask extends AbstractDbaaSTask implements Serializabl
         UUID backupId = cloneDatabaseProcessObject.getBackupId();
         blueGreenService.createDatabaseBackup(backupId, sourceNamespace, sourceDatabaseId);
         log.debug("Done '{}' task with databaseId = {}", super.getName(), sourceDatabaseId);
+    }
+
+    private boolean isSourceDatabaseReady(DatabaseRegistry databaseRegistry) {
+        return databaseRegistry.getDatabase() != null
+                && DatabaseStateStatus.CREATED.equals(databaseRegistry.getDbState().getDatabaseState())
+                && databaseRegistry.getAdapterId() != null
+                && !databaseRegistry.getAdapterId().isBlank();
     }
 }

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/processengine/tasks/BackupDatabaseTaskTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/processengine/tasks/BackupDatabaseTaskTest.java
@@ -62,26 +62,24 @@ class BackupDatabaseTaskTest {
 
     @Test
     void testExecuteTask_shouldWaitUntilSourceDatabaseIsReady() {
-        UUID registryId = UUID.randomUUID();
-        DatabaseRegistry processingRegistry = databaseRegistry(registryId, PROCESSING, POSTGRES_ADAPTER_ID);
-        DatabaseRegistry registryWithoutAdapter = databaseRegistry(registryId, CREATED, null);
-        DatabaseRegistry readyRegistry = databaseRegistry(registryId, CREATED, POSTGRES_ADAPTER_ID);
+        DatabaseRegistry processingRegistryWithoutAdapter = databaseRegistry(PROCESSING, null);
+        DatabaseRegistry processingRegistry = databaseRegistry(PROCESSING, POSTGRES_ADAPTER_ID);
+        DatabaseRegistry readyRegistry = databaseRegistry(CREATED, POSTGRES_ADAPTER_ID);
         when(databaseRegistryDbaasRepository.getDatabaseByClassifierAndType(
                 processObject.getSourceClassifier(), processObject.getConfig().getType()))
-                .thenReturn(Optional.empty(), Optional.of(processingRegistry),
-                        Optional.of(registryWithoutAdapter), Optional.of(readyRegistry));
+                .thenReturn(Optional.empty(), Optional.of(processingRegistryWithoutAdapter),
+                        Optional.of(processingRegistry), Optional.of(readyRegistry));
 
         backupDatabaseTask.executeTask(dataContext);
 
         verify(databaseRegistryDbaasRepository, times(4)).getDatabaseByClassifierAndType(
                 processObject.getSourceClassifier(), processObject.getConfig().getType());
-        verify(blueGreenService).createDatabaseBackup(backupId, namespace, registryId);
+        verify(blueGreenService).createDatabaseBackup(backupId, namespace, readyRegistry.getId());
     }
 
     @Test
     void testExecuteTask_shouldStartBackupImmediatelyForReadySourceDatabase() {
-        UUID registryId = UUID.randomUUID();
-        DatabaseRegistry readyRegistry = databaseRegistry(registryId, CREATED, POSTGRES_ADAPTER_ID);
+        DatabaseRegistry readyRegistry = databaseRegistry(CREATED, POSTGRES_ADAPTER_ID);
         when(databaseRegistryDbaasRepository.getDatabaseByClassifierAndType(
                 processObject.getSourceClassifier(), processObject.getConfig().getType()))
                 .thenReturn(Optional.of(readyRegistry));
@@ -90,16 +88,15 @@ class BackupDatabaseTaskTest {
 
         verify(databaseRegistryDbaasRepository).getDatabaseByClassifierAndType(
                 processObject.getSourceClassifier(), processObject.getConfig().getType());
-        verify(blueGreenService).createDatabaseBackup(backupId, namespace, registryId);
+        verify(blueGreenService).createDatabaseBackup(backupId, namespace, readyRegistry.getId());
     }
 
-    private DatabaseRegistry databaseRegistry(UUID registryId,
-                                              AbstractDbState.DatabaseStateStatus state,
+    private DatabaseRegistry databaseRegistry(AbstractDbState.DatabaseStateStatus state,
                                               String adapterId) {
         return new DatabaseBuilder()
                 .state(state)
                 .adapterId(adapterId)
-                .registry(registry -> registry.id(registryId))
+                .registry()
                 .build()
                 .getDatabaseRegistry()
                 .getFirst();

--- a/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/processengine/tasks/BackupDatabaseTaskTest.java
+++ b/dbaas/dbaas-aggregator/src/test/java/com/netcracker/cloud/dbaas/service/processengine/tasks/BackupDatabaseTaskTest.java
@@ -4,57 +4,104 @@ import com.netcracker.cloud.dbaas.dto.bluegreen.CloneDatabaseProcessObject;
 import com.netcracker.cloud.dbaas.dto.declarative.DatabaseDeclaration;
 import com.netcracker.cloud.dbaas.entity.pg.DatabaseDeclarativeConfig;
 import com.netcracker.cloud.dbaas.entity.pg.DatabaseRegistry;
+import com.netcracker.cloud.dbaas.entity.shared.AbstractDbState;
 import com.netcracker.cloud.dbaas.repositories.dbaas.DatabaseRegistryDbaasRepository;
 import com.netcracker.cloud.dbaas.repositories.dbaas.LogicalDbDbaasRepository;
 import com.netcracker.cloud.dbaas.service.BlueGreenService;
+import com.netcracker.cloud.dbaas.utils.DatabaseBuilder;
 import com.netcracker.core.scheduler.po.DataContext;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.netcracker.cloud.dbaas.entity.shared.AbstractDbState.DatabaseStateStatus.CREATED;
+import static com.netcracker.cloud.dbaas.entity.shared.AbstractDbState.DatabaseStateStatus.PROCESSING;
+import static com.netcracker.cloud.dbaas.utils.DatabaseBuilder.PG_TYPE;
+import static com.netcracker.cloud.dbaas.utils.DatabaseBuilder.POSTGRES_ADAPTER_ID;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class BackupDatabaseTaskTest {
-    @Test
-    void executeTask() {
-        UUID registryId = UUID.randomUUID();
-        UUID backupId = UUID.randomUUID();
-        String namespace = "namespace";
+    private final UUID backupId = UUID.randomUUID();
+    private final String namespace = "namespace";
 
-        DataContext dataContext = Mockito.mock(DataContext.class);
-        CloneDatabaseProcessObject processObject = new CloneDatabaseProcessObject();
+    @Mock
+    DataContext dataContext;
+    @Mock
+    BlueGreenService blueGreenService;
+    @Mock
+    LogicalDbDbaasRepository logicalDbDbaasRepository;
+    @Mock
+    DatabaseRegistryDbaasRepository databaseRegistryDbaasRepository;
+    @InjectMocks
+    BackupDatabaseTask backupDatabaseTask;
+
+    private CloneDatabaseProcessObject processObject;
+
+    @BeforeEach
+    void setUp() {
+        DatabaseDeclaration declaration = new DatabaseDeclaration();
+        declaration.setType(PG_TYPE);
+
+        processObject = new CloneDatabaseProcessObject();
         processObject.setBackupId(backupId);
         processObject.setSourceNamespace(namespace);
-        processObject.setConfig(new DatabaseDeclarativeConfig(new DatabaseDeclaration(), new TreeMap<>(), namespace));
-        doReturn(processObject).when(dataContext).get(eq("processObject"));
+        processObject.setSourceClassifier(new TreeMap<>());
+        processObject.setConfig(new DatabaseDeclarativeConfig(declaration, new TreeMap<>(), namespace));
 
-        BlueGreenService blueGreenService = mock(BlueGreenService.class);
-        LogicalDbDbaasRepository logicalDbDbaasRepository = mock(LogicalDbDbaasRepository.class);
-        DatabaseRegistryDbaasRepository databaseRegistryDbaasRepository = mock(DatabaseRegistryDbaasRepository.class);
-        DatabaseRegistry databaseRegistry = mock(DatabaseRegistry.class);
+        when(dataContext.get("processObject")).thenReturn(processObject);
+        when(logicalDbDbaasRepository.getDatabaseRegistryDbaasRepository()).thenReturn(databaseRegistryDbaasRepository);
+    }
 
-        doReturn(null).when(blueGreenService).createDatabaseBackup(backupId, namespace, registryId);
-        doReturn(databaseRegistryDbaasRepository).when(logicalDbDbaasRepository).getDatabaseRegistryDbaasRepository();
-        doReturn(registryId).when(databaseRegistry).getId();
-        AtomicInteger retryCount = new AtomicInteger(0);
-        doAnswer(invocation -> {
-            if (retryCount.incrementAndGet() < 5) {
-                return Optional.empty();
-            } else {
-                return Optional.of(databaseRegistry);
-            }
-        }).when(databaseRegistryDbaasRepository).getDatabaseByClassifierAndType(processObject.getSourceClassifier(), processObject.getConfig().getType());
+    @Test
+    void testExecuteTask_shouldWaitUntilSourceDatabaseIsReady() {
+        UUID registryId = UUID.randomUUID();
+        DatabaseRegistry processingRegistry = databaseRegistry(registryId, PROCESSING, POSTGRES_ADAPTER_ID);
+        DatabaseRegistry registryWithoutAdapter = databaseRegistry(registryId, CREATED, null);
+        DatabaseRegistry readyRegistry = databaseRegistry(registryId, CREATED, POSTGRES_ADAPTER_ID);
+        when(databaseRegistryDbaasRepository.getDatabaseByClassifierAndType(
+                processObject.getSourceClassifier(), processObject.getConfig().getType()))
+                .thenReturn(Optional.empty(), Optional.of(processingRegistry),
+                        Optional.of(registryWithoutAdapter), Optional.of(readyRegistry));
 
-        BackupDatabaseTask backupDatabaseTask = new BackupDatabaseTask();
-        backupDatabaseTask.blueGreenService = blueGreenService;
-        backupDatabaseTask.logicalDbDbaasRepository = logicalDbDbaasRepository;
         backupDatabaseTask.executeTask(dataContext);
-        verify(databaseRegistryDbaasRepository, times(5)).getDatabaseByClassifierAndType(processObject.getSourceClassifier(), processObject.getConfig().getType());
-        verify(blueGreenService, times(1)).createDatabaseBackup(backupId, namespace, registryId);
+
+        verify(databaseRegistryDbaasRepository, times(4)).getDatabaseByClassifierAndType(
+                processObject.getSourceClassifier(), processObject.getConfig().getType());
+        verify(blueGreenService).createDatabaseBackup(backupId, namespace, registryId);
+    }
+
+    @Test
+    void testExecuteTask_shouldStartBackupImmediatelyForReadySourceDatabase() {
+        UUID registryId = UUID.randomUUID();
+        DatabaseRegistry readyRegistry = databaseRegistry(registryId, CREATED, POSTGRES_ADAPTER_ID);
+        when(databaseRegistryDbaasRepository.getDatabaseByClassifierAndType(
+                processObject.getSourceClassifier(), processObject.getConfig().getType()))
+                .thenReturn(Optional.of(readyRegistry));
+
+        backupDatabaseTask.executeTask(dataContext);
+
+        verify(databaseRegistryDbaasRepository).getDatabaseByClassifierAndType(
+                processObject.getSourceClassifier(), processObject.getConfig().getType());
+        verify(blueGreenService).createDatabaseBackup(backupId, namespace, registryId);
+    }
+
+    private DatabaseRegistry databaseRegistry(UUID registryId,
+                                              AbstractDbState.DatabaseStateStatus state,
+                                              String adapterId) {
+        return new DatabaseBuilder()
+                .state(state)
+                .adapterId(adapterId)
+                .registry(registry -> registry.id(registryId))
+                .build()
+                .getDatabaseRegistry()
+                .getFirst();
     }
 }

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/DeclarationsV1IT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/DeclarationsV1IT.java
@@ -172,6 +172,30 @@ class DeclarationsV1IT extends AbstractIT {
     }
 
     @Test
+    @Tag("backup")
+    void testApplyConfig_shouldWaitForSourceDatabaseReadiness() throws IOException, SQLException {
+        String microserviceName = "source-readiness-service";
+        String sourceClassifierValue = "source-readiness-source";
+        String cloneClassifierValue = "source-readiness-clone";
+
+        DeclarativePayload sourceDeclaration = new DeclarativeDBConfigBuilder()
+                .classifier(new ClassifierBuilder().test(sourceClassifierValue).ms(microserviceName))
+                .build().asPayload(TEST_NAMESPACE, microserviceName);
+        DeclarativePayload cloneDeclaration = new DeclarativeDBConfigBuilder()
+                .classifier(new ClassifierBuilder().test(cloneClassifierValue).ms(microserviceName))
+                .initClone(new ClassifierBuilder().test(sourceClassifierValue).ms(microserviceName))
+                .build().asPayload(TEST_NAMESPACE, microserviceName);
+
+        declarativeHelper.applyDeclarativeConfigs(List.of(sourceDeclaration, cloneDeclaration));
+
+        helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE),
+                getSimplePostgresCreateRequest(sourceClassifierValue, microserviceName, TEST_NAMESPACE), 200);
+        DatabaseResponse cloneDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE),
+                getSimplePostgresCreateRequest(cloneClassifierValue, microserviceName, TEST_NAMESPACE), 200);
+        helperV3.checkConnectionPostgres(cloneDatabase);
+    }
+
+    @Test
     void testApplyConfigFail() throws IOException {
         DeclarativePayload waitingDeclarativePayload = new DeclarativeDBConfigBuilder()
                 .classifier(new ClassifierBuilder().test("new").ms(TEST_MICROSERVICE_NAME))

--- a/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/DeclarationsV1IT.java
+++ b/dbaas/dbaas-integration-tests/src/test/java/com/netcracker/it/dbaas/test/declarative/DeclarationsV1IT.java
@@ -172,30 +172,6 @@ class DeclarationsV1IT extends AbstractIT {
     }
 
     @Test
-    @Tag("backup")
-    void testApplyConfig_shouldWaitForSourceDatabaseReadiness() throws IOException, SQLException {
-        String microserviceName = "source-readiness-service";
-        String sourceClassifierValue = "source-readiness-source";
-        String cloneClassifierValue = "source-readiness-clone";
-
-        DeclarativePayload sourceDeclaration = new DeclarativeDBConfigBuilder()
-                .classifier(new ClassifierBuilder().test(sourceClassifierValue).ms(microserviceName))
-                .build().asPayload(TEST_NAMESPACE, microserviceName);
-        DeclarativePayload cloneDeclaration = new DeclarativeDBConfigBuilder()
-                .classifier(new ClassifierBuilder().test(cloneClassifierValue).ms(microserviceName))
-                .initClone(new ClassifierBuilder().test(sourceClassifierValue).ms(microserviceName))
-                .build().asPayload(TEST_NAMESPACE, microserviceName);
-
-        declarativeHelper.applyDeclarativeConfigs(List.of(sourceDeclaration, cloneDeclaration));
-
-        helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE),
-                getSimplePostgresCreateRequest(sourceClassifierValue, microserviceName, TEST_NAMESPACE), 200);
-        DatabaseResponse cloneDatabase = helperV3.createDatabase(String.format(DATABASES_V3, TEST_NAMESPACE),
-                getSimplePostgresCreateRequest(cloneClassifierValue, microserviceName, TEST_NAMESPACE), 200);
-        helperV3.checkConnectionPostgres(cloneDatabase);
-    }
-
-    @Test
     void testApplyConfigFail() throws IOException {
         DeclarativePayload waitingDeclarativePayload = new DeclarativeDBConfigBuilder()
                 .classifier(new ClassifierBuilder().test("new").ms(TEST_MICROSERVICE_NAME))


### PR DESCRIPTION
## What got changed
- Wait for the source database to reach CREATED state and receive a valid adapter ID before starting backup.
- Preserve the existing retry policy for sources that are missing or still provisioning.
