### PR TITLE
docs(operator): correct comments that misstate what the code does

### DIFF
--- a/dbaas-operator/api/v1/balancingrule_types.go
+++ b/dbaas-operator/api/v1/balancingrule_types.go
@@ -116,6 +116,7 @@ type MicroserviceBalancingRuleStatus struct {
 
 // MicroserviceBalancingRule is the Schema for the microservicebalancingrules API.
 // It declares a physical database placement rule for specific microservices in a namespace.
+// The object must be named microservice-balancing-rules, so a namespace can hold only one.
 type MicroserviceBalancingRule struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -222,6 +223,7 @@ type NamespaceBalancingRuleStatus struct {
 
 // NamespaceBalancingRule is the Schema for the namespacebalancingrules API.
 // It declares a namespace-level physical database placement rule.
+// The object must be named namespace-balancing-rules, so a namespace can hold only one.
 type NamespaceBalancingRule struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -321,6 +323,9 @@ type PermanentBalancingRuleStatus struct {
 
 // PermanentBalancingRule is the Schema for the permanentbalancingrules API.
 // It declares a permanent namespace-level physical database placement rule.
+// The object must be named permanent-balancing-rules and must live in the
+// namespace the operator runs in. Any other name or namespace is reported as an
+// invalid configuration, and the rules are not applied.
 type PermanentBalancingRule struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/dbaas-operator/api/v1/classifier_helpers.go
+++ b/dbaas-operator/api/v1/classifier_helpers.go
@@ -62,11 +62,15 @@ func EffectiveClassifier(c Classifier, fallbackNamespace string) Classifier {
 // ClassifierFlatMap converts a Classifier into the flat map shape expected on
 // the wire by dbaas-aggregator (Map<String, Object>). All scalar fields are
 // added as top-level keys; customKeys is added as a nested map[string]any
-// under the "customKeys" key, with each JSON value deserialized. Empty
-// optional fields (namespace, tenantId, customKeys) are omitted entirely so
-// the resulting map matches what the aggregator stores for an equivalent
-// CR — critical for ClassifierIndexKey to produce the same string on both
-// sides of a rotation event.
+// under the "customKeys" key, with each JSON value deserialized. extraKeys are
+// deserialized the same way but flattened onto the top level beside the
+// scalars; an extraKey whose name collides with a typed field is dropped
+// rather than applied, and [ReservedExtraKeys] reports those collisions so a
+// caller can reject the CR instead. Empty optional fields (namespace,
+// tenantId, customKeys) are omitted entirely so the resulting map matches what
+// the aggregator stores for an equivalent CR — critical for
+// [ClassifierIndexKey] to produce the same string on both sides of a rotation
+// event.
 func ClassifierFlatMap(c Classifier) map[string]any {
 	m := make(map[string]any, 4+len(c.CustomKeys)+len(c.ExtraKeys))
 	m["microserviceName"] = c.MicroserviceName
@@ -84,11 +88,10 @@ func ClassifierFlatMap(c Classifier) map[string]any {
 		}
 		m["customKeys"] = customKeys
 	}
-	// extraKeys are flattened onto the top level (legacy open-classifier
-	// compatibility). Reserved keys are skipped defensively: the controllers
-	// reject them during pre-flight validation (there is no CRD CEL rule for
-	// extraKeys), and the typed fields above always win, so a stray reserved
-	// extraKey can never corrupt identity.
+	// Flattening rather than nesting is legacy open-classifier compatibility.
+	// Skipping reserved names is a backstop: no CRD CEL rule covers extraKeys,
+	// so the controllers' pre-flight validation is the only other place a
+	// collision is caught.
 	for k, v := range c.ExtraKeys {
 		if _, reserved := reservedClassifierKeys[k]; reserved {
 			continue
@@ -98,10 +101,13 @@ func ClassifierFlatMap(c Classifier) map[string]any {
 	return m
 }
 
-// reservedClassifierKeys are the top-level keys owned by the typed Classifier
-// fields. extraKeys may not shadow them: the controllers reject such a key during
-// pre-flight validation, and the check in ClassifierFlatMap is a defensive backstop
-// for objects that were admitted before that check existed.
+// reservedClassifierKeys are the wire keys the typed [Classifier] fields own: the
+// JSON name of every field except extraKeys itself, which may legitimately appear
+// as a flattened key. A new typed field on Classifier needs a new entry here.
+//
+// extraKeys may not shadow a reserved key. [ReservedExtraKeys] reports the
+// collision so a controller can reject the spec during pre-flight validation, and
+// [ClassifierFlatMap] drops the entry regardless, so the typed field always wins.
 var reservedClassifierKeys = map[string]struct{}{
 	"microserviceName": {},
 	"scope":            {},

--- a/dbaas-operator/api/v1/common_types.go
+++ b/dbaas-operator/api/v1/common_types.go
@@ -94,8 +94,6 @@ type Classifier struct {
 //
 // InternalDatabase additionally uses WaitingForDependency while polling
 // an asynchronous provisioning operation in dbaas-aggregator.
-// ExternalDatabase and DatabaseAccessPolicy never transition into WaitingForDependency —
-// their reconcile flows are fully synchronous.
 //
 // Phase is an observational summary for humans, not an API contract: it exists so
 // that `kubectl get` can show a single readable column, which conditions cannot
@@ -119,8 +117,7 @@ const (
 
 	// PhaseWaitingForDependency indicates the controller is polling an
 	// asynchronous provisioning operation in dbaas-aggregator (HTTP 202 +
-	// trackingId flow). Used only by InternalDatabase — ExternalDatabase
-	// and DatabaseAccessPolicy have synchronous reconcile flows and never use this phase.
+	// trackingId flow). Used only by InternalDatabase.
 	PhaseWaitingForDependency Phase = "WaitingForDependency"
 
 	// PhaseSucceeded indicates the resource was successfully processed by dbaas-aggregator.
@@ -154,17 +151,31 @@ type OperatorStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// conditions represent the current state of the resource.
-	// Ready is True when the current generation was successfully processed;
-	// False on any error, with Reason carrying the error category. Success
-	// reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-	// (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-	// ProvisioningStarted while the async operation runs), BindingRegistered
-	// (NamespaceBinding; BindingBlocked while deletion is deferred,
-	// BindingReleased once only other controllers' finalizers keep the object
-	// alive, OwnershipCheckError when listing blocking resources fails).
-	// Stalled=True marks a permanent error; the controller does not retry
-	// until the spec changes. Stalled=False covers successful, ongoing, and
-	// retriable states.
+	// Ready is True when the current generation was successfully processed and
+	// False on any error, with Message carrying the detail. Stalled is True for a
+	// permanent error, which the controller does not retry until the spec changes,
+	// and False for successful, ongoing, and retriable states. Most reasons below
+	// are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+	// Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+	//
+	// Reasons any kind except NamespaceBinding can report, that one having no spec
+	// to validate and never calling dbaas-aggregator: InvalidSpec and
+	// AggregatorRejected are permanent, Unauthorized and AggregatorError are
+	// retried, and Succeeded is the Stalled reason after a successful reconcile.
+	//
+	// Reasons that belong to one kind:
+	//   - ExternalDatabase: DatabaseRegistered, SecretError.
+	//   - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+	//     asynchronous operation runs, OperationTerminated.
+	//   - DatabaseAccessPolicy: PolicyApplied.
+	//   - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+	//     SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+	//     EmptyConnectionProperties.
+	//   - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+	//     deferred, BindingReleased once only other controllers' finalizers keep
+	//     the object alive, OwnershipCheckError.
+	//   - MicroserviceBalancingRule, NamespaceBalancingRule and
+	//     PermanentBalancingRule: BalancingRuleApplied.
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/dbaas-operator/api/v1/databasesecretclaim_types.go
+++ b/dbaas-operator/api/v1/databasesecretclaim_types.go
@@ -81,15 +81,16 @@ type DatabaseSecretClaimStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // DatabaseSecretClaim is the Schema for the databasesecretclaims API (dbaas.netcracker.com group).
+// It requests dbaas-aggregator to provision credentials for a managed database and write them into
+// a named Kubernetes Secret in the same namespace.
+//
 // The label app.kubernetes.io/name is required — its value is sent as originService in the
-// get-by-classifier request to dbaas-aggregator. It cannot be enforced by CEL: a root-level
-// XValidation rule only sees metadata.name and metadata.generateName, so referencing
-// self.metadata.labels makes the API server reject the whole CRD with "undefined field 'labels'"
-// (controller-gen itself generates such a rule without complaint). The same limit rules out a CEL
-// check that spec.classifier.namespace equals metadata.namespace. Both are therefore enforced by a
-// controller-level pre-flight check before the aggregator is called.
-// It requests dbaas-aggregator to provision credentials for a managed database
-// and write them into a named Kubernetes Secret in the same namespace.
+// get-by-classifier request to dbaas-aggregator. spec.classifier.namespace, when set, must equal
+// metadata.namespace. Neither rule can be enforced by CEL: a root-level XValidation rule only sees
+// metadata.name and metadata.generateName, so referencing self.metadata.labels makes the API server
+// reject the whole CRD with "undefined field 'labels'" (controller-gen itself generates such a rule
+// without complaint). Both are therefore enforced by a controller-level pre-flight check before the
+// aggregator is called.
 type DatabaseSecretClaim struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/dbaas-operator/api/v1/externaldatabase_types.go
+++ b/dbaas-operator/api/v1/externaldatabase_types.go
@@ -98,7 +98,7 @@ type ExternalDatabaseSpec struct {
 	Type string `json:"type"`
 
 	// dbName is the logical database name used by dbaas-aggregator to identify
-	// this registration. Included in the request URL path.
+	// this registration. Sent in the registration request body.
 	// Immutable after creation.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1

--- a/dbaas-operator/api/v1/namespacebinding_types.go
+++ b/dbaas-operator/api/v1/namespacebinding_types.go
@@ -32,7 +32,7 @@ const (
 
 // NamespaceBindingSpec declares the desired namespace ownership.
 type NamespaceBindingSpec struct {
-	// OperatorNamespace is the Kubernetes namespace where the dbaas-operator instance
+	// operatorNamespace is the Kubernetes namespace where the dbaas-operator instance
 	// that owns this namespace is deployed (its CLOUD_NAMESPACE).
 	// It is immutable after creation — change it by deleting and re-creating the NamespaceBinding.
 	//
@@ -81,6 +81,8 @@ type NamespaceBinding struct {
 	Status NamespaceBindingStatus `json:"status,omitempty"`
 }
 
+// SetObservedGeneration stores generation in the object's status. The write stays in
+// memory; the caller writes the status subresource back.
 func (nb *NamespaceBinding) SetObservedGeneration(generation int64) {
 	nb.Status.ObservedGeneration = generation
 }

--- a/dbaas-operator/cmd/credentials_test.go
+++ b/dbaas-operator/cmd/credentials_test.go
@@ -117,6 +117,8 @@ func TestReadCredentials(t *testing.T) {
 
 // ── loadAggregatorCredentials ─────────────────────────────────────────────────
 
+// TestLoadAggregatorCredentials verifies that loadAggregatorCredentials returns the
+// operator username and the password read from users.json in the given directory.
 // Only the success path is unit-tested; the failure path calls os.Exit(1).
 func TestLoadAggregatorCredentials(t *testing.T) {
 	t.Parallel()
@@ -167,8 +169,9 @@ func TestWatchCredentials_ReloadsOnFileChange(t *testing.T) {
 	}
 }
 
-// TestWatchCredentials_ReloadsOnKubernetesSymlinkSwap simulates the atomic
-// "..data" symlink replacement that kubelet performs when a Secret is updated.
+// TestWatchCredentials_ReloadsOnKubernetesSymlinkSwap verifies that replacing the
+// "..data" symlink, the atomic update kubelet performs when a Secret changes,
+// reloads the credentials from the new version directory.
 //
 // Linux-only: inotify (production platform) generates IN_MOVED_TO → Create
 // for the destination of a rename, which our filter catches as base="..data".

--- a/dbaas-operator/cmd/logr_adapter.go
+++ b/dbaas-operator/cmd/logr_adapter.go
@@ -52,6 +52,9 @@ func (a *logrAdapter) WithValues(keysAndValues ...any) logr.LogSink {
 	return &logrAdapter{logger: a.logger, name: a.name, kvs: append(append([]any{}, a.kvs...), keysAndValues...)}
 }
 
+// WithName joins name onto the receiver's name with "/" and logs through the
+// platform logger registered under that joined name, which resolves its own level
+// from the logging configuration. The accumulated key/value pairs carry over.
 func (a *logrAdapter) WithName(name string) logr.LogSink {
 	fullName := name
 	if a.name != "" {
@@ -64,6 +67,8 @@ func (a *logrAdapter) WithName(name string) logr.LogSink {
 	}
 }
 
+// formatMessage appends the pairs in kvs to msg as space-separated key=value
+// text, in the order given. A trailing key with no value is dropped.
 func formatMessage(msg string, kvs []any) string {
 	if len(kvs) == 0 {
 		return msg

--- a/dbaas-operator/cmd/main.go
+++ b/dbaas-operator/cmd/main.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
+	// Import all Kubernetes client auth plugins (Azure, GCP, OIDC, and the rest)
+	// so the operator can authenticate against a cluster that requires one.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
@@ -334,8 +334,7 @@ func main() {
 	}
 	setupLog.Infof("Rotation poller registered interval=%v", pollInterval)
 
-	// In Basic Auth mode, reload the aggregator credentials when the mounted
-	// Secret is updated, so a password rotation is picked up without a restart.
+	// credentialWatcher is set only in Basic Auth mode.
 	if credentialWatcher != nil {
 		if err := mgr.Add(credentialWatcher); err != nil {
 			setupLog.Errorf("Failed to register credential watcher: %v", err)
@@ -382,11 +381,11 @@ func recorderFor(mgr ctrl.Manager, name string, enabled bool) record.EventRecord
 	return noopRecorder{}
 }
 
-// silentEventsTransport is a transport.WrapperFunc that intercepts event POST
-// requests and returns a fake 201 without hitting the API server.  Used as
-// LeaderElectionConfig.WrapTransport when K8S_EVENTS_ENABLED=false, because
-// the leader-election recorder is wired inside controller-runtime and bypasses
-// the per-controller noopRecorder.
+// silentEventsTransport is a transport.WrapperFunc that answers any request whose
+// URL path ends in /events with a 201 and an empty JSON object, without hitting the
+// API server.  Used as LeaderElectionConfig.WrapTransport when
+// K8S_EVENTS_ENABLED=false, because the leader-election recorder is wired
+// inside controller-runtime and bypasses the per-controller noopRecorder.
 func silentEventsTransport(rt http.RoundTripper) http.RoundTripper {
 	return silentEventsRT{rt}
 }

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_databaseaccesspolicies.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_databaseaccesspolicies.yaml
@@ -149,17 +149,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_databasesecretclaims.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_databasesecretclaims.yaml
@@ -36,15 +36,16 @@ spec:
       openAPIV3Schema:
         description: |-
           DatabaseSecretClaim is the Schema for the databasesecretclaims API (dbaas.netcracker.com group).
+          It requests dbaas-aggregator to provision credentials for a managed database and write them into
+          a named Kubernetes Secret in the same namespace.
+
           The label app.kubernetes.io/name is required — its value is sent as originService in the
-          get-by-classifier request to dbaas-aggregator. It cannot be enforced by CEL: a root-level
-          XValidation rule only sees metadata.name and metadata.generateName, so referencing
-          self.metadata.labels makes the API server reject the whole CRD with "undefined field 'labels'"
-          (controller-gen itself generates such a rule without complaint). The same limit rules out a CEL
-          check that spec.classifier.namespace equals metadata.namespace. Both are therefore enforced by a
-          controller-level pre-flight check before the aggregator is called.
-          It requests dbaas-aggregator to provision credentials for a managed database
-          and write them into a named Kubernetes Secret in the same namespace.
+          get-by-classifier request to dbaas-aggregator. spec.classifier.namespace, when set, must equal
+          metadata.namespace. Neither rule can be enforced by CEL: a root-level XValidation rule only sees
+          metadata.name and metadata.generateName, so referencing self.metadata.labels makes the API server
+          reject the whole CRD with "undefined field 'labels'" (controller-gen itself generates such a rule
+          without complaint). Both are therefore enforced by a controller-level pre-flight check before the
+          aggregator is called.
         properties:
           apiVersion:
             description: |-
@@ -164,17 +165,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_externaldatabases.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_externaldatabases.yaml
@@ -207,7 +207,7 @@ spec:
               dbName:
                 description: |-
                   dbName is the logical database name used by dbaas-aggregator to identify
-                  this registration. Included in the request URL path.
+                  this registration. Sent in the registration request body.
                   Immutable after creation.
                 minLength: 1
                 type: string
@@ -236,17 +236,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_internaldatabases.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_internaldatabases.yaml
@@ -258,17 +258,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_microservicebalancingrules.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_microservicebalancingrules.yaml
@@ -34,6 +34,7 @@ spec:
         description: |-
           MicroserviceBalancingRule is the Schema for the microservicebalancingrules API.
           It declares a physical database placement rule for specific microservices in a namespace.
+          The object must be named microservice-balancing-rules, so a namespace can hold only one.
         properties:
           apiVersion:
             description: |-
@@ -133,17 +134,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_namespacebalancingrules.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_namespacebalancingrules.yaml
@@ -34,6 +34,7 @@ spec:
         description: |-
           NamespaceBalancingRule is the Schema for the namespacebalancingrules API.
           It declares a namespace-level physical database placement rule.
+          The object must be named namespace-balancing-rules, so a namespace can hold only one.
         properties:
           apiVersion:
             description: |-
@@ -140,17 +141,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_namespacebindings.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_namespacebindings.yaml
@@ -67,7 +67,7 @@ spec:
             properties:
               operatorNamespace:
                 description: |-
-                  OperatorNamespace is the Kubernetes namespace where the dbaas-operator instance
+                  operatorNamespace is the Kubernetes namespace where the dbaas-operator instance
                   that owns this namespace is deployed (its CLOUD_NAMESPACE).
                   It is immutable after creation — change it by deleting and re-creating the NamespaceBinding.
                 minLength: 1
@@ -92,17 +92,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/config/crd/bases/dbaas.netcracker.com_permanentbalancingrules.yaml
+++ b/dbaas-operator/config/crd/bases/dbaas.netcracker.com_permanentbalancingrules.yaml
@@ -34,6 +34,9 @@ spec:
         description: |-
           PermanentBalancingRule is the Schema for the permanentbalancingrules API.
           It declares a permanent namespace-level physical database placement rule.
+          The object must be named permanent-balancing-rules and must live in the
+          namespace the operator runs in. Any other name or namespace is reported as an
+          invalid configuration, and the rules are not applied.
         properties:
           apiVersion:
             description: |-
@@ -132,17 +135,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/dev/aggregator-mock/main.go
+++ b/dbaas-operator/dev/aggregator-mock/main.go
@@ -83,9 +83,12 @@ import (
 	"github.com/netcracker/qubership-core-lib-go-error-handling/v3/tmf"
 )
 
-// MockRule fully describes the response for a specific dbName or microserviceName.
-// All TmfErrorResponse fields are specified here — the mock contains no hardcoded
-// templates; the ConfigMap is the single source of truth for every response.
+// MockRule fully describes one response. The three files loadRules reads map a key to one of
+// these — dbName, microserviceName, or originService, depending on the endpoint; poll-rules.json,
+// get-by-classifier.json and changed.json carry other shapes. The mock builds a few rules itself,
+// from MOCK_RESPONSE_CODE and from literals such as [authRuleUnauthorized]. All TmfErrorResponse
+// fields are specified here and the mock keeps no per-code templates, so an error body carries
+// exactly what its rule spells out.
 //
 // For 2xx codes TmfCode/Reason/Message are ignored (no error body is returned).
 // For 4xx/5xx codes omitted fields produce empty strings in the JSON output,
@@ -117,7 +120,7 @@ func newPendingCounter(rules map[string]MockRule) *pendingCounter {
 	return &pendingCounter{left: left}
 }
 
-// consume reports whether this call must still answer 202, decrementing the counter.
+// consume reports whether this call must still answer 202, spending one pending answer if so.
 func (p *pendingCounter) consume(key string) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -129,18 +132,19 @@ func (p *pendingCounter) consume(key string) bool {
 }
 
 // MockPollRule describes the poll response for a specific trackingId.
-// HTTPCode overrides the response code (e.g. 404). Status controls the payload.
 type MockPollRule struct {
-	// HTTPCode, when non-zero, returns a non-200 response (e.g. 404).
+	// HTTPCode, when it is neither 0 nor 200, is returned with an empty body (e.g. 404).
 	HTTPCode int `json:"httpCode,omitempty"`
 	// Status is the operation status to return: "COMPLETED", "FAILED", "TERMINATED",
-	// "IN_PROGRESS", "NOT_STARTED". Defaults to "COMPLETED" when HTTPCode is 0.
+	// "IN_PROGRESS", "NOT_STARTED". Defaults to "COMPLETED" when empty.
 	Status string `json:"status,omitempty"`
-	// FailReason is included in the DataBaseCreated condition reason when Status=FAILED.
+	// FailReason, when non-empty, becomes the DataBaseCreated condition's reason and sets
+	// its message to "Failed", whatever Status says.
 	FailReason string `json:"failReason,omitempty"`
 }
 
-// authRuleUnauthorized is the fixed response for a missing/empty Bearer token (401).
+// authRuleUnauthorized is the fixed 401 response for a request that carries neither
+// Basic Auth nor a Bearer token.
 var authRuleUnauthorized = MockRule{
 	HTTPCode: http.StatusUnauthorized,
 	Message:  "Requested role is not allowed",
@@ -228,7 +232,7 @@ func classifierKey(classifier map[string]any, dbType string) string {
 }
 
 // isTenant reports whether a classifier is tenant-scoped (scope=tenant), matched
-// case-insensitively like the operator and aggregator do.
+// case-insensitively as the operator does. The real aggregator compares scope exactly.
 func isTenant(classifier map[string]any) bool {
 	scope, _ := classifier["scope"].(string)
 	return strings.EqualFold(scope, "tenant")
@@ -273,7 +277,7 @@ func main() {
 }
 
 // loadRules reads a JSON file that maps a string key → MockRule.
-// A missing file is not an error.
+// A missing file is not an error; a malformed one is fatal.
 func loadRules(path string) map[string]MockRule {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -293,7 +297,7 @@ func loadRules(path string) map[string]MockRule {
 }
 
 // loadPollRules reads a JSON file that maps trackingId → MockPollRule.
-// A missing file is not an error.
+// A missing file is not an error; a malformed one is fatal.
 func loadPollRules(path string) map[string]MockPollRule {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -313,7 +317,7 @@ func loadPollRules(path string) map[string]MockPollRule {
 }
 
 // loadChanged reads the rotation feed (a JSON array of ChangedEntry).
-// A missing file is not an error — it yields an empty feed.
+// A missing file is not an error — it yields an empty feed; a malformed one is fatal.
 func loadChanged(path string) []ChangedEntry {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -334,7 +338,7 @@ func loadChanged(path string) []ChangedEntry {
 
 // loadGbcRules reads a JSON file mapping originService → connectionProperties.
 // A missing file is not an error — get-by-classifier then falls back to a
-// synthetic default property set for every lookup.
+// synthetic default property set for every lookup. A malformed file is fatal.
 func loadGbcRules(path string) map[string]map[string]any {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -352,6 +356,8 @@ func loadGbcRules(path string) map[string]map[string]any {
 	return rules
 }
 
+// handler routes the mocked aggregator endpoints. Each call builds its own database store
+// and pending-call counters, so two handlers never share materialization state.
 func handler(
 	defaultRule MockRule, rules map[string]MockRule,
 	applyRules map[string]MockRule, pollRules map[string]MockPollRule,
@@ -502,7 +508,9 @@ func handleExternalDB(
 //   - "DatabaseDeclaration"  → 202 IN_PROGRESS with deterministic trackingId
 //
 // An explicit rule in applyRules (keyed by microserviceName) overrides the default.
-// Error rules (4xx/5xx) are returned as TmfErrorResponse regardless of subKind.
+// Error rules (4xx/5xx) are returned as TmfErrorResponse regardless of subKind; a 2xx
+// rule answers COMPLETED with no trackingId, so it cannot stand in for the asynchronous
+// DatabaseDeclaration path.
 func handleApply(w http.ResponseWriter, body []byte, applyRules map[string]MockRule) {
 	var req struct {
 		SubKind  string `json:"subKind"`
@@ -552,7 +560,7 @@ func handleApply(w http.ResponseWriter, body []byte, applyRules map[string]MockR
 		return
 	}
 
-	// DatabaseAccessPolicy and any other subKind: default 200 COMPLETED (synchronous).
+	// DbPolicy (a DatabaseAccessPolicy) and any other subKind: default 200 COMPLETED (synchronous).
 	log.Printf("  → apply config  subKind=%q microserviceName=%q → 200 COMPLETED (default)", req.SubKind, msName)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -681,11 +689,12 @@ func handleChanged(w http.ResponseWriter, r *http.Request, changed []ChangedEntr
 }
 
 // handleGetByClassifier serves POST /api/v3/dbaas/{namespace}/databases/get-by-classifier/{type}.
-// It returns 200 with a DatabaseResponseV3SingleCP-shaped body. connectionProperties
-// come from the per-originService rule when present, otherwise from a synthetic
-// default. Editing a rule's password (and restarting the mock) lets a subsequent
-// rotation fan-out surface a real SecretRotated; the stable default yields the
-// content-aware no-op (SecretUpToDate) on re-fetch.
+// It answers 200 with a DatabaseResponseV3SingleCP-shaped body whenever a per-originService
+// rule supplies connectionProperties. Failing that, a tenant-scoped classifier that no
+// get-or-create has materialized yet gets 404 DatabaseNotFound, and every other request gets
+// the same 200 with a synthetic default property set. Editing a rule's password (and
+// restarting the mock) lets a subsequent rotation fan-out surface a real SecretRotated; the
+// stable default yields the content-aware no-op (SecretUpToDate) on re-fetch.
 func handleGetByClassifier(
 	w http.ResponseWriter, r *http.Request, body []byte,
 	gbcRules map[string]map[string]any, store *dbStore,
@@ -767,10 +776,12 @@ func defaultConnProps(role string) map[string]any {
 
 // handleCreateDatabase serves PUT /api/v3/dbaas/{namespace}/databases — the get-or-create
 // database call the operator issues to materialize a concrete {scope=tenant, tenantId}
-// database for a tenant declaration that pins a tenantId. The response code comes from the
-// per-originService createDbRules rule when present (e.g. to simulate a 500); otherwise the
-// mock returns 200 with a DatabaseResponseV3-shaped body. The operator ignores the body and
-// inspects only the status code, so a minimal descriptor is enough.
+// database for a tenant declaration that pins a tenantId. A rule's PendingCalls budget is
+// spent first: while it lasts the call answers 202 and records nothing, so the database stays
+// invisible to get-by-classifier. After that the response code comes from the per-originService
+// createDbRules rule when present (e.g. to simulate a 500); otherwise the mock returns 200 with
+// a DatabaseResponseV3-shaped body. The operator ignores the body and inspects only the status
+// code, so a minimal descriptor is enough.
 func handleCreateDatabase(
 	w http.ResponseWriter, r *http.Request, body []byte,
 	createDbRules map[string]MockRule, store *dbStore, pending *pendingCounter,
@@ -858,8 +869,8 @@ func writeAcceptedDatabase(w http.ResponseWriter, namespace, dbType string, clas
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-// logRequest logs the incoming request and returns the body bytes.
-// The caller is responsible for passing the body to any handler that needs it.
+// logRequest logs the incoming request and returns the body bytes. It drains r.Body, so a
+// handler must work from the returned slice rather than read the request again.
 func logRequest(r *http.Request) []byte {
 	auth := "none"
 	if user, _, ok := r.BasicAuth(); ok && user != "" {
@@ -950,7 +961,7 @@ func parseTS(s string) (time.Time, error) {
 }
 
 // highWaterMark returns the greatest (lastRotatedAt, id) across the feed as a
-// ChangeCursor-shaped map, or nil when the feed is empty.
+// ChangeCursor-shaped map, or nil when no entry has a parseable lastRotatedAt.
 func highWaterMark(changed []ChangedEntry) any {
 	var maxT time.Time
 	var maxID string

--- a/dbaas-operator/dev/aggregator-mock/main_test.go
+++ b/dbaas-operator/dev/aggregator-mock/main_test.go
@@ -31,9 +31,8 @@ func newTestHandler(defaultCode int, createDbRules map[string]MockRule) http.Han
 	return handler(MockRule{HTTPCode: defaultCode}, nil, nil, nil, nil, nil, createDbRules)
 }
 
-// tenantCreateBody builds a get-or-create request body for a tenant-scoped database,
-// keeping the test lines short (the inline JSON literal would otherwise trip the
-// line-length linter).
+// tenantCreateBody builds a get-or-create request body for a tenant-scoped postgresql
+// database. An empty tenant leaves tenantId out of the classifier.
 func tenantCreateBody(t *testing.T, microservice, tenant string) string {
 	t.Helper()
 	classifier := map[string]any{
@@ -57,7 +56,8 @@ func tenantCreateBody(t *testing.T, microservice, tenant string) string {
 
 const gbcPath = "/api/v3/dbaas/test-ns/databases/get-by-classifier/postgresql"
 
-// gbcReqBody builds a get-by-classifier request body for the given classifier.
+// gbcReqBody builds a get-by-classifier request body for the given classifier,
+// always with userRole "admin".
 func gbcReqBody(t *testing.T, classifier map[string]any, origin string) string {
 	t.Helper()
 	b, err := json.Marshal(map[string]any{
@@ -220,8 +220,8 @@ func TestGetByClassifier_ServiceNoMaterializationNeeded(t *testing.T) {
 }
 
 // TestCreateDatabase_PendingCalls_Returns202ThenCreates reproduces the aggregator's asynchronous
-// creation, which broke tenant materialization before the operator learned to handle it: the first
-// get-or-create answers 202 with no usable credentials, and only a later call returns the database.
+// creation: while a rule's pendingCalls budget lasts, get-or-create answers 202 with no id, no
+// name, and a null password, and only the call past the budget returns the created database.
 // A client that treats the 202 as either success or failure never gets credentials.
 func TestCreateDatabase_PendingCalls_Returns202ThenCreates(t *testing.T) {
 	rules := map[string]MockRule{"slow-svc": {HTTPCode: http.StatusOK, PendingCalls: 2}}

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-databaseaccesspolicies.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-databaseaccesspolicies.yaml
@@ -150,17 +150,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-databasesecretclaims.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-databasesecretclaims.yaml
@@ -37,15 +37,16 @@ spec:
       openAPIV3Schema:
         description: |-
           DatabaseSecretClaim is the Schema for the databasesecretclaims API (dbaas.netcracker.com group).
+          It requests dbaas-aggregator to provision credentials for a managed database and write them into
+          a named Kubernetes Secret in the same namespace.
+
           The label app.kubernetes.io/name is required — its value is sent as originService in the
-          get-by-classifier request to dbaas-aggregator. It cannot be enforced by CEL: a root-level
-          XValidation rule only sees metadata.name and metadata.generateName, so referencing
-          self.metadata.labels makes the API server reject the whole CRD with "undefined field 'labels'"
-          (controller-gen itself generates such a rule without complaint). The same limit rules out a CEL
-          check that spec.classifier.namespace equals metadata.namespace. Both are therefore enforced by a
-          controller-level pre-flight check before the aggregator is called.
-          It requests dbaas-aggregator to provision credentials for a managed database
-          and write them into a named Kubernetes Secret in the same namespace.
+          get-by-classifier request to dbaas-aggregator. spec.classifier.namespace, when set, must equal
+          metadata.namespace. Neither rule can be enforced by CEL: a root-level XValidation rule only sees
+          metadata.name and metadata.generateName, so referencing self.metadata.labels makes the API server
+          reject the whole CRD with "undefined field 'labels'" (controller-gen itself generates such a rule
+          without complaint). Both are therefore enforced by a controller-level pre-flight check before the
+          aggregator is called.
         properties:
           apiVersion:
             description: |-
@@ -165,17 +166,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-externaldatabases.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-externaldatabases.yaml
@@ -208,7 +208,7 @@ spec:
               dbName:
                 description: |-
                   dbName is the logical database name used by dbaas-aggregator to identify
-                  this registration. Included in the request URL path.
+                  this registration. Sent in the registration request body.
                   Immutable after creation.
                 minLength: 1
                 type: string
@@ -237,17 +237,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-internaldatabases.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-internaldatabases.yaml
@@ -259,17 +259,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-microservicebalancingrules.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-microservicebalancingrules.yaml
@@ -35,6 +35,7 @@ spec:
         description: |-
           MicroserviceBalancingRule is the Schema for the microservicebalancingrules API.
           It declares a physical database placement rule for specific microservices in a namespace.
+          The object must be named microservice-balancing-rules, so a namespace can hold only one.
         properties:
           apiVersion:
             description: |-
@@ -134,17 +135,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-namespacebalancingrules.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-namespacebalancingrules.yaml
@@ -35,6 +35,7 @@ spec:
         description: |-
           NamespaceBalancingRule is the Schema for the namespacebalancingrules API.
           It declares a namespace-level physical database placement rule.
+          The object must be named namespace-balancing-rules, so a namespace can hold only one.
         properties:
           apiVersion:
             description: |-
@@ -141,17 +142,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-namespacebindings.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-namespacebindings.yaml
@@ -68,7 +68,7 @@ spec:
             properties:
               operatorNamespace:
                 description: |-
-                  OperatorNamespace is the Kubernetes namespace where the dbaas-operator instance
+                  operatorNamespace is the Kubernetes namespace where the dbaas-operator instance
                   that owns this namespace is deployed (its CLOUD_NAMESPACE).
                   It is immutable after creation — change it by deleting and re-creating the NamespaceBinding.
                 minLength: 1
@@ -93,17 +93,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/helm-templates/dbaas-operator/templates/crd-permanentbalancingrules.yaml
+++ b/dbaas-operator/helm-templates/dbaas-operator/templates/crd-permanentbalancingrules.yaml
@@ -35,6 +35,9 @@ spec:
         description: |-
           PermanentBalancingRule is the Schema for the permanentbalancingrules API.
           It declares a permanent namespace-level physical database placement rule.
+          The object must be named permanent-balancing-rules and must live in the
+          namespace the operator runs in. Any other name or namespace is reported as an
+          invalid configuration, and the rules are not applied.
         properties:
           apiVersion:
             description: |-
@@ -133,17 +136,31 @@ spec:
               conditions:
                 description: |-
                   conditions represent the current state of the resource.
-                  Ready is True when the current generation was successfully processed;
-                  False on any error, with Reason carrying the error category. Success
-                  reasons: DatabaseRegistered (ExternalDatabase), PolicyApplied
-                  (DatabaseAccessPolicy), DatabaseProvisioned (InternalDatabase;
-                  ProvisioningStarted while the async operation runs), BindingRegistered
-                  (NamespaceBinding; BindingBlocked while deletion is deferred,
-                  BindingReleased once only other controllers' finalizers keep the object
-                  alive, OwnershipCheckError when listing blocking resources fails).
-                  Stalled=True marks a permanent error; the controller does not retry
-                  until the spec changes. Stalled=False covers successful, ongoing, and
-                  retriable states.
+                  Ready is True when the current generation was successfully processed and
+                  False on any error, with Message carrying the detail. Stalled is True for a
+                  permanent error, which the controller does not retry until the spec changes,
+                  and False for successful, ongoing, and retriable states. Most reasons below
+                  are also emitted as a Kubernetes event under the same name; SecretUpToDate,
+                  Succeeded, BindingReleased and OwnershipCheckError are condition-only.
+
+                  Reasons any kind except NamespaceBinding can report, that one having no spec
+                  to validate and never calling dbaas-aggregator: InvalidSpec and
+                  AggregatorRejected are permanent, Unauthorized and AggregatorError are
+                  retried, and Succeeded is the Stalled reason after a successful reconcile.
+
+                  Reasons that belong to one kind:
+                    - ExternalDatabase: DatabaseRegistered, SecretError.
+                    - InternalDatabase: DatabaseProvisioned, ProvisioningStarted while the
+                      asynchronous operation runs, OperationTerminated.
+                    - DatabaseAccessPolicy: PolicyApplied.
+                    - DatabaseSecretClaim: SecretCreated, SecretRotated, SecretUpToDate,
+                      SecretConflict (permanent), DatabaseNotFound, DatabaseNotFoundTimeout,
+                      EmptyConnectionProperties.
+                    - NamespaceBinding: BindingRegistered, BindingBlocked while deletion is
+                      deferred, BindingReleased once only other controllers' finalizers keep
+                      the object alive, OwnershipCheckError.
+                    - MicroserviceBalancingRule, NamespaceBalancingRule and
+                      PermanentBalancingRule: BalancingRuleApplied.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.

--- a/dbaas-operator/internal/client/aggregator_client.go
+++ b/dbaas-operator/internal/client/aggregator_client.go
@@ -100,9 +100,10 @@ func (c *AggregatorClient) SetCredentials(username, password string) {
 	c.creds.Store(&credentials{username: username, password: password})
 }
 
-// newClient is the internal constructor used in package-level tests. A non-nil
-// getToken selects M2M (Bearer) mode; nil selects Basic Auth mode, in which case
-// the caller must seed credentials via creds.Store / SetCredentials.
+// newClient is the constructor every exported constructor here delegates to, and
+// package-level tests call it directly. A non-nil getToken selects M2M (Bearer)
+// mode; nil selects Basic Auth mode, in which case the caller must seed
+// credentials via creds.Store or [AggregatorClient.SetCredentials].
 func newClient(baseURL string, getToken func(ctx context.Context) (string, error)) *AggregatorClient {
 	c := &AggregatorClient{getToken: getToken}
 
@@ -149,12 +150,11 @@ func newClient(baseURL string, getToken func(ctx context.Context) (string, error
 	return c
 }
 
-// doRequest sends method+path to the aggregator through the shared resty client
-// (so the auth OnBeforeRequest hook applies), with ctx, an optional JSON body, and
-// an optional prep hook to tweak the request (e.g. query params). It returns the
-// response only when its status is in okCodes; otherwise an *AggregatorError. It
-// centralizes the transport + status-check boilerplate shared by every endpoint;
-// per-endpoint semantics (verb, OK codes, whether/what to decode) stay at the call site.
+// doRequest sends method+path through the shared resty client, so the auth
+// OnBeforeRequest hook applies. body is marshaled as JSON when non-nil, and prep,
+// when non-nil, adjusts the request before it is sent — query parameters, for
+// example. Returns the response only when its status is in okCodes, and an
+// *AggregatorError otherwise.
 func (c *AggregatorClient) doRequest(
 	ctx context.Context, method, path string, body any, prep func(*resty.Request), okCodes ...int,
 ) (*resty.Response, error) {
@@ -231,8 +231,8 @@ func (c *AggregatorClient) ApplyConfig(ctx context.Context, payload *Declarative
 
 // GetOperationStatus polls the status of an asynchronous operation.
 //
-// The trackingId is obtained from a previous ApplyConfig call.  The caller
-// should keep calling this method while the returned Status is TaskStateInProgress.
+// trackingID comes from a previous [AggregatorClient.ApplyConfig] call. Keep
+// calling this method while the returned Status is [TaskStateInProgress].
 //
 // Returns *AggregatorError on non-2xx.
 func (c *AggregatorClient) GetOperationStatus(ctx context.Context, trackingID string) (*DeclarativeResponse, error) {

--- a/dbaas-operator/internal/client/aggregator_client_test.go
+++ b/dbaas-operator/internal/client/aggregator_client_test.go
@@ -51,8 +51,8 @@ func requestContext() context.Context {
 	return contextWithRequestID("client-test-request-id")
 }
 
-// staticToken returns a TokenSource function that always returns the given token.
-// Used in tests to avoid touching the global tokensource state.
+// staticToken returns a getToken function that always returns the given token, so
+// a test never touches the global tokensource state.
 func staticToken(token string) func(context.Context) (string, error) {
 	return func(context.Context) (string, error) { return token, nil }
 }
@@ -412,7 +412,7 @@ func TestRegisterExternalDatabase_ContextCancellation(t *testing.T) {
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(requestContext())
-	cancel() // cancel immediately
+	cancel()
 
 	c := newClient(srv.URL, staticToken("test-token"))
 	err := c.RegisterExternalDatabase(ctx, "ns", minimalExtDBRequest())
@@ -1161,8 +1161,8 @@ func TestGetDatabaseByClassifier_EmptyBodyReturnsError(t *testing.T) {
 	}
 }
 
-// Conversely, the declarative apply/operation-status endpoints DO tolerate an
-// empty body (a success status with no payload yields the zero value, no error).
+// The declarative apply and operation-status endpoints tolerate an empty body: a
+// success status with no payload yields the zero value, not an error.
 func TestGetOperationStatus_EmptyBodyIsZeroValue(t *testing.T) {
 	t.Parallel()
 

--- a/dbaas-operator/internal/client/changed_databases_test.go
+++ b/dbaas-operator/internal/client/changed_databases_test.go
@@ -25,6 +25,11 @@ import (
 	"time"
 )
 
+// A cursor-less call must carry neither sinceTs nor sinceId. Their absence is what makes
+// the aggregator answer with the high-water mark alone and no items, so the poller seeds
+// a baseline instead of replaying every rotation already on record. A limit of 0 must stay
+// off the query as well: the aggregator rejects any limit below 1 with HTTP 400 and applies
+// its own page size when the parameter is absent.
 func TestGetChangedSince_SeedCallOmitsCursorParams(t *testing.T) {
 	hwm := ChangeCursor{LastRotatedAt: time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC), ID: "11111111-1111-1111-1111-111111111111"}
 	var gotMethod, gotPath, gotSinceTs, gotSinceID, gotLimit string
@@ -64,6 +69,11 @@ func TestGetChangedSince_SeedCallOmitsCursorParams(t *testing.T) {
 	}
 }
 
+// A non-nil cursor must reach the aggregator as sinceTs plus sinceId, with sinceTs
+// formatted RFC3339Nano so the sub-second part of the cursor is not lost — the aggregator
+// selects rows strictly after (sinceTs, sinceId), so a coarser timestamp would hand back
+// rotations that were already fanned out. The returned items must decode into a
+// ChangedDatabaseRef with its identity and timestamp intact.
 func TestGetChangedSince_SendsCursorParamsAndParsesItems(t *testing.T) {
 	cursor := ChangeCursor{LastRotatedAt: time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC), ID: "22222222-2222-2222-2222-222222222222"}
 	next := cursor.LastRotatedAt.Add(time.Minute)

--- a/dbaas-operator/internal/client/types.go
+++ b/dbaas-operator/internal/client/types.go
@@ -235,7 +235,8 @@ type DatabaseResponseSingleCP struct {
 // rotation or restore), as returned by GET /api/v3/dbaas/databases/changed. It
 // carries only the identity needed to locate the consuming DatabaseSecretClaim
 // CR(s); connection properties are fetched separately via GetDatabaseByClassifier.
-// Id together with LastRotatedAt forms the keyset cursor the poller advances by.
+// ID is the aggregator's registry id, one row per classifier rather than one per
+// database, and with LastRotatedAt it forms the keyset cursor the poller advances by.
 type ChangedDatabaseRef struct {
 	ID            string         `json:"id"`
 	Namespace     string         `json:"namespace"`

--- a/dbaas-operator/internal/controller/balancingrule_controller.go
+++ b/dbaas-operator/internal/controller/balancingrule_controller.go
@@ -56,6 +56,8 @@ import (
 
 // BalancingRuleReconciler reconciles the three balancing-rule CRDs into the
 // existing dbaas-aggregator balancing rule administration APIs.
+// [BalancingRuleReconciler.SetupWithManager] runs one controller per CRD, so
+// each has its own entry point instead of a shared Reconcile method.
 type BalancingRuleReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme
@@ -67,6 +69,11 @@ type BalancingRuleReconciler struct {
 	bindingTriggerTracker
 }
 
+// generationOrLifecycleChangedPredicate admits creates, deletes, and generic
+// events unconditionally, and an update only when the generation, the deletion
+// timestamp, or the finalizer list changed. Finalizer and deletion-timestamp
+// writes leave the generation untouched, so watching the generation alone would
+// swallow the reconcile that has to follow the controller's own finalizer patch.
 func generationOrLifecycleChangedPredicate() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(event.CreateEvent) bool {
@@ -93,6 +100,11 @@ func generationOrLifecycleChangedPredicate() predicate.Funcs {
 	}
 }
 
+// ReconcileMicroservice applies the MicroserviceBalancingRule singleton to the
+// aggregator in a single call carrying every rule in the spec. It proceeds only
+// in namespaces the operator owns; on its first pass it adds the cleanup
+// finalizer and returns, so no aggregator state is ever created for a resource
+// the operator could not later clean up.
 func (r *BalancingRuleReconciler) ReconcileMicroservice(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	ctx, requestID := initReconcileContext(ctx)
 
@@ -164,6 +176,12 @@ func (r *BalancingRuleReconciler) ReconcileMicroservice(ctx context.Context, req
 	return ctrl.Result{}, nil
 }
 
+// ReconcileNamespace applies the NamespaceBalancingRule singleton to the
+// aggregator one rule at a time, so a reconcile can end with the aggregator
+// holding part of the spec. status.appliedRules is what the aggregator has
+// accepted, in the order it was applied, and it is the list the deletion path
+// cleans up. Ownership gating and the cleanup finalizer work as in
+// [BalancingRuleReconciler.ReconcileMicroservice].
 func (r *BalancingRuleReconciler) ReconcileNamespace(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	ctx, requestID := initReconcileContext(ctx)
 
@@ -215,8 +233,6 @@ func (r *BalancingRuleReconciler) ReconcileNamespace(ctx context.Context, req ct
 		return invalidSpec(ctx, &rule.Status.Phase, &rule.Status.Conditions, rule.Generation, r.Recorder, rule, msg)
 	}
 
-	// Prune removed rules before applying desired rules. A mid-list delete failure
-	// leaves still-live rules in status so later reconciles can retry cleanup.
 	if err := r.cleanupSupersededNamespaceRules(ctx, rule); err != nil {
 		return handleAggregatorError(&rule.Status.Phase, &rule.Status.Conditions, rule.Generation, r.Recorder, rule, err, requestID)
 	}
@@ -244,7 +260,6 @@ func (r *BalancingRuleReconciler) ReconcileNamespace(ctx context.Context, req ct
 		rule.Status.AppliedRules = out
 	}
 
-	// Apply desired rules; upsert into the applied set only on a successful apply.
 	for _, item := range rule.Spec.Rules {
 		aggStart := time.Now()
 		err = r.Aggregator.ApplyNamespaceBalancingRule(ctx, rule.Namespace, item.Name, namespaceRequestFromSpecItem(item))
@@ -271,6 +286,11 @@ func (r *BalancingRuleReconciler) ReconcileNamespace(ctx context.Context, req ct
 	return ctrl.Result{}, nil
 }
 
+// ReconcilePermanent applies the PermanentBalancingRule singleton to the
+// aggregator in a single call carrying every rule in the spec. It has no
+// ownership gate, because the resource is only valid in the operator's own
+// namespace and needs no NamespaceBinding for that namespace or for the
+// namespaces its rules name.
 func (r *BalancingRuleReconciler) ReconcilePermanent(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	ctx, requestID := initReconcileContext(ctx)
 
@@ -279,8 +299,8 @@ func (r *BalancingRuleReconciler) ReconcilePermanent(ctx context.Context, req ct
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// PermanentBalancingRule is operator-namespace-only and does not require a
-	// NamespaceBinding for either the CR namespace or target namespaces.
+	// No NamespaceBinding watch feeds this controller, so a spec change is the
+	// only trigger it can report.
 	recordReconcileTrigger(controllerPBR, triggerSpecChange)
 
 	if !rule.DeletionTimestamp.IsZero() {
@@ -330,6 +350,10 @@ func (r *BalancingRuleReconciler) ReconcilePermanent(ctx context.Context, req ct
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager registers one controller per balancing-rule CRD, each under
+// its own name and reconcile entry point, and gives all three the same opts. It
+// stops at the first registration failure, so a non-nil error can leave earlier
+// controllers already registered with mgr.
 func (r *BalancingRuleReconciler) SetupWithManager(mgr ctrl.Manager, opts ctrlcontroller.Options) error {
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&dbaasv1.MicroserviceBalancingRule{},
@@ -369,6 +393,10 @@ func (r *BalancingRuleReconciler) SetupWithManager(mgr ctrl.Manager, opts ctrlco
 		Complete(reconcile.Func(r.ReconcilePermanent))
 }
 
+// reconcileMicroserviceDelete clears the microservices recorded in
+// status.appliedRules from the aggregator, then drops the finalizer. Any
+// aggregator failure leaves the finalizer in place, so the CR cannot go away
+// while rules it created are still live aggregator-side.
 func (r *BalancingRuleReconciler) reconcileMicroserviceDelete(
 	ctx context.Context,
 	rule *dbaasv1.MicroserviceBalancingRule,
@@ -396,6 +424,9 @@ func (r *BalancingRuleReconciler) reconcileMicroserviceDelete(
 	return nil
 }
 
+// reconcileNamespaceDelete deletes the rules recorded in status.appliedRules
+// from the aggregator, then drops the finalizer, on the terms
+// reconcileMicroserviceDelete describes.
 func (r *BalancingRuleReconciler) reconcileNamespaceDelete(
 	ctx context.Context,
 	rule *dbaasv1.NamespaceBalancingRule,
@@ -423,6 +454,9 @@ func (r *BalancingRuleReconciler) reconcileNamespaceDelete(
 	return nil
 }
 
+// reconcilePermanentDelete deletes the namespaces recorded in
+// status.appliedRules from the aggregator, then drops the finalizer, on the
+// terms reconcileMicroserviceDelete describes.
 func (r *BalancingRuleReconciler) reconcilePermanentDelete(
 	ctx context.Context,
 	rule *dbaasv1.PermanentBalancingRule,
@@ -450,6 +484,10 @@ func (r *BalancingRuleReconciler) reconcilePermanentDelete(
 	return nil
 }
 
+// cleanupSupersededMicroserviceRules clears, per rule type, the microservices
+// that status.appliedRules still lists and the spec no longer does. Types are
+// matched case-folded, so a type the spec has dropped entirely loses all of its
+// microservices.
 func (r *BalancingRuleReconciler) cleanupSupersededMicroserviceRules(
 	ctx context.Context,
 	rule *dbaasv1.MicroserviceBalancingRule,
@@ -515,6 +553,10 @@ func retainNamespaceAppliedExcept(
 	return out
 }
 
+// cleanupSupersededPermanentRules deletes, per dbType, the namespaces that
+// status.appliedRules still lists and the spec no longer does. dbTypes are
+// matched case-folded, so a dbType the spec has dropped entirely loses all of
+// its namespaces.
 func (r *BalancingRuleReconciler) cleanupSupersededPermanentRules(
 	ctx context.Context,
 	rule *dbaasv1.PermanentBalancingRule,
@@ -535,6 +577,9 @@ func (r *BalancingRuleReconciler) cleanupSupersededPermanentRules(
 	return nil
 }
 
+// cleanupMicroserviceTargets clears the balancing rules for the given
+// microservices under dbType in namespace. Removal is expressed as an apply
+// carrying an empty rule list, not as a delete request.
 func (r *BalancingRuleReconciler) cleanupMicroserviceTargets(
 	ctx context.Context,
 	namespace, dbType string,
@@ -579,6 +624,8 @@ func (r *BalancingRuleReconciler) deletePermanentTargets(
 // msgSpecRulesEmpty is the validation message returned when spec.rules is empty.
 const msgSpecRulesEmpty = "spec.rules must not be empty"
 
+// validateMicroserviceRule returns the first spec problem as a message for the
+// resource's status and events, or "" when the spec is valid.
 func (r *BalancingRuleReconciler) validateMicroserviceRule(rule *dbaasv1.MicroserviceBalancingRule) string {
 	if rule.Name != dbaasv1.MicroserviceBalancingRuleName {
 		return fmt.Sprintf("metadata.name must be %q", dbaasv1.MicroserviceBalancingRuleName)
@@ -611,6 +658,11 @@ func (r *BalancingRuleReconciler) validateMicroserviceRule(rule *dbaasv1.Microse
 	return ""
 }
 
+// validateNamespaceRule returns the first spec problem as a message for the
+// resource's status and events, or "" when the spec is valid. A non-nil error
+// means the cross-resource name check could not run, so the reconcile is
+// retried rather than reported as a bad spec. That check is skipped altogether
+// when the reconciler has no client.
 func (r *BalancingRuleReconciler) validateNamespaceRule(ctx context.Context, rule *dbaasv1.NamespaceBalancingRule) (string, error) {
 	if rule.Name != dbaasv1.NamespaceBalancingRuleName {
 		return fmt.Sprintf("metadata.name must be %q", dbaasv1.NamespaceBalancingRuleName), nil
@@ -652,6 +704,10 @@ func (r *BalancingRuleReconciler) validateNamespaceRule(ctx context.Context, rul
 	return "", nil
 }
 
+// validateNamespaceRuleGlobalConflicts reports a name in names that some other
+// NamespaceBalancingRule in the cluster already manages, or "" when there is no
+// clash. A non-nil error means the other rules could not be listed. names must
+// be keyed by the case-folded rule name.
 func (r *BalancingRuleReconciler) validateNamespaceRuleGlobalConflicts(
 	ctx context.Context,
 	rule *dbaasv1.NamespaceBalancingRule,
@@ -682,6 +738,9 @@ func (r *BalancingRuleReconciler) validateNamespaceRuleGlobalConflicts(
 	return "", nil
 }
 
+// validatePermanentRule returns the first spec problem as a message for the
+// resource's status and events, or "" when the spec is valid. The rule must
+// live in MyNamespace; leaving MyNamespace empty accepts it from any namespace.
 func (r *BalancingRuleReconciler) validatePermanentRule(rule *dbaasv1.PermanentBalancingRule) string {
 	if rule.Name != dbaasv1.PermanentBalancingRuleName {
 		return fmt.Sprintf("metadata.name must be %q", dbaasv1.PermanentBalancingRuleName)
@@ -741,6 +800,9 @@ func namespaceRuleTriggerKey(namespace, name string) string {
 	return "namespace/" + namespace + "/" + name
 }
 
+// differenceStrings returns the values in previous that current does not
+// contain, in their original order, and nil when previous is empty. Values are
+// compared exactly.
 func differenceStrings(previous, current []string) []string {
 	if len(previous) == 0 {
 		return nil
@@ -819,6 +881,9 @@ func appliedMicroserviceRulesFromSpec(
 	return applied
 }
 
+// removedNamespaceAppliedRules returns the applied rules whose name is absent
+// from desired, keeping their order. Names are matched exactly, without the
+// case folding the validators apply.
 func removedNamespaceAppliedRules(
 	applied []dbaasv1.NamespaceBalancingRuleAppliedRule,
 	desired []dbaasv1.NamespaceBalancingRuleItem,

--- a/dbaas-operator/internal/controller/balancingrule_reconcile_test.go
+++ b/dbaas-operator/internal/controller/balancingrule_reconcile_test.go
@@ -230,7 +230,7 @@ var _ = Describe("BalancingRule Controller", func() {
 		})
 
 		It("keeps previously-applied rules recorded when an updated spec fails to apply a new earlier rule", func() {
-			// D1 follow-up: status already records two rules that are live in the
+			// Status already records two rules that are live in the
 			// aggregator. The updated spec prepends a new rule whose apply fails, so
 			// the loop never re-applies the existing two. They must stay recorded —
 			// emptying status here would orphan rules still live aggregator-side.

--- a/dbaas-operator/internal/controller/balancingrule_reconcile_test.go
+++ b/dbaas-operator/internal/controller/balancingrule_reconcile_test.go
@@ -29,6 +29,10 @@ type balancingRuleCall struct {
 	body   []byte
 }
 
+// balancingRuleReconcileFixture wires a [BalancingRuleReconciler] to a stub
+// aggregator that records every request in calls. The stub answers each request
+// with the head of statuses, popping one entry per request, and falls back to
+// statusCode once statuses is empty; statusCode starts at 200.
 type balancingRuleReconcileFixture struct {
 	reconciler *BalancingRuleReconciler
 	calls      []balancingRuleCall
@@ -514,6 +518,11 @@ var _ = Describe("BalancingRule Controller", func() {
 	})
 })
 
+// newBalancingRuleReconcileFixture starts the stub aggregator's listener, so a
+// caller must pair it with [balancingRuleReconcileFixture.close]. It seeds the
+// ownership cache with ownedNamespace as Mine, standing in for a NamespaceBinding
+// these specs never create; without it the microservice and namespace reconcilers
+// requeue instead of applying anything.
 func newBalancingRuleReconcileFixture(ownedNamespace string) *balancingRuleReconcileFixture {
 	GinkgoHelper()
 	fixture := &balancingRuleReconcileFixture{
@@ -551,6 +560,9 @@ func newBalancingRuleReconcileFixture(ownedNamespace string) *balancingRuleRecon
 	return fixture
 }
 
+// namespaceRuleWithFinalizer returns the two-rule singleton the namespace specs
+// share, with the finalizer already set. ReconcileNamespace patches a missing
+// finalizer and returns, so a rule without one never reaches the apply path.
 func namespaceRuleWithFinalizer() *dbaasv1.NamespaceBalancingRule {
 	return &dbaasv1.NamespaceBalancingRule{
 		ObjectMeta: metav1.ObjectMeta{

--- a/dbaas-operator/internal/controller/balancingrule_validation_test.go
+++ b/dbaas-operator/internal/controller/balancingrule_validation_test.go
@@ -291,6 +291,10 @@ var _ = Describe("BalancingRule validation", func() {
 	})
 })
 
+// unstructuredBalancingRule builds a balancing rule CR as raw JSON, so a spec can
+// omit a field the typed Go struct always marshals. Order on
+// NamespaceBalancingRuleItem carries no omitempty, so only this form can present
+// the CRD with the field absent.
 func unstructuredBalancingRule(kind, name, namespace string, spec map[string]any) *unstructured.Unstructured {
 	GinkgoHelper()
 	return &unstructured.Unstructured{

--- a/dbaas-operator/internal/controller/conditions.go
+++ b/dbaas-operator/internal/controller/conditions.go
@@ -11,7 +11,8 @@ const (
 
 	// conditionTypeStalled is set to True when the error is permanent and
 	// retrying will not help until the spec is changed.
-	// Stalled=False — error is transient; the controller will retry automatically.
+	// Stalled=False — the reconcile succeeded, is still in progress, or failed
+	// transiently; none of the three needs a spec change to make progress.
 	conditionTypeStalled = "Stalled"
 )
 

--- a/dbaas-operator/internal/controller/conditions.go
+++ b/dbaas-operator/internal/controller/conditions.go
@@ -6,7 +6,7 @@ const (
 	// conditionTypeReady is the canonical condition describing whether the
 	// current generation was successfully processed by the controller.
 	// Ready=True  — the resource has been accepted and is active.
-	// Ready=False — processing failed; check Reason and Message for details.
+	// Ready=False — processing is in progress or it failed; check Reason and Message.
 	conditionTypeReady = "Ready"
 
 	// conditionTypeStalled is set to True when the error is permanent and
@@ -16,6 +16,8 @@ const (
 	conditionTypeStalled = "Stalled"
 )
 
+// stalledMsgPermanent and stalledMsgTransient are the Message the controllers put
+// on the Stalled condition.
 const (
 	stalledMsgPermanent = "Permanent error — spec must be corrected before the controller will retry."
 	stalledMsgTransient = "Transient error — the controller will retry automatically."

--- a/dbaas-operator/internal/controller/databaseaccesspolicy_controller.go
+++ b/dbaas-operator/internal/controller/databaseaccesspolicy_controller.go
@@ -42,9 +42,9 @@ import (
 
 // DatabaseAccessPolicyReconciler reconciles DatabaseAccessPolicy objects.
 //
-// On every reconcile it validates the spec, assembles a DeclarativePayload, calls
-// POST /api/declarations/v1/apply on dbaas-aggregator, and updates the CR status.
-// Key outcomes are also emitted as Kubernetes Events.
+// For a CR in a namespace bound to this operator, it validates the spec, assembles
+// a DeclarativePayload, calls POST /api/declarations/v1/apply on dbaas-aggregator,
+// and updates the CR status. Key outcomes are also emitted as Kubernetes Events.
 type DatabaseAccessPolicyReconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
@@ -94,7 +94,7 @@ func (r *DatabaseAccessPolicyReconciler) Reconcile(ctx context.Context, req ctrl
 	dp.Status.Phase = dbaasv1.PhaseProcessing
 
 	// Field-level constraints (microserviceName, services[].name/roles, policy[].type/defaultRole)
-	// are enforced by CRD admission. Only the cross-field constraint below cannot be expressed in schema.
+	// are enforced by CRD admission. The cross-field constraint is the one the schema does not cover.
 
 	if len(dp.Spec.Services) == 0 && len(dp.Spec.Policy) == 0 {
 		return invalidSpec(ctx, &dp.Status.Phase, &dp.Status.Conditions, dp.Generation, r.Recorder, dp, "spec: at least one of 'services' or 'policy' must be set")
@@ -127,7 +127,6 @@ type dbPolicyAggregatorSpec struct {
 }
 
 // buildPayload assembles the DeclarativePayload for POST /api/declarations/v1/apply.
-// MicroserviceName goes into metadata (not into the spec that is forwarded to the aggregator).
 func (r *DatabaseAccessPolicyReconciler) buildPayload(dp *dbaasv1.DatabaseAccessPolicy) *aggregatorclient.DeclarativePayload {
 	return &aggregatorclient.DeclarativePayload{
 		APIVersion: apiVersionV1,
@@ -152,8 +151,7 @@ func (r *DatabaseAccessPolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts
 		For(&dbaasv1.DatabaseAccessPolicy{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		// Re-enqueue all DatabaseAccessPolicies in a namespace when its NamespaceBinding
-		// is created or updated, so existing CRs are reconciled without waiting for
-		// a spec change.
+		// changes, so existing CRs are reconciled without waiting for a spec change.
 		Watches(&dbaasv1.NamespaceBinding{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueForBinding),
 			// The binding status is written by its own controller; only create, delete,
@@ -165,7 +163,8 @@ func (r *DatabaseAccessPolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts
 }
 
 // enqueueForBinding maps a NamespaceBinding event to reconcile requests for
-// all DatabaseAccessPolicies that live in the same namespace.
+// all DatabaseAccessPolicies that live in the same namespace, stamping each one
+// so its next reconcile is counted as NamespaceBinding-triggered.
 func (r *DatabaseAccessPolicyReconciler) enqueueForBinding(ctx context.Context, obj client.Object) []reconcile.Request {
 	return enqueueForBindingList(ctx, r.Client, &dbaasv1.DatabaseAccessPolicyList{}, obj.GetNamespace(),
 		func(o client.Object) { r.stampBindingTrigger(o.GetNamespace() + "/" + o.GetName()) })

--- a/dbaas-operator/internal/controller/databaseaccesspolicy_controller.go
+++ b/dbaas-operator/internal/controller/databaseaccesspolicy_controller.go
@@ -151,7 +151,7 @@ func (r *DatabaseAccessPolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dbaasv1.DatabaseAccessPolicy{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		// Re-enqueue all DbPolicies in a namespace when its NamespaceBinding
+		// Re-enqueue all DatabaseAccessPolicies in a namespace when its NamespaceBinding
 		// is created or updated, so existing CRs are reconciled without waiting for
 		// a spec change.
 		Watches(&dbaasv1.NamespaceBinding{},
@@ -164,8 +164,8 @@ func (r *DatabaseAccessPolicyReconciler) SetupWithManager(mgr ctrl.Manager, opts
 		Complete(r)
 }
 
-// enqueueForBinding maps an NamespaceBinding event to reconcile requests for
-// all DbPolicies that live in the same namespace.
+// enqueueForBinding maps a NamespaceBinding event to reconcile requests for
+// all DatabaseAccessPolicies that live in the same namespace.
 func (r *DatabaseAccessPolicyReconciler) enqueueForBinding(ctx context.Context, obj client.Object) []reconcile.Request {
 	return enqueueForBindingList(ctx, r.Client, &dbaasv1.DatabaseAccessPolicyList{}, obj.GetNamespace(),
 		func(o client.Object) { r.stampBindingTrigger(o.GetNamespace() + "/" + o.GetName()) })

--- a/dbaas-operator/internal/controller/databaseaccesspolicy_controller_test.go
+++ b/dbaas-operator/internal/controller/databaseaccesspolicy_controller_test.go
@@ -50,7 +50,7 @@ var _ = Describe("DatabaseAccessPolicy Controller", func() {
 		namespacedName types.NamespacedName
 	)
 
-	// baseSpec builds a minimal valid spec for use in aggregator-response tests.
+	// baseSpec builds a minimal valid spec.
 	baseSpec := func() dbaasv1.DatabaseAccessPolicySpec {
 		return dbaasv1.DatabaseAccessPolicySpec{
 			MicroserviceName: "test-service",

--- a/dbaas-operator/internal/controller/databasesecretclaim_controller.go
+++ b/dbaas-operator/internal/controller/databasesecretclaim_controller.go
@@ -113,12 +113,11 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	original := s.DeepCopy()
 	defer func() {
-		// Stamp observedGeneration on terminal states only. Successful
-		// reconciles now carry a safety-net RequeueAfter, so the result's
-		// requeue delay can no longer distinguish "done" from "retrying";
-		// gate on the conditions instead. Ready=True and Stalled=True are
-		// terminal (the generation has been fully processed); a transient
-		// error leaves both false (still polling).
+		// Stamp observedGeneration on terminal states only, and let the conditions
+		// identify them: Ready=True or Stalled=True means the generation was fully
+		// processed, and a transient error leaves both False. The requeue delay
+		// cannot stand in for this, because a successful reconcile carries a
+		// safety-net RequeueAfter too.
 		patchStatusOnExit(ctx, r.Status(), s, original, &retErr,
 			func(obj *dbaasv1.DatabaseSecretClaim, retErr error) bool {
 				return retErr == nil && isTerminal(obj.Status.Conditions, obj.Generation)
@@ -308,7 +307,7 @@ func (r *DatabaseSecretClaimReconciler) writeSecret(
 // Only a change to connectionProperties.json is treated as a rotation — it
 // stamps Status.LastRotatedAt and emits SecretRotated. A metadata.json or label
 // backfill (credentials unchanged) still rewrites the Secret but reports plain
-// success (SecretCreated reason, no LastRotatedAt, no SecretRotated event), so
+// success (SecretUpToDate reason, no LastRotatedAt, no SecretRotated event), so
 // the rotation timestamp stays faithful to its connection-properties contract.
 func (r *DatabaseSecretClaimReconciler) updateOwnedSecret(
 	ctx context.Context,
@@ -327,8 +326,6 @@ func (r *DatabaseSecretClaimReconciler) updateOwnedSecret(
 		return ctrl.Result{RequeueAfter: secretRotationSafetyNetInterval}, nil
 	}
 
-	// Only credential changes advance LastRotatedAt and emit SecretRotated;
-	// metadata.json or label backfills do not.
 	// existing.Data is the pre-update content; secretData is the desired content.
 	credentialsChanged := !bytes.Equal(
 		existing.Data[secretKeyConnectionProperties],
@@ -374,10 +371,7 @@ func (r *DatabaseSecretClaimReconciler) updateOwnedSecret(
 			return ctrl.Result{}, err
 		}
 	}
-	// The Secret was written. Only stamp LastRotatedAt and emit SecretRotated
-	// when the credentials actually changed. A metadata.json or label backfill
-	// rewrites the Secret once but is not a rotation, so it must not advance the
-	// rotation timestamp nor report SecretRotated.
+	// The Secret was written, but a metadata or label backfill is not a rotation.
 	if !credentialsChanged {
 		log.InfoC(ctx, "DatabaseSecretClaim Secret updated without credential change (metadata/label backfill) name=%s secretName=%s",
 			s.Name, s.Spec.SecretName)
@@ -444,7 +438,7 @@ func (r *DatabaseSecretClaimReconciler) markSecretConflict(ctx context.Context, 
 // handleAggregatorErr maps aggregator errors to phase/conditions/events for DatabaseSecretClaim.
 // It injects the DatabaseNotFound case before delegating to the shared handler:
 //   - 404 + CORE-DBAAS-4006  → BackingOff / DatabaseNotFound  (transient, DB not yet registered)
-//   - 404 without TMF body   → AggregatorError / BackingOff    (BG edge: no active namespace)
+//   - 404 without TMF body   → AggregatorError / BackingOff    (blue-green edge: no active namespace)
 //   - 401                    → BackingOff / Unauthorized        (transient)
 //   - 400 / 403              → InvalidConfiguration / AggregatorRejected (permanent)
 //   - 5xx / network          → BackingOff / AggregatorError     (transient)

--- a/dbaas-operator/internal/controller/databasesecretclaim_controller.go
+++ b/dbaas-operator/internal/controller/databasesecretclaim_controller.go
@@ -75,6 +75,11 @@ type DatabaseSecretClaimReconciler struct {
 	Ownership  *ownership.OwnershipResolver
 
 	bindingTriggerTracker
+	// triggerMu guards siblingTriggerStamps and rotationTriggerValues, the
+	// sibling and rotation counterparts of bindingTriggerTracker: keyed by
+	// namespace/name and best-effort, so a lost entry only mis-classifies the
+	// reconcile-trigger metric. rotationTriggerValues holds the last annotation
+	// value seen for a key, so the first observation is never a rotation.
 	triggerMu             sync.Mutex
 	siblingTriggerStamps  map[string]struct{}
 	rotationTriggerValues map[string]string
@@ -168,9 +173,10 @@ func (r *DatabaseSecretClaimReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 // preflightValidate runs all spec-level and pre-aggregator validations:
-// classifier.namespace consistency, the required app.kubernetes.io/name label,
-// ownership of any pre-existing target Secret, and the sibling-CR tiebreak that
-// resolves spec.secretName collisions deterministically (older claimant wins).
+// classifier.namespace consistency, classifier.extraKeys not shadowing a typed
+// classifier field, the required app.kubernetes.io/name label, ownership of any
+// pre-existing target Secret, and the sibling-CR tiebreak that resolves
+// spec.secretName collisions deterministically (older claimant wins).
 // It returns stop=true when a terminal state has been set on the CR and the
 // caller must return res/err immediately; stop=false means validation passed
 // and the reconcile may proceed to the aggregator call.
@@ -440,7 +446,7 @@ func (r *DatabaseSecretClaimReconciler) markSecretConflict(ctx context.Context, 
 //   - 404 + CORE-DBAAS-4006  → BackingOff / DatabaseNotFound  (transient, DB not yet registered)
 //   - 404 without TMF body   → AggregatorError / BackingOff    (blue-green edge: no active namespace)
 //   - 401                    → BackingOff / Unauthorized        (transient)
-//   - 400 / 403              → InvalidConfiguration / AggregatorRejected (permanent)
+//   - 400/403/409/410/422    → InvalidConfiguration / AggregatorRejected (permanent)
 //   - 5xx / network          → BackingOff / AggregatorError     (transient)
 //
 // On a continuous DatabaseNotFound streak longer than databaseNotFoundTimeout
@@ -512,10 +518,10 @@ const (
 // the key. UserRole is the requested role (DatabaseSecretClaim.spec.userRole), not
 // the role the aggregator resolved at runtime; it is omitted when empty.
 //
-// Id, Name, Namespace, and Settings mirror the aggregator's
+// ID, Name, Namespace, and Settings mirror the aggregator's
 // DatabaseResponseV3SingleCP so dbaas-client can reconstruct a full LogicalDb
 // from a mounted Secret without a REST call. They are descriptive only (not
-// part of the match key) and are omitted when empty; Id in particular may be
+// part of the match key) and are omitted when empty; ID in particular may be
 // empty because the aggregator returns it best-effort on a by-classifier lookup.
 type secretMetadata struct {
 	Classifier map[string]any `json:"classifier"`
@@ -650,9 +656,7 @@ func (r *DatabaseSecretClaimReconciler) enqueueForBinding(ctx context.Context, o
 
 // enqueueSiblingsBySecretName re-enqueues every DatabaseSecretClaim in the same
 // namespace that shares spec.secretName with the given object, excluding the
-// object itself. It fires on create/update/delete of any DatabaseSecretClaim so that
-// CRs sitting in SecretConflict can recover automatically once the older
-// claimant is removed or rebinds.
+// object itself.
 func (r *DatabaseSecretClaimReconciler) enqueueSiblingsBySecretName(ctx context.Context, obj client.Object) []reconcile.Request {
 	ds, ok := obj.(*dbaasv1.DatabaseSecretClaim)
 	if !ok || ds.Spec.SecretName == "" {

--- a/dbaas-operator/internal/controller/events.go
+++ b/dbaas-operator/internal/controller/events.go
@@ -36,11 +36,11 @@ const (
 	EventReasonPolicyApplied = "PolicyApplied"
 
 	// EventReasonProvisioningStarted is emitted when dbaas-aggregator returns HTTP 202
-	// for a InternalDatabase, meaning the async operation has been accepted.
+	// for an InternalDatabase, meaning the async operation has been accepted.
 	// Type: Normal (informational — not yet complete).
 	EventReasonProvisioningStarted = "ProvisioningStarted"
 
-	// EventReasonDatabaseProvisioned is emitted when a InternalDatabase is
+	// EventReasonDatabaseProvisioned is emitted when an InternalDatabase is
 	// successfully provisioned by dbaas-aggregator (either via HTTP 200 sync or
 	// after polling completes with COMPLETED). Type: Normal.
 	EventReasonDatabaseProvisioned = "DatabaseProvisioned"
@@ -89,7 +89,7 @@ const (
 	// last operation completed successfully.
 	ReasonSucceeded = "Succeeded"
 
-	// EventReasonBindingRegistered is emitted when an NamespaceBinding is
+	// EventReasonBindingRegistered is emitted when a NamespaceBinding is
 	// successfully registered (finalizer added). Type: Normal.
 	EventReasonBindingRegistered = "BindingRegistered"
 
@@ -132,8 +132,9 @@ const (
 	ReasonSecretUpToDate = "SecretUpToDate"
 
 	// EventReasonDatabaseNotFound is emitted when dbaas-aggregator returns HTTP 404
-	// for a get-by-classifier request, meaning the database is not yet registered and
-	// the operator retries until it appears. The controller retries with exponential backoff. Type: Warning.
+	// for a get-by-classifier request, meaning the database is not registered yet.
+	// The controller keeps retrying with exponential backoff until it appears.
+	// Type: Warning.
 	EventReasonDatabaseNotFound = "DatabaseNotFound"
 
 	// EventReasonEmptyConnectionProperties is emitted when dbaas-aggregator returns HTTP 200

--- a/dbaas-operator/internal/controller/events.go
+++ b/dbaas-operator/internal/controller/events.go
@@ -67,9 +67,10 @@ const (
 	// the CR spec is not at fault. Type: Warning.
 	EventReasonUnauthorized = "Unauthorized"
 
-	// EventReasonAggregatorRejected is emitted when dbaas-aggregator returns a
-	// 4xx error other than 401 (e.g. 400, 403, 409). Indicates a permanent
-	// spec error — retrying the same request will not help. Type: Warning.
+	// EventReasonAggregatorRejected is emitted when dbaas-aggregator returns 400,
+	// 403, 409, 410, or 422, or when a polled InternalDatabase operation ends
+	// with status FAILED. Indicates a permanent spec error — retrying the same
+	// request will not help. Type: Warning.
 	EventReasonAggregatorRejected = "AggregatorRejected"
 
 	// EventReasonAggregatorError is emitted on 5xx or network errors from

--- a/dbaas-operator/internal/controller/externaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller.go
@@ -192,15 +192,11 @@ func (r *ExternalDatabaseReconciler) buildRequest(
 	}
 
 	return &aggregatorclient.ExternalDatabaseRequest{
-		// Serialize the classifier with dbaasv1.ClassifierFlatMap — the same helper
-		// the InternalDatabase and DatabaseSecretClaim paths use. It keeps customKeys
-		// as a nested "customKeys" object, which is the canonical dbaas-aggregator
-		// classifier shape: the aggregator stores the classifier verbatim and reads
-		// classifier.customKeys.* as a nested map, so an externally registered
-		// database is found by the same classifier dbaas-client consumers use.
-		// EffectiveClassifier defaults classifier.namespace to metadata.namespace
-		// when omitted — the aggregator requires it (isValidClassifierV3) and the
-		// controller already validates that a non-empty value equals metadata.namespace.
+		// The wire classifier has to match what a dbaas-client consumer sends, or the
+		// aggregator stores this database under an identity nobody looks it up by.
+		// ClassifierFlatMap produces that shape — customKeys nested rather than
+		// flattened — and EffectiveClassifier supplies the namespace the aggregator
+		// requires.
 		Classifier:                 dbaasv1.ClassifierFlatMap(dbaasv1.EffectiveClassifier(edb.Spec.Classifier, edb.Namespace)),
 		Type:                       edb.Spec.Type,
 		DBName:                     edb.Spec.DBName,
@@ -349,7 +345,7 @@ func (r *ExternalDatabaseReconciler) SetupWithManager(mgr ctrl.Manager, opts ctr
 		Complete(r)
 }
 
-// enqueueForBinding maps an NamespaceBinding event to reconcile requests for
+// enqueueForBinding maps a NamespaceBinding event to reconcile requests for
 // all ExternalDatabases that live in the same namespace.
 func (r *ExternalDatabaseReconciler) enqueueForBinding(ctx context.Context, obj client.Object) []reconcile.Request {
 	return enqueueForBindingList(ctx, r.Client, &dbaasv1.ExternalDatabaseList{}, obj.GetNamespace(),

--- a/dbaas-operator/internal/controller/externaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller.go
@@ -48,8 +48,7 @@ import (
 )
 
 // externalDatabaseDefaultResync is the fallback re-reconcile period used when
-// ResyncInterval is left zero. Referenced credential Secret changes are picked up
-// on the next periodic resync.
+// ResyncInterval is left zero.
 const externalDatabaseDefaultResync = 10 * time.Minute
 
 // ExternalDatabaseReconciler reconciles ExternalDatabase objects.
@@ -174,8 +173,6 @@ func (r *ExternalDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	markSucceeded(&edb.Status.Phase, &edb.Status.Conditions, edb.Generation, EventReasonDatabaseRegistered)
 	r.Recorder.Eventf(edb, corev1.EventTypeNormal, EventReasonDatabaseRegistered,
 		"registered with dbaas-aggregator (type=%s, dbName=%s)", edb.Spec.Type, edb.Spec.DBName)
-	// Periodically re-reconcile so a change to a referenced credentials Secret is picked up
-	// without a Secret watch (the operator holds only namespaced Secret RBAC).
 	return ctrl.Result{RequeueAfter: r.ResyncInterval}, nil
 }
 

--- a/dbaas-operator/internal/controller/externaldatabase_controller_test.go
+++ b/dbaas-operator/internal/controller/externaldatabase_controller_test.go
@@ -679,7 +679,6 @@ var _ = Describe("ExternalDatabase Controller", func() {
 
 	Context("credentialsSecretRef — Secret exists but has no data (empty Secret)", func() {
 		It("returns error, sets Phase=BackingOff / SecretError, never calls aggregator", func() {
-			// Secret exists but Data map is completely empty.
 			Expect(k8sClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns},
 				// Data intentionally omitted — equivalent to an empty map.

--- a/dbaas-operator/internal/controller/helpers.go
+++ b/dbaas-operator/internal/controller/helpers.go
@@ -38,6 +38,8 @@ import (
 var log = logging.GetLogger("dbaas-operator")
 
 const (
+	// apiVersionV1 is the apiVersion field of the declarative payload posted to
+	// the aggregator, not the operator's own CRD group.
 	apiVersionV1 = "core.netcracker.com/v1"
 )
 
@@ -169,8 +171,6 @@ func setCondition(
 	for i, existing := range *conditions {
 		if existing.Type == condType {
 			if existing.Status == status {
-				// Status unchanged: preserve the transition time per Kubernetes API
-				// conventions (LastTransitionTime reflects Status changes only).
 				cond.LastTransitionTime = existing.LastTransitionTime
 			}
 			(*conditions)[i] = cond
@@ -297,6 +297,13 @@ func markPermanentFailure[P ~string](
 		conditionTypeStalled, metav1.ConditionTrue, readyReason, stalledMsgPermanent)
 }
 
+// patchStatusOnExit patches obj's status against original and is meant to run
+// from a deferred call in Reconcile, with retErr pointing at the named error
+// result. When shouldObserve accepts obj and the pending error, it first stamps
+// status.observedGeneration from obj's metadata.generation. A patch that fails
+// because the object is gone is not an error; any other patch failure is joined
+// into *retErr, so it can turn an otherwise successful reconcile into a retry.
+// objectType names the kind in the log lines.
 func patchStatusOnExit[T interface {
 	client.Object
 	SetObservedGeneration(int64)

--- a/dbaas-operator/internal/controller/helpers.go
+++ b/dbaas-operator/internal/controller/helpers.go
@@ -356,8 +356,7 @@ func conditionTrueForGeneration(conditions []metav1.Condition, condType string, 
 // without touching conditions (for example on a benign create/update race)
 // still carries the previous generation's Ready=True, and without the check
 // the exit patch would stamp status.observedGeneration for a spec it never
-// finished processing. The former phase-based predicate was immune to this
-// because phase was reset to Processing at the start of every reconcile.
+// finished processing.
 func isTerminal(conditions []metav1.Condition, generation int64) bool {
 	return conditionTrueForGeneration(conditions, conditionTypeReady, generation) ||
 		conditionTrueForGeneration(conditions, conditionTypeStalled, generation)

--- a/dbaas-operator/internal/controller/helpers_test.go
+++ b/dbaas-operator/internal/controller/helpers_test.go
@@ -155,7 +155,7 @@ func TestSetCondition_LastTransitionTime(t *testing.T) {
 	})
 }
 
-// cond builds a condition for the predicate tests below.
+// cond builds a condition for the isTerminal and isReadyForGeneration tests.
 func cond(condType string, status metav1.ConditionStatus, generation int64) metav1.Condition {
 	return metav1.Condition{
 		Type:               condType,
@@ -165,18 +165,15 @@ func cond(condType string, status metav1.ConditionStatus, generation int64) meta
 	}
 }
 
-// TestIsTerminal covers the predicate that replaced the former
-// "phase == Succeeded || phase == InvalidConfiguration" check: a resource is
-// terminal once it either succeeded (Ready=True) or hit a permanent error
-// (Stalled=True) for the given generation. Transient failures and in-flight
-// work are not terminal.
+// A resource is terminal once it either succeeded (Ready=True) or hit a
+// permanent error (Stalled=True) for the given generation. Transient failures
+// and in-flight work are not terminal.
 //
-// The stale cases are regression tests: conditions persist across reconciles,
-// so a reconcile that exits early after a spec change still carries the
-// previous generation's terminal condition. Counting it as terminal would let
-// patchStatusOnExit stamp status.observedGeneration for a spec the controller
-// never finished processing. The former phase-based predicate was immune —
-// phase was reset to Processing at the start of every reconcile.
+// The stale cases guard the generation check: conditions persist across
+// reconciles, so a reconcile that exits early after a spec change still carries
+// the previous generation's terminal condition. Counting it as terminal would
+// let patchStatusOnExit stamp status.observedGeneration for a spec the
+// controller never finished processing.
 func TestIsTerminal(t *testing.T) {
 	t.Parallel()
 
@@ -238,10 +235,9 @@ func TestIsTerminal(t *testing.T) {
 	}
 }
 
-// TestIsReadyForGeneration covers the predicate that replaced the former
-// "observedGeneration >= generation && phase == Succeeded" check. A Ready
-// condition left over from an earlier generation must not count as success for
-// the current spec.
+// Ready=True counts as success only when it was recorded for the current
+// generation or newer. A Ready condition left over from an earlier generation
+// must not count as success for the current spec.
 func TestIsReadyForGeneration(t *testing.T) {
 	t.Parallel()
 

--- a/dbaas-operator/internal/controller/internaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller.go
@@ -53,9 +53,13 @@ const pollRequeueAfter = 5 * time.Second
 //
 // The reconcile loop has two branches:
 //   - SUBMIT: no pending trackingId → validate, build payload, call POST /apply.
-//     HTTP 200 → Succeeded (synchronous). HTTP 202 → store trackingId, requeue for polling.
+//     HTTP 200 → Succeeded (synchronous), or WaitingForDependency and requeue while a pinned
+//     tenant database is still materializing (see materializeTenantDatabaseIfPinned).
+//     HTTP 202 → store trackingId, requeue for polling.
 //   - POLL: pending trackingId → call GET /operation/{id}/status.
-//     COMPLETED → Succeeded. FAILED/TERMINATED → InvalidConfiguration. IN_PROGRESS → requeue.
+//     COMPLETED → Succeeded, or WaitingForDependency on that same pinned-tenant condition.
+//     FAILED → InvalidConfiguration. TERMINATED → BackingOff with the
+//     trackingId cleared, so the next reconcile resubmits. IN_PROGRESS → requeue.
 type InternalDatabaseReconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
@@ -219,7 +223,8 @@ func (r *InternalDatabaseReconciler) reconcilePoll(
 
 // buildPayload assembles the DeclarativePayload for POST /api/declarations/v1/apply.
 // kind/subKind are hardcoded to what the aggregator expects.
-// microserviceName goes into metadata; the entire spec is forwarded as-is.
+// The CR's name, namespace and microserviceName go into metadata; every spec
+// field reaches the aggregator through [toWireSpec], which reshapes and defaults it.
 func (r *InternalDatabaseReconciler) buildPayload(dd *dbaasv1.InternalDatabase) *aggregatorclient.DeclarativePayload {
 	return &aggregatorclient.DeclarativePayload{
 		APIVersion: apiVersionV1,
@@ -357,6 +362,8 @@ func pollConditionText(resp *aggregatorclient.DeclarativeResponse, fallback stri
 	return fallback
 }
 
+// validateInternalDatabaseSpec returns a message describing the first cross-field
+// violation in dd's spec, or "" when the spec is acceptable.
 func validateInternalDatabaseSpec(dd *dbaasv1.InternalDatabase) string {
 	// CRD enforces: classifier.required, classifier.microserviceName/scope required+minLength,
 	// type required+minLength. Controller handles cross-field constraints only.

--- a/dbaas-operator/internal/controller/internaldatabase_controller.go
+++ b/dbaas-operator/internal/controller/internaldatabase_controller.go
@@ -272,7 +272,7 @@ func markTenantMaterializationPending(dd *dbaasv1.InternalDatabase) {
 		conditionTypeStalled, metav1.ConditionFalse, EventReasonProvisioningStarted, stalledMsgTransient)
 }
 
-// toWireSpec converts a InternalDatabaseSpec (CRD shape) into the wire format
+// toWireSpec converts an InternalDatabaseSpec (CRD shape) into the wire format
 // expected by dbaas-aggregator. namespace is the owning CR's metadata.namespace,
 // used to default classifier.namespace when omitted.
 //
@@ -591,7 +591,7 @@ func (r *InternalDatabaseReconciler) SetupWithManager(mgr ctrl.Manager, opts ctr
 		Complete(r)
 }
 
-// enqueueForBinding maps an NamespaceBinding event to reconcile requests for
+// enqueueForBinding maps a NamespaceBinding event to reconcile requests for
 // all InternalDatabases that live in the same namespace.
 func (r *InternalDatabaseReconciler) enqueueForBinding(ctx context.Context, obj client.Object) []reconcile.Request {
 	return enqueueForBindingList(ctx, r.Client, &dbaasv1.InternalDatabaseList{}, obj.GetNamespace(),

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -77,8 +77,6 @@ const (
 	operationDeletePermanentRule     = "delete_permanent_balancing_rule"
 )
 
-// Metric declarations.
-
 // dbaasReconcileTriggerTotal counts reconcile invocations by meaningful source.
 // Controller-runtime already exposes reconcile totals; this metric adds the
 // trigger dimension that the framework cannot infer.
@@ -91,8 +89,8 @@ var dbaasReconcileTriggerTotal = prometheus.NewCounterVec(
 )
 
 // dbaasSecretResolutionErrorsTotal counts failures reading credential Secrets,
-// labeled by error category. A non-zero value means a credential rotation
-// left a database without valid credentials - direct service impact.
+// labeled by error category. A non-zero value means an ExternalDatabase cannot
+// be registered until its credentialsSecretRef resolves.
 var dbaasSecretResolutionErrorsTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "dbaas_secret_resolution_errors_total",
@@ -147,8 +145,6 @@ func init() {
 	)
 }
 
-// Helper functions.
-
 // recordAggregatorCall records both the duration and the outcome counter for a
 // single aggregator HTTP call. Call it immediately after every aggregator
 // method returns, passing the start time and the error (nil = success).
@@ -161,7 +157,9 @@ func recordAggregatorCall(controller, operation string, start time.Time, err err
 		Inc()
 }
 
-// aggregatorResult maps an error from AggregatorClient to a result label.
+// aggregatorResult maps an error from AggregatorClient to a result label. An
+// error that does not wrap an [aggregatorclient.AggregatorError] is labeled
+// network_error, including a 2xx response the client could not decode.
 func aggregatorResult(err error) string {
 	if err == nil {
 		return resultSuccess
@@ -186,6 +184,9 @@ func aggregatorResult(err error) string {
 	return resultNetworkError
 }
 
+// secretResolutionError carries the failure category for a credential Secret that
+// could not be resolved. reason is one of the secretReason constants and becomes
+// the reason label on dbaas_secret_resolution_errors_total.
 type secretResolutionError struct {
 	reason string
 	err    error

--- a/dbaas-operator/internal/controller/metrics.go
+++ b/dbaas-operator/internal/controller/metrics.go
@@ -26,9 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// Label value constants.
-
-// Keeping the constants here because they are only relevant to Prometheus metrics.
+// Label values for the metrics in this file, grouped by the label they belong to.
+// Each value is part of a metric's public surface: renaming one breaks the
+// dashboards and alerts that select on it.
 const (
 	controllerEDB = "externaldatabase"
 	controllerIDB = "internaldatabase"
@@ -126,7 +126,8 @@ var dbaasAggregatorRequestsTotal = prometheus.NewCounterVec(
 )
 
 // dbaasAsyncOperationDurationSeconds measures end-to-end provisioning time from
-// async submit (HTTP 202) to final poll outcome. This is the user-visible DD SLO.
+// async submit (HTTP 202) to final poll outcome. It is the user-visible
+// provisioning SLO.
 var dbaasAsyncOperationDurationSeconds = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "dbaas_async_operation_duration_seconds",

--- a/dbaas-operator/internal/controller/metrics_test.go
+++ b/dbaas-operator/internal/controller/metrics_test.go
@@ -8,6 +8,8 @@ import (
 	aggregatorclient "github.com/netcracker/qubership-dbaas/dbaas-operator/internal/client"
 )
 
+// Every outcome of an aggregator call lands in exactly one result label, and the
+// classification sees through error wrapping.
 func TestAggregatorResultClassifiesOwnershipBuckets(t *testing.T) {
 	tests := []struct {
 		name string
@@ -35,6 +37,8 @@ func TestAggregatorResultClassifiesOwnershipBuckets(t *testing.T) {
 	}
 }
 
+// An error that wraps a secretResolutionError reports that error's reason;
+// anything else reports secretReasonReadFailed.
 func TestSecretResolutionReason(t *testing.T) {
 	tests := []struct {
 		name string

--- a/dbaas-operator/internal/controller/namespacebinding_controller.go
+++ b/dbaas-operator/internal/controller/namespacebinding_controller.go
@@ -86,8 +86,7 @@ func (r *NamespaceBindingReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// responsibility. This return sits above the status defer on purpose: two
 	// instances writing conditions to the same object would fight forever. The
 	// flip side: a binding whose operatorNamespace matches no running operator
-	// keeps an empty status — document that as "unclaimed", it cannot be
-	// reported by anyone.
+	// keeps an empty status, because no instance is entitled to write one.
 	if nb.Spec.OperatorNamespace != r.MyNamespace {
 		log.InfoC(ctx, "NamespaceBinding %s/%s belongs to operatorNamespace=%s (mine=%s) — skipping mutations",
 			nb.Namespace, nb.Name, nb.Spec.OperatorNamespace, r.MyNamespace)
@@ -210,9 +209,9 @@ func enqueueBindingForWorkload(_ context.Context, obj client.Object) []reconcile
 }
 
 // workloadLifecyclePredicate limits the workload watches to create and delete
-// events. The binding only cares whether blocking resources exist, and a
-// spec or status update cannot change that — without the filter every status
-// write on every workload CR re-enqueued the binding.
+// events. The binding only cares whether blocking resources exist, and a spec or
+// status update cannot change that — without the filter, every status write on
+// every workload CR would re-enqueue the binding.
 var workloadLifecyclePredicate = predicate.Funcs{
 	CreateFunc:  func(event.CreateEvent) bool { return true },
 	DeleteFunc:  func(event.DeleteEvent) bool { return true },

--- a/dbaas-operator/internal/controller/namespacebinding_controller.go
+++ b/dbaas-operator/internal/controller/namespacebinding_controller.go
@@ -46,15 +46,13 @@ import (
 // NamespaceBindingReconciler reconciles NamespaceBinding objects.
 //
 // Responsibilities:
-//  1. Keep the ownership cache (OwnershipResolver) up-to-date on every
+//  1. Keep the ownership cache ([ownership.OwnershipResolver]) up-to-date on every
 //     create/update/delete.
-//  2. Manage the NamespaceBindingProtectionFinalizer: add it when the namespace
-//     contains blocking dbaas resources; remove it (allowing deletion) only once
-//     those resources are gone.
-//  3. Watch workload resources (ExternalDatabase, DatabaseAccessPolicy, InternalDatabase,
-//     and balancing rules)
-//     so that any create/delete of a workload in a bound namespace triggers a
-//     re-evaluation of the finalizer.
+//  2. Manage the NamespaceBindingProtectionFinalizer: add it to every binding this
+//     instance owns, and remove it (allowing deletion) only once Checker reports no
+//     blocking resource left in the namespace.
+//  3. Watch the workload kinds that can block deletion, so that creating or
+//     deleting one in a bound namespace re-evaluates the finalizer.
 type NamespaceBindingReconciler struct {
 	client.Client
 	Scheme      *runtime.Scheme

--- a/dbaas-operator/internal/controller/namespacebinding_controller_test.go
+++ b/dbaas-operator/internal/controller/namespacebinding_controller_test.go
@@ -106,7 +106,6 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(controllerutil.ContainsFinalizer(fetched, dbaasv1.NamespaceBindingProtectionFinalizer)).To(BeTrue())
 
-			// Ownership cache must reflect Mine.
 			Expect(resolver.GetState(ns)).To(Equal(ownership.Mine))
 		})
 
@@ -176,12 +175,10 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			drainRecordedEvents(fakeRecorder.Events)
 
-			// Trigger deletion.
 			Expect(k8sClient.Delete(ctx, &dbaasv1.NamespaceBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: bindingName, Namespace: ns},
 			})).To(Succeed())
 
-			// Reconcile the deletion.
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -190,7 +187,6 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			err = k8sClient.Get(ctx, namespacedName, &dbaasv1.NamespaceBinding{})
 			Expect(client.IgnoreNotFound(err)).To(Succeed())
 
-			// Cache must be cleared.
 			Expect(resolver.GetState(ns)).To(Equal(ownership.Unknown))
 		})
 	})
@@ -199,7 +195,6 @@ var _ = Describe("NamespaceBinding Controller", func() {
 
 	Context("when the NamespaceBinding is deleted but blocking resources exist", func() {
 		It("keeps the finalizer and emits a BindingBlocked warning", func() {
-			// Use a checker that always reports blocking.
 			reconciler.Checker = &alwaysBlockingChecker{}
 
 			nb := newBinding(myOperatorNS)
@@ -208,12 +203,10 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			drainRecordedEvents(fakeRecorder.Events)
 
-			// Trigger deletion.
 			Expect(k8sClient.Delete(ctx, &dbaasv1.NamespaceBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: bindingName, Namespace: ns},
 			})).To(Succeed())
 
-			// Reconcile — should keep the finalizer.
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -379,10 +372,10 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(reconcile.Result{}))
 
-			// Cache must reflect Foreign, not Mine.
 			Expect(resolver.GetState(ns)).To(Equal(ownership.Foreign))
 
-			// The owning operator must NOT have added the finalizer.
+			// The finalizer belongs to the owning instance, so this one must not
+			// have added it.
 			fetched := &dbaasv1.NamespaceBinding{}
 			Expect(k8sClient.Get(ctx, namespacedName, fetched)).To(Succeed())
 			Expect(controllerutil.ContainsFinalizer(fetched, dbaasv1.NamespaceBindingProtectionFinalizer)).To(BeFalse())
@@ -393,7 +386,6 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			Expect(fetched.Status.Conditions).To(BeEmpty())
 			Expect(fetched.Status.ObservedGeneration).To(BeZero())
 
-			// No events must be emitted.
 			expectNoRecordedEvent(fakeRecorder.Events)
 		})
 
@@ -410,7 +402,6 @@ var _ = Describe("NamespaceBinding Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, nb)).To(Succeed())
 
-			// Trigger deletion.
 			Expect(k8sClient.Delete(ctx, &dbaasv1.NamespaceBinding{
 				ObjectMeta: metav1.ObjectMeta{Name: bindingName, Namespace: ns},
 			})).To(Succeed())

--- a/dbaas-operator/internal/controller/resource_metrics.go
+++ b/dbaas-operator/internal/controller/resource_metrics.go
@@ -117,8 +117,11 @@ var (
 )
 
 // RegisterResourceMetrics registers kube-state-style current-state metrics for
-// dbaas CRs. The metrics intentionally expose CR name only on gauges that
-// represent current state; counters and histograms remain low-cardinality.
+// dbaas CRs on the controller-runtime metrics registry. Only the first call
+// registers; later calls are no-ops, so the c, resolver, and operatorNamespace
+// passed the first time are the ones every scrape uses. The metrics intentionally
+// expose CR name only on gauges that represent current state; counters and
+// histograms remain low-cardinality.
 func RegisterResourceMetrics(c client.Client, resolver *ownership.OwnershipResolver, operatorNamespace string) {
 	registerResourceMetricsOnce.Do(func() {
 		metrics.Registry.MustRegister(&resourceMetricsCollector{
@@ -129,6 +132,14 @@ func RegisterResourceMetrics(c client.Client, resolver *ownership.OwnershipResol
 	})
 }
 
+// resourceMetricsCollector answers a Prometheus scrape by listing dbaas CRs and
+// turning their current status into gauges. It keeps no state between scrapes.
+//
+// Two rules hold across every collect method. Each reports
+// dbaas_resource_collector_success for its kind, so a failed LIST is
+// distinguishable from a kind that has no objects. And each emits status series
+// only for the resources this instance owns, so no object's status is reported
+// by two instances at once; the methods differ in how they establish ownership.
 type resourceMetricsCollector struct {
 	client            client.Client
 	ownership         *ownership.OwnershipResolver
@@ -148,6 +159,10 @@ func (c *resourceMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- resourceCollectorSuccessDesc
 }
 
+// Collect runs one sweep over every dbaas kind per scrape, bounded as a whole
+// by [resourceMetricsCollectionTimeout]. A kind whose LIST does not finish
+// inside that budget reports dbaas_resource_collector_success 0 rather than
+// dropping out of the scrape.
 func (c *resourceMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), resourceMetricsCollectionTimeout)
 	defer cancel()
@@ -204,6 +219,10 @@ func (c *resourceMetricsCollector) collectDatabaseAccessPolicies(ctx context.Con
 	}
 }
 
+// collectDatabaseSecretClaims adds the two DatabaseSecretClaim timestamp gauges
+// to the common status series. Each is emitted only when the status field
+// behind it is set, so a claim with no rotation series has never rotated, and
+// one with no first-not-found series has no DatabaseNotFound streak open.
 func (c *resourceMetricsCollector) collectDatabaseSecretClaims(ctx context.Context, ch chan<- prometheus.Metric) {
 	list := &dbaasv1.DatabaseSecretClaimList{}
 	if !c.collectList(ctx, ch, resourceKindDatabaseSecretClaim, list) {
@@ -237,6 +256,10 @@ func (c *resourceMetricsCollector) collectDatabaseSecretClaims(ctx context.Conte
 	}
 }
 
+// collectMicroserviceBalancingRules adds the desired and applied target gauges
+// to the common status series. A target here is one microservice, summed across
+// the rules rather than counted per rule, which is what the microservice
+// target_type stands for.
 func (c *resourceMetricsCollector) collectMicroserviceBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
 	list := &dbaasv1.MicroserviceBalancingRuleList{}
 	if !c.collectList(ctx, ch, resourceKindMicroserviceBalancingRule, list) {
@@ -270,6 +293,9 @@ func (c *resourceMetricsCollector) collectMicroserviceBalancingRules(ctx context
 	}
 }
 
+// collectNamespaceBalancingRules adds the desired and applied target gauges to
+// the common status series. A namespace balancing rule names no targets of its
+// own, so the count is the number of rules and the target_type is rule.
 func (c *resourceMetricsCollector) collectNamespaceBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
 	list := &dbaasv1.NamespaceBalancingRuleList{}
 	if !c.collectList(ctx, ch, resourceKindNamespaceBalancingRule, list) {
@@ -303,6 +329,12 @@ func (c *resourceMetricsCollector) collectNamespaceBalancingRules(ctx context.Co
 	}
 }
 
+// collectPermanentBalancingRules is the one collect method that does not list
+// cluster-wide: permanent rules live in the operator's own namespace, so
+// membership there is the ownership check and no resolver lookup is needed.
+// With no operator namespace configured it lists nothing and reports
+// dbaas_resource_collector_success 0, rather than falling back to a
+// cluster-wide LIST.
 func (c *resourceMetricsCollector) collectPermanentBalancingRules(ctx context.Context, ch chan<- prometheus.Metric) {
 	if c.operatorNamespace == "" {
 		ch <- prometheus.MustNewConstMetric(resourceCollectorSuccessDesc, prometheus.GaugeValue, 0, resourceKindPermanentBalancingRule)
@@ -339,6 +371,9 @@ func (c *resourceMetricsCollector) collectPermanentBalancingRules(ctx context.Co
 	}
 }
 
+// collectNamespaceBindings reports dbaas_namespace_binding_state for every
+// binding in the cluster, foreign ones included, so one instance's scrape shows
+// how the whole cluster is divided between operators.
 func (c *resourceMetricsCollector) collectNamespaceBindings(ctx context.Context, ch chan<- prometheus.Metric) {
 	list := &dbaasv1.NamespaceBindingList{}
 	if !c.collectList(ctx, ch, resourceKindNamespaceBinding, list) {
@@ -368,6 +403,11 @@ func (c *resourceMetricsCollector) collectNamespaceBindings(ctx context.Context,
 	}
 }
 
+// collectList lists every object of kind into list and reports the outcome as
+// dbaas_resource_collector_success for that kind. It returns false when the
+// LIST failed; the caller must then emit no series for the kind, so that a
+// scrape taken during an API-server outage does not read as the resources
+// having been deleted.
 func (c *resourceMetricsCollector) collectList(
 	ctx context.Context,
 	ch chan<- prometheus.Metric,
@@ -382,6 +422,11 @@ func (c *resourceMetricsCollector) collectList(
 	return true
 }
 
+// ownsNamespace reports whether this instance owns namespace, consulting the
+// resolver cache and never the API server. A namespace the cache has not seen
+// counts as not owned, as does a nil resolver, so a scrape taken before the
+// cache is warm omits series rather than claiming an object that belongs to
+// another instance.
 func (c *resourceMetricsCollector) ownsNamespace(namespace string) bool {
 	if c.ownership == nil {
 		return false
@@ -389,6 +434,13 @@ func (c *resourceMetricsCollector) ownsNamespace(namespace string) bool {
 	return c.ownership.GetState(namespace) == ownership.Mine
 }
 
+// collectOperatorStatus emits the three series every dbaas kind shares: phase,
+// observed-generation lag, and one series per status condition. An empty phase
+// is reported as Unknown, so every resource contributes exactly one phase
+// series. Conditions are deduplicated by type, the first occurrence winning:
+// two entries of one type can agree on every remaining label, and a duplicate
+// label set makes the registry reject the whole gather, not just the resource
+// that produced it.
 func collectOperatorStatus(
 	ch chan<- prometheus.Metric,
 	kind string,
@@ -438,6 +490,8 @@ func collectOperatorStatus(
 	}
 }
 
+// generationLag returns how far observedGeneration trails generation, clamped
+// at zero: an observedGeneration at or ahead of generation reports no lag.
 func generationLag(generation, observedGeneration int64) int64 {
 	if generation <= observedGeneration {
 		return 0
@@ -445,6 +499,13 @@ func generationLag(generation, observedGeneration int64) int64 {
 	return generation - observedGeneration
 }
 
+// namespaceBindingState returns the dbaas_namespace_binding_state label value
+// for binding as seen by the operator running in operatorNamespace: mine or
+// foreign while the binding is alive, deleting or deleting_with_finalizer once
+// deletion has started. Deletion outranks ownership, so a binding under
+// deletion never reports mine. Only NamespaceBindingProtectionFinalizer
+// produces deleting_with_finalizer here; a finalizer belonging to another
+// controller leaves the state at deleting.
 func namespaceBindingState(binding *dbaasv1.NamespaceBinding, operatorNamespace string) string {
 	if !binding.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(binding, dbaasv1.NamespaceBindingProtectionFinalizer) {
@@ -458,6 +519,11 @@ func namespaceBindingState(binding *dbaasv1.NamespaceBinding, operatorNamespace 
 	return namespaceBindingStateForeign
 }
 
+// collectDeletionState emits dbaas_resource_deletion_state for a resource whose
+// deletion has started, and nothing at all otherwise: absence of the series is
+// how a live resource is reported. Any surviving finalizer makes the state
+// deleting_with_finalizer, whichever controller owns it — unlike
+// [namespaceBindingState], which counts only the operator's own finalizer.
 func collectDeletionState(
 	ch chan<- prometheus.Metric,
 	kind string,

--- a/dbaas-operator/internal/controller/resource_metrics_test.go
+++ b/dbaas-operator/internal/controller/resource_metrics_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/netcracker/qubership-dbaas/dbaas-operator/internal/ownership"
 )
 
+// The reported lag is never negative: an observedGeneration at or ahead of
+// metadata.generation reports zero rather than a negative number.
 func TestGenerationLag(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -35,6 +37,10 @@ func TestGenerationLag(t *testing.T) {
 	}
 }
 
+// Two status conditions of the same type yield one dbaas_resource_condition
+// series. A second series with the same labels makes the registry fail the
+// gather, which loses every metric in the scrape rather than this one resource,
+// so the failure to fix is in collectOperatorStatus, not in the assertion.
 func TestCollectOperatorStatusDeduplicatesConditionsByType(t *testing.T) {
 	collector := duplicateConditionCollector{}
 	registry := prometheus.NewRegistry()
@@ -89,6 +95,11 @@ func TestResourceMetricsCollectorFiltersByOwnedNamespace(t *testing.T) {
 	}
 }
 
+// A failed LIST sets dbaas_resource_collector_success to 0 instead of leaving
+// the series out, so a scrape can tell an outage from an empty cluster. The
+// fake client is built without the dbaas scheme on purpose — that is what makes
+// every LIST fail; registering testResourceMetricsScheme here would let the
+// LIST succeed, and the assertion would then see success 1.
 func TestResourceMetricsCollectorReportsListErrors(t *testing.T) {
 	cl := fake.NewClientBuilder().Build()
 
@@ -103,6 +114,10 @@ func TestResourceMetricsCollectorReportsListErrors(t *testing.T) {
 	}
 }
 
+// With no operator namespace configured, the PermanentBalancingRule collector
+// reports dbaas_resource_collector_success 0 and emits no phase series. The
+// fixture stores a rule the collector would have found, so a regression that
+// falls back to a cluster-wide LIST fails both assertions.
 func TestPermanentBalancingRuleCollectorRequiresOperatorNamespace(t *testing.T) {
 	scheme := testResourceMetricsScheme(t)
 	cl := fake.NewClientBuilder().
@@ -146,6 +161,9 @@ func gatherResourceMetrics(t *testing.T, collector prometheus.Collector) []*dto.
 	return metrics
 }
 
+// countMetrics counts the series in the family named name whose labels match,
+// per metricHasLabels. An unknown name counts zero rather than failing, so an
+// assertion of zero passes on a misspelled metric name too.
 func countMetrics(metrics []*dto.MetricFamily, name string, labels map[string]string) int {
 	var count int
 	for _, family := range metrics {
@@ -161,6 +179,10 @@ func countMetrics(metrics []*dto.MetricFamily, name string, labels map[string]st
 	return count
 }
 
+// metricValue returns the gauge value of the first series in the family named
+// name whose labels match, per metricHasLabels, and -1 when nothing matches. No
+// gauge in resource_metrics.go is ever negative, so -1 is unambiguous as the
+// not-found marker.
 func metricValue(metrics []*dto.MetricFamily, name string, labels map[string]string) float64 {
 	for _, family := range metrics {
 		if family.GetName() != name {
@@ -175,6 +197,9 @@ func metricValue(metrics []*dto.MetricFamily, name string, labels map[string]str
 	return -1
 }
 
+// metricHasLabels reports whether metric carries every label in want with the
+// value want gives it. Labels absent from want are ignored, so a caller can
+// select on one label of a series that carries six.
 func metricHasLabels(metric *dto.Metric, want map[string]string) bool {
 	for key, value := range want {
 		found := false
@@ -191,6 +216,9 @@ func metricHasLabels(metric *dto.Metric, want map[string]string) bool {
 	return true
 }
 
+// duplicateConditionCollector drives collectOperatorStatus with a status that
+// carries the Ready condition twice, so that a gather can observe what the
+// deduplication leaves behind.
 type duplicateConditionCollector struct{}
 
 func (duplicateConditionCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -210,6 +238,8 @@ func (duplicateConditionCollector) Collect(ch chan<- prometheus.Metric) {
 	})
 }
 
+// Deletion outranks ownership: a binding under deletion reports deleting or
+// deleting_with_finalizer, and only a live binding reports mine or foreign.
 func TestNamespaceBindingState(t *testing.T) {
 	now := metav1.Now()
 
@@ -260,6 +290,8 @@ func TestNamespaceBindingState(t *testing.T) {
 	}
 }
 
+// All four balancing-rule counters sum the targets across the rules instead of
+// counting the rules: two rules holding two and one target report 3, not 2.
 func TestBalancingRuleAppliedTargetCounts(t *testing.T) {
 	if got := microserviceDesiredTargetCount([]dbaasv1.MicroserviceBalancingRuleItem{
 		{Microservices: []string{"a", "b"}},

--- a/dbaas-operator/internal/controller/suite_test.go
+++ b/dbaas-operator/internal/controller/suite_test.go
@@ -142,7 +142,8 @@ var _ = AfterSuite(func() {
 	}, time.Minute, time.Second).Should(Succeed())
 })
 
-// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// getFirstFoundEnvTestBinaryDir returns the first subdirectory of dbaas-operator/bin/k8s,
+// or "" when that directory is missing or holds no subdirectory.
 // ENVTEST-based tests depend on specific binaries, usually located in paths set by
 // controller-runtime. When running tests directly (e.g., via an IDE) without using
 // Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.

--- a/dbaas-operator/internal/controller/test_helpers_test.go
+++ b/dbaas-operator/internal/controller/test_helpers_test.go
@@ -54,6 +54,9 @@ func drainRecordedEvents(events <-chan string) {
 	}
 }
 
+// aggregatorSyncFixture is a stub aggregator. server answers every request with
+// statusCode and body, recording the last request in capturedPath and capturedBody;
+// recorder collects the events the reconciler emits. Call close when the spec ends.
 type aggregatorSyncFixture struct {
 	statusCode   int
 	body         string
@@ -101,6 +104,10 @@ func closeServerAndDrain(srv *httptest.Server, rec *record.FakeRecorder) {
 	}
 }
 
+// reconcileAndFetchObject reconciles key once and returns the object as k8sClient sees
+// it afterwards, together with the reconcile result and error. newObj must allocate a
+// fresh empty object on each call. The read-back is unconditional, so a reconcile that
+// deletes its object fails the test instead of returning a not-found error.
 func reconcileAndFetchObject[T client.Object](
 	reconciler reconcile.Reconciler,
 	key types.NamespacedName,
@@ -152,9 +159,9 @@ func foreignOwnershipResolver(namespaces ...string) *ownership.OwnershipResolver
 	return r
 }
 
-// emptyOwnershipResolver returns an OwnershipResolver with an empty cache and
-// no NamespaceBinding objects in the API server.  IsMyNamespace will perform a
-// live GET, find nothing, and return (false, nil) — leaving the state Unknown.
+// emptyOwnershipResolver returns an OwnershipResolver with an empty cache, so
+// [ownership.OwnershipResolver.IsMyNamespace] does a live GET. Absent a NamespaceBinding
+// it returns (false, nil) and caches Unbound, so the next call takes the fast path.
 func emptyOwnershipResolver() *ownership.OwnershipResolver {
 	return ownership.NewOwnershipResolver("test-namespace", k8sClient)
 }

--- a/dbaas-operator/internal/controller/trigger_stamps_test.go
+++ b/dbaas-operator/internal/controller/trigger_stamps_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 )
 
-// testEDBKey is the namespace/name key reused across trigger-stamp tests.
 const testEDBKey = "test-ns/test-edb"
 
 func TestExternalDatabaseBindingTriggerLifecycle(t *testing.T) {
@@ -19,6 +18,8 @@ func TestInternalDatabaseBindingTriggerLifecycle(t *testing.T) {
 	assertBindingTriggerLifecycle(t, r.stampBindingTrigger, r.consumeBindingTrigger, r.clearBindingTrigger)
 }
 
+// clearAsyncStart deletes the key's async-operation start stamp, and a second
+// call for a key that no longer has one is a no-op.
 func TestInternalDatabaseClearAsyncStart(t *testing.T) {
 	key := "test-ns/test-dd"
 	r := &InternalDatabaseReconciler{
@@ -40,6 +41,10 @@ func TestDatabaseAccessPolicyBindingTriggerLifecycle(t *testing.T) {
 	assertBindingTriggerLifecycle(t, r.stampBindingTrigger, r.consumeBindingTrigger, r.clearBindingTrigger)
 }
 
+// Stamping and consuming one key from separate goroutines is safe. The concurrent
+// phase asserts nothing by itself: an unguarded stamp map surfaces as a concurrent
+// map write panic, or as a report under go test -race. The explicit check is that
+// clearBindingTrigger, once the goroutines have finished, leaves nothing to consume.
 func TestExternalDatabaseTriggerStampsConcurrentAccess(t *testing.T) {
 	r := &ExternalDatabaseReconciler{}
 	key := testEDBKey
@@ -64,6 +69,11 @@ func TestExternalDatabaseTriggerStampsConcurrentAccess(t *testing.T) {
 	}
 }
 
+// assertBindingTriggerLifecycle checks the bindingTriggerTracker methods one
+// reconciler promotes, passed as method values so each reconciler type is covered
+// separately. Stamping is idempotent: after two stamps the first consume reports
+// true and the second false. Clearing drops a pending stamp, so the consume that
+// follows reports false too.
 func assertBindingTriggerLifecycle(t *testing.T, stamp func(string), consume func(string) bool, clear func(string)) {
 	t.Helper()
 

--- a/dbaas-operator/internal/ownership/checker.go
+++ b/dbaas-operator/internal/ownership/checker.go
@@ -34,8 +34,7 @@ type BlockingResourceChecker interface {
 }
 
 // KindChecker checks for the presence of any object of a specific list kind
-// within a namespace.  Use the generic constructor NewKindChecker so that the
-// type constraints are verified at compile time.
+// within a namespace.  Construct it with [NewKindChecker].
 type KindChecker[L client.ObjectList] struct {
 	cl      client.Client
 	kind    string
@@ -48,9 +47,9 @@ func NewKindChecker[L client.ObjectList](cl client.Client, kind string, newList 
 	return &KindChecker[L]{cl: cl, kind: kind, newList: newList}
 }
 
-// BlockingKinds returns [kind] when at least one object of this kind exists in
-// namespace, and nil otherwise. The list is capped at one item — presence is
-// enough, counting would need an uncapped LIST.
+// BlockingKinds returns a one-element slice holding kind when at least one object
+// of that kind exists in namespace, and nil otherwise. The LIST is capped at one
+// item — presence is enough, and counting would need an uncapped LIST.
 func (c *KindChecker[L]) BlockingKinds(ctx context.Context, namespace string) ([]string, error) {
 	list := c.newList()
 	log.InfoC(ctx, "Checking blocking resources kind=%s namespace=%s", c.kind, namespace)
@@ -76,15 +75,16 @@ func NewCompositeChecker(checkers ...BlockingResourceChecker) *CompositeChecker 
 	return &CompositeChecker{checkers: checkers}
 }
 
-// Add appends a checker to the composite.
+// Add appends a checker to the composite. It takes no lock, so add every
+// checker before the first [CompositeChecker.BlockingKinds] call.
 func (c *CompositeChecker) Add(ch BlockingResourceChecker) {
 	c.checkers = append(c.checkers, ch)
 }
 
-// BlockingKinds runs every constituent checker and returns the union of the
-// kinds they report, in registration order. Unlike a short-circuiting bool
-// check, the full sweep costs one Limit(1) LIST per kind and buys a complete
-// answer for the user-facing message.
+// BlockingKinds runs every constituent checker in registration order and
+// concatenates what they report, duplicates included. The first error aborts
+// the sweep and comes back with a nil slice. Nothing short-circuits on the
+// first non-empty result: the caller names every blocking kind to the user.
 func (c *CompositeChecker) BlockingKinds(ctx context.Context, namespace string) ([]string, error) {
 	log.InfoC(ctx, "Checking blocking resources namespace=%s checkers=%d", namespace, len(c.checkers))
 	var kinds []string

--- a/dbaas-operator/internal/ownership/resolver.go
+++ b/dbaas-operator/internal/ownership/resolver.go
@@ -81,8 +81,9 @@ func NewOwnershipResolver(myNamespace string, c client.Client) *OwnershipResolve
 	}
 }
 
-// SetOwner updates the cache for namespace based on the binding's location.
-// Called by NamespaceBindingReconciler on every create/update reconcile.
+// SetOwner caches namespace as Mine when location equals this operator's own
+// namespace, and as Foreign otherwise. location is the spec.operatorNamespace
+// of that namespace's NamespaceBinding.
 func (r *OwnershipResolver) SetOwner(namespace, location string) {
 	state := Foreign
 	if location == r.myNamespace {
@@ -93,8 +94,8 @@ func (r *OwnershipResolver) SetOwner(namespace, location string) {
 	r.mu.Unlock()
 }
 
-// Forget removes the cached entry for namespace.
-// Called by NamespaceBindingReconciler when an NamespaceBinding is deleted.
+// Forget removes the cached entry for namespace, so
+// [OwnershipResolver.GetState] reports Unknown until the binding is seen again.
 func (r *OwnershipResolver) Forget(namespace string) {
 	r.mu.Lock()
 	delete(r.cache, namespace)
@@ -114,7 +115,9 @@ func (r *OwnershipResolver) GetState(namespace string) OwnershipState {
 }
 
 // IsMyNamespace reports whether the operator owns namespace, using the cache
-// when populated and falling back to a live NamespaceBinding lookup on Unknown.
+// when populated and falling back to a live NamespaceBinding lookup on
+// Unknown. A successful lookup caches Mine, Foreign, or Unbound; false covers
+// the last two, so use [OwnershipResolver.GetState] to tell them apart.
 func (r *OwnershipResolver) IsMyNamespace(ctx context.Context, namespace string) (bool, error) {
 	if state := r.GetState(namespace); state != Unknown {
 		return state == Mine, nil

--- a/dbaas-operator/internal/poller/rotation_poller.go
+++ b/dbaas-operator/internal/poller/rotation_poller.go
@@ -27,8 +27,8 @@ import (
 )
 
 // DefaultLimit is the page size requested per poll. Excess changes are drained on
-// subsequent ticks — the keyset cursor advances by the last returned item, so a
-// full page never stalls even when many rows share a timestamp.
+// subsequent ticks: the cursor advances by the last item a page returned, not by
+// the feed's high-water mark, so a full page never skips its tail.
 const DefaultLimit = 500
 
 // zeroUUID is the smallest UUID; paired with the epoch timestamp it forms the
@@ -41,7 +41,9 @@ func epochCursor() aggregatorclient.ChangeCursor {
 }
 
 // ChangedSource is the subset of the aggregator client the poller depends on.
-// Defined as an interface so tests can supply a fake.
+// Defined as an interface so tests can supply a fake, which owes the full contract
+// of [aggregatorclient.AggregatorClient.GetChangedSince], including what a nil
+// cursor and a non-positive limit ask for.
 type ChangedSource interface {
 	GetChangedSince(ctx context.Context, cursor *aggregatorclient.ChangeCursor, limit int) (*aggregatorclient.ChangedDatabasesResponse, error)
 }
@@ -64,7 +66,8 @@ type RotationPoller struct {
 	Client client.Client
 	// Source is the aggregator changed-databases endpoint.
 	Source ChangedSource
-	// Interval is the polling period.
+	// Interval is the polling period. It must be positive: [RotationPoller.Start]
+	// feeds it to [time.NewTicker], which panics on a non-positive duration.
 	Interval time.Duration
 	// Limit is the page size; DefaultLimit when zero.
 	Limit int
@@ -74,7 +77,9 @@ type RotationPoller struct {
 // cursor owner drives the fan-out.
 func (p *RotationPoller) NeedLeaderElection() bool { return true }
 
-// Start runs the poll loop until ctx is canceled. It implements manager.Runnable.
+// Start runs the poll loop until ctx is canceled. It implements manager.Runnable
+// and always returns nil: a failed poll is logged and retried on the next tick, so
+// the loop ends only on cancellation.
 func (p *RotationPoller) Start(ctx context.Context) error {
 	limit := p.Limit
 	if limit <= 0 {
@@ -106,7 +111,8 @@ func (p *RotationPoller) Start(ctx context.Context) error {
 // A nil cursor triggers a seed: the seed-only (since-less) call returns the
 // aggregator's current high-water mark, which becomes the baseline so existing
 // rotations — already synced by the startup reconcile — are not replayed. A failed
-// seed returns nil so the next tick retries it.
+// seed returns nil so the next tick retries it; a failed poll returns the cursor
+// unchanged, so the next tick re-requests the same page.
 func (p *RotationPoller) pollOnce(ctx context.Context, cursor *aggregatorclient.ChangeCursor, limit int) *aggregatorclient.ChangeCursor {
 	// Give each poll iteration its own correlation scope instead of reusing an ID
 	// inherited from the long-lived manager context.
@@ -143,8 +149,8 @@ func (p *RotationPoller) pollOnce(ctx context.Context, cursor *aggregatorclient.
 				it.Namespace, it.Type, perr)
 		}
 		// Items are ordered by (lastRotatedAt, id) ascending; advance the cursor
-		// unconditionally so a per-namespace list error (logged above) does not
-		// stall it — the safety-net reconcile heals any skipped fan-out.
+		// unconditionally so a failed fan-out (logged above) does not stall it. The
+		// safety-net reconcile heals whatever the fan-out missed.
 		advanced = &aggregatorclient.ChangeCursor{LastRotatedAt: it.LastRotatedAt, ID: it.ID}
 	}
 	if len(resp.Items) > 0 {

--- a/dbaas-operator/internal/poller/trigger.go
+++ b/dbaas-operator/internal/poller/trigger.go
@@ -40,6 +40,9 @@ var log = logging.GetLogger("dbaas-rotation-poller")
 // changes so the controller predicate fires even when the CR is otherwise
 // unchanged.
 //
+// classifier is the aggregator's flat wire map, the shape ClassifierFlatMap
+// produces from a typed dbaasv1.Classifier.
+//
 // Per-CR patch failures are logged and skipped, not propagated: one transient
 // k8s API error must not block notifications for the rest, and the safety-net
 // reconcile will heal any CR missed here.


### PR DESCRIPTION
## Why

Comments in `dbaas-operator` had drifted from the code they describe. Some were wrong in ways a reader would act on: a CRD description told users a field travels in the request URL path when the operator sends it in the body; `EventReasonAggregatorRejected` claimed it covers "a 4xx error other than 401" when it is chosen for five specific codes and for a failed async operation; `OwnershipResolver.SetOwner` named its argument "the binding's location" when both call sites pass the operator's own namespace. Others were structurally unusable: `status.conditions` listed the Ready reasons for four of the eight kinds and had never been extended, so a reader who did not find their reason concluded the wrong thing.

None of this is caught by the build. A comment that names a symbol which no longer exists still compiles, a Go doc link that resolves to nothing renders as literal text, and a CRD description ships to users through `kubectl explain` with no review step of its own.

## What

Four commits, one per area, comments only:

| Commit | Area |
|---|---|
| `d36bb97` | `internal/client`, `internal/poller`, `internal/ownership` |
| `7f5968d` | `api/v1` + the CRDs regenerated from it |
| `a3848e5` | `internal/controller` |
| `faa7df5` | `cmd`, `dev/aggregator-mock` |

Corrections outnumber additions in the parts that matter. A representative sample of what was wrong:

- `spec.dbName` said it is included in the request URL path; it is sent in the registration request body.
- `MockRule` said the ConfigMap is the single source of truth for every response; the mock hardcodes two, and three of the six files it loads hold a different shape entirely.
- `buildPayload` said the entire spec is forwarded as-is; `toWireSpec` reshapes it and defaults `classifier.namespace`.
- `preflightValidate` enumerated the checks it runs and omitted the `extraKeys` collision check, which makes the list worse than no list.
- `conditions.go` said `Stalled=False` meant a transient error; it also covers a successful and an in-progress reconcile.
- The `DatabaseAccessPolicy` watch comments called the CRs "DbPolicies", which is the aggregator's wire `subKind` rather than the kind of the CR.
- `updateOwnedSecret` said a metadata-only rewrite reports `SecretCreated`; that path sets `SecretUpToDate`.

Contracts that were absent rather than wrong now have a home: `RotationPoller.Interval` panics the ticker when non-positive; `Start` never returns an error, so no poll failure reaches the manager; `IsMyNamespace` writes its result back to the cache and cannot distinguish `Foreign` from `Unbound`; `CompositeChecker.Add` takes no lock; the mock's four loaders call `log.Fatalf` on a parse error, so a malformed file kills the process.

`status.conditions` now names all 23 Reason values grouped by the kind that reports them, verified against `events.go` in the same change, with the four condition-only ones called out. `api/v1` edits are regenerated into `config/crd/bases` and the chart's CRD templates in the same commit, so `verify-generated` stays green.

Cut throughout: accounts of how the code came to be this way, caller lists that find-usages answers (two of which were incomplete), and rationale for why a helper exists at all.

## How to verify

Nothing executable changed. That is checkable rather than asserted — strip the comments from every file in this branch and what remains is byte-identical to the base:

```
make -C dbaas-operator lint test-unit
make -C dbaas-operator manifests generate sync-helm-crds && git status --porcelain   # must be empty
```

`make lint` is red at base on two findings that predate this branch and are untouched by it: `SA1019` in `api/v1/groupversion_info.go` and `unparam` in `dev/aggregator-mock/main_test.go`. Gate on "no new findings" rather than on a clean run.

`make test` is not the check to run here — it needs envtest binaries. `make test-unit` covers everything this branch could affect.
